### PR TITLE
Add spec paths to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 test:
-	./nightwatch -c tests/nightwatch/local.json -s legacy -t ${test}
+	./nightwatch -c tests/nightwatch/local.json -s legacy -t tests/nightwatch/specs/current/${spec}.js
 test-chrome:
-	./nightwatch -c tests/nightwatch/local.json -s legacy --env chrome -t ${test}
+	./nightwatch -c tests/nightwatch/local.json -s legacy --env chrome -t tests/nightwatch/specs/current/${spec}.js
 test-firefox:
-	./nightwatch -c tests/nightwatch/local.json -s legacy --env firefox -t ${test}
+	./nightwatch -c tests/nightwatch/local.json -s legacy --env firefox -t tests/nightwatch/specs/current/${spec}.js
 test-legacy:
-	./nightwatch -c tests/nightwatch/local.json -s current -t ${test}
+	./nightwatch -c tests/nightwatch/local.json -s current -t tests/nightwatch/specs/current/${spec}.js
 test-all:
 	./nightwatch -c tests/nightwatch/local.json


### PR DESCRIPTION
For individual tests use:

`make test spec=spec-file-name` (without extension)