### PR TITLE
Pressing back after submitting case causes 500

### DIFF
--- a/cla_public/apps/checker/tests/test_views.py
+++ b/cla_public/apps/checker/tests/test_views.py
@@ -542,10 +542,6 @@ class CheckerWizardTestCase(CLATestCase):
 
         self.mocked_is_eligible_post.return_value = mocked_api.IS_ELIGIBLE_UNKNOWN
 
-        #self.assertRaises(InconsistentStateException,
-        #    self.client.get, self.result_url
-        #)
-
         response = self.client.get(self.result_url, follow=True)
         self.assertRedirects(response, self.your_problem_url)
         
@@ -566,8 +562,6 @@ class CheckerWizardTestCase(CLATestCase):
             "contact_details-mobile_phone": '0123456789',
             "contact_details-home_phone": '9876543210',
         }
-        #with self.assertRaises(InconsistentStateException):
-        #    r1 = self.client.get(self.result_url)
 
         response = self.client.get(self.result_url, follow=True)
         self.assertRedirects(response, self.your_problem_url)

--- a/cla_public/apps/checker/views.py
+++ b/cla_public/apps/checker/views.py
@@ -217,7 +217,8 @@ class CheckerWizard(NamedUrlSessionWizardView):
             return super(CheckerWizard, self).render(form, **kwargs)
         except InconsistentStateException:
             # should be "Eligibility Reference cannot be None"
-            return self.render_goto_step(1)
+
+            return self.render_goto_step(self.steps.first)
 
 
 class StartPageView(TemplateView):


### PR DESCRIPTION
fix: for "Pressing back after submitting case causes 500" - this only happened after all form's are complete so solution was to redirect back to first form.

Also-
test_post_result_fails_without_reference(...) in test_views.py has data which isn't used
should I remove this data?
