### PR TITLE
basic GA tracking script include

### DIFF
--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -89,6 +89,8 @@ SENTRY_SITE_NAME = os.environ.get('RAVEN_CONFIG_SITE', '')
 ADDRESSFINDER_API_HOST = os.environ.get('ADDRESSFINDER_API_HOST')
 ADDRESSFINDER_API_TOKEN = os.environ.get('ADDRESSFINDER_API_TOKEN')
 
+GA_ID = os.environ.get('GA_ID')
+
 CACHE_CONFIG = {
     'CACHE_TYPE': 'simple'
 }

--- a/cla_public/config/local.py.example
+++ b/cla_public/config/local.py.example
@@ -15,3 +15,10 @@ LOGGING['loggers'] = {
 
 DEBUG_TB_INTERCEPT_REDIRECTS = False
 EXTENSIONS.append(DebugToolbarExtension())
+
+ADDRESSFINDER_API_HOST = os.environ.get(
+    'ADDRESSFINDER_API_HOST',
+    'http://your_service_host/')
+ADDRESSFINDER_API_TOKEN = os.environ.get(
+    'ADDRESSFINDER_API_TOKEN',
+    'your_service_token')

--- a/cla_public/templates/_analytics.html
+++ b/cla_public/templates/_analytics.html
@@ -1,0 +1,13 @@
+<script type="text/javascript">
+
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', '{{ config.GA_ID }}']);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+</script>

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -15,6 +15,10 @@
   <![endif]-->
 {% endblock %}
 
+{% block head %}
+  {% include "_analytics.html" %}
+{% endblock %}
+
 {% block content %}
   {% include "_phase-tag.html" %}
 


### PR DESCRIPTION
gets GA_ID from environment, fails silently (outputs empty string) locally or if GA_ID not found
