### PR TITLE
FE: Strip out CLA JS from error pages

### DIFF
--- a/cla_public/templates/errors/404.html
+++ b/cla_public/templates/errors/404.html
@@ -6,3 +6,7 @@
   <h1>Sorry, this page doesn’t exist</h1>
   <p>Please return to the <a href="/">Can I get legal aid?</a> page and try again.</p>
 {% endblock %}
+
+{% block javascripts %}
+  {% include "_analytics.html" %}
+{% endblock %}

--- a/cla_public/templates/errors/4xx.html
+++ b/cla_public/templates/errors/4xx.html
@@ -7,3 +7,7 @@
   <h1>{{ title }}</h1>
   <p>Please return to the <a href="/">Can I get legal aid?</a> page and try again.</p>
 {% endblock %}
+
+{% block javascripts %}
+  {% include "_analytics.html" %}
+{% endblock %}

--- a/cla_public/templates/errors/5xx.html
+++ b/cla_public/templates/errors/5xx.html
@@ -4,10 +4,15 @@
 
 {% block inner_content %}
   <h1>This service is temporarily unavailable</h1>
+
   <p>This service is not available right now, but we're working hard to get things up and running again.</p>
   <p>You can try again later or call us on 0345 345 4 345. </p>
   <p>Minicom: 0345 609 6677 </p>
   <p>Or text 'legalaid' and your name to 80010. </p>
   <p><a href="https://www.gov.uk/call-charges" rel="external">Find out about call charges here</a>.</p>
   <p>This service is only available if you are a resident of England or Wales.</p>
+{% endblock %}
+
+{% block javascripts %}
+  {% include "_analytics.html" %}
 {% endblock %}


### PR DESCRIPTION
Unfortunately we can't remove jQuery as it's served by MOJ Template without any blocks that can be overridden. But hopefully it will already be cached when the user sees the error page.
