### PR TITLE
Display a form validation error if the backend API times out

### DIFF
--- a/cla_public/apps/checker/api.py
+++ b/cla_public/apps/checker/api.py
@@ -1,10 +1,12 @@
 from collections import OrderedDict
-import slumber
 import urllib
+
 from flask import current_app, session
-from cla_public.libs.api_proxy import on_timeout
-from cla_public.apps.checker.constants import CATEGORIES
+import slumber
+
 from cla_common.constants import ELIGIBILITY_STATES
+from cla_public.apps.checker.constants import CATEGORIES
+from cla_public.libs.api_proxy import on_timeout
 
 
 def get_api_connection():

--- a/cla_public/apps/checker/decorators.py
+++ b/cla_public/apps/checker/decorators.py
@@ -59,7 +59,10 @@ def redirect_if_ineligible():
     def view(fn):
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
-            is_eligible = post_to_is_eligible_api()
+            try:
+                is_eligible = post_to_is_eligible_api()
+            except (ConnectionError, Timeout):
+                is_eligible = ELIGIBILITY_STATES.UNKNOWN
             if is_eligible == ELIGIBILITY_STATES.NO:
                 return redirect(
                     url_for(

--- a/cla_public/apps/checker/decorators.py
+++ b/cla_public/apps/checker/decorators.py
@@ -39,7 +39,7 @@ def form_view(form_class, form_template):
                     session.update_form_data(form)
                     try:
                         post_to_eligibility_check_api(form)
-                    except ConnectionError, Timeout:
+                    except (ConnectionError, Timeout):
                         form.errors['timeout'] = _(
                             u'Server did not respond, please try again')
                         return render_template(form_template, form=form)

--- a/cla_public/apps/checker/tests/test_api_timeout.py
+++ b/cla_public/apps/checker/tests/test_api_timeout.py
@@ -1,0 +1,39 @@
+import unittest
+from mock import Mock
+
+from requests.exceptions import ConnectionError, Timeout
+
+from cla_public.app import create_app
+from cla_public.apps.checker import api
+
+
+def mock_api_timeout():
+
+    def timeout(*args):
+        raise Timeout()
+
+    mock_api = Mock()
+    mock_api.eligibility_check.post = timeout
+    api.get_api_connection = lambda: mock_api
+
+
+class TestApiTimeout(unittest.TestCase):
+
+    def setUp(self):
+        app = create_app('config/testing.py')
+        app.test_request_context().push()
+        self.client = app.test_client()
+        with self.client.session_transaction() as session:
+            session['test'] = True
+        mock_api_timeout()
+
+    def test_form_error_on_api_timeout(self):
+        try:
+            response = self.client.post('/problem', data={
+                'categories': ['debt']})
+        except Timeout:
+            self.fail('Timeout not caught')
+        except ConnectionError:
+            self.fail('ConnectionError not caught')
+
+        assert 'Server did not respond, please try again' in response.data

--- a/cla_public/templates/benefits.html
+++ b/cla_public/templates/benefits.html
@@ -18,7 +18,11 @@
 
     {% if form.errors %}
       {% call Element.alert('error', icon='cross') %}
+        {% if form.errors.timeout %}
+        <p>{{ form.errors.timeout }}</p>
+        {% else %}
         <p>{{ _('Please select at least one option.') }}</p>
+        {% endif %}
       {% endcall %}
     {% endif %}
 

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -488,8 +488,12 @@
 {% macro handle_errors(form) %}
   {% if form.errors %}
     {% call Element.alert('error', icon='cross') %}
+      {% if form.errors.timeout %}
+      <p>{{ form.errors.timeout }}</p>
+      {% else %}
       <p>{{  _('This form has errors.') }}</p>
       <p>{{ _('Please see below for the errors you need to correct.') }}</p>
+      {% endif %}
     {% endcall %}
   {% endif %}
 {% endmacro %}

--- a/cla_public/templates/problem.html
+++ b/cla_public/templates/problem.html
@@ -16,7 +16,11 @@
 
     {% if form.errors %}
       {% call Element.alert('error', icon='cross') %}
+        {% if form.errors.timeout %}
+        <p>{{ form.errors.timeout }}</p>
+        {% else %}
         <p>{{ _('Please select the area of law you need help with.') }}</p>
+        {% endif %}
       {% endcall %}
     {% endif %}
 


### PR DESCRIPTION
Rather than throwing a 500 error