### PR TITLE
Turn off server tokens

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -18,7 +18,7 @@ http {
         tcp_nodelay on;
         keepalive_timeout 65;
         types_hash_max_size 2048;
-        # server_tokens off;
+        server_tokens off;
 
         # server_names_hash_bucket_size 64;
         # server_name_in_redirect off;


### PR DESCRIPTION
Prevent Nginx from adding a "Server" HTTP header
