### PR TITLE
FE: Disable autocomplete on text inputs

### DIFF
--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -236,7 +236,7 @@
         {% if prefix %}
           <label class="input-prefix" for="{{field.id}}">{{prefix}}</label>
         {% endif %}
-        {{ field(class_='form-control ' + class_) }}
+        {{ field(class_='form-control ' + class_, autocomplete='off') }}
         {% if suffix %}
           <label class="input-suffix" for="{{field.id}}">{{suffix}}</label>
         {% endif %}
@@ -250,7 +250,7 @@
       {% if prefix %}
         <label class="input-prefix" for="{{field.id}}">{{prefix}}</label>
       {% endif %}
-      {{ field(class_='form-control ' + class_) }}
+      {{ field(class_='form-control ' + class_, autocomplete='off') }}
       {% if suffix %}
         <label class="input-suffix" for="{{field.id}}">{{suffix}}</label>
       {% endif %}
@@ -316,13 +316,13 @@
     {% if use_form_group %}
       {% call form_group(field, title_as_label=field.per_interval_value.id, class_=group_class) %}
         <label class="input-prefix" for="{{field.per_interval_value.id}}">£</label>
-        {{ field.per_interval_value(class_='form-control m-small') }}
+        {{ field.per_interval_value(class_='form-control m-small', autocomplete='off') }}
         {{ field.interval_period(class_='form-control') }}
       {% endcall %}
     {% else %}
       {{field.label}}
       <label class="input-prefix" for="{{field.per_interval_value.id}}">£</label>
-      {{ field.per_interval_value(class_='form-control m-small') }}
+      {{ field.per_interval_value(class_='form-control m-small', autocomplete='off') }}
       {{ field.interval_period(class_='form-control') }}
     {% endif %}
   {% endif %}
@@ -480,7 +480,7 @@
 {% macro postcode_field(field, attributes={}) %}
   {% call form_group(field) %}
     <div class="address-finder">
-      {{ field(class_='form-control m-small', **attributes) }}
+      {{ field(class_='form-control m-small', autocomplete='off', **attributes) }}
     </div>
   {% endcall %}
 {% endmacro %}


### PR DESCRIPTION
Text inputs save previous values. This disables autocomplete with previous values.
