### PR TITLE
Implement textarea character counter

### DIFF
--- a/cla_public/apps/contact/tests/test_notes.py
+++ b/cla_public/apps/contact/tests/test_notes.py
@@ -1,0 +1,31 @@
+import unittest
+
+from werkzeug.datastructures import MultiDict
+
+from cla_public.app import create_app
+from cla_public.apps.contact.forms import ContactForm
+
+
+def submit(**kwargs):
+    return ContactForm(MultiDict(kwargs), csrf_enabled=False)
+
+
+class NotesTest(unittest.TestCase):
+
+    def setUp(self):
+        app = create_app('config/testing.py')
+        app.test_request_context().push()
+
+    def validate_notes(self, notes):
+        form = submit(
+            extra_notes=notes)
+        form.validate()
+        return u'Your notes must be 4000 characters or less' not in \
+            form.extra_notes.errors
+
+    def test_notes_max_length(self):
+        longest_allowed = 'x' * 4000
+        self.assertTrue(self.validate_notes(longest_allowed))
+
+        too_long = longest_allowed + 'x'
+        self.assertFalse(self.validate_notes(too_long))

--- a/cla_public/static-src/javascripts/modules/textarea-character-count.js
+++ b/cla_public/static-src/javascripts/modules/textarea-character-count.js
@@ -1,0 +1,69 @@
+(function () {
+  'use strict';
+
+  var LOW_CHAR_COUNT = 80;
+
+  moj.Modules.TextAreaCharacterCount = {
+    $currentCounter: null,
+
+    init: function() {
+      this.cacheEls();
+
+      if(this.textAreasWithCharCount.length) {
+        this.templates();
+        this.bindEvents();
+      }
+    },
+
+    renderCounter: function(evt) {
+      var self = this;
+      var $textArea = $(evt.target);
+      var value = $textArea.val();
+      var maxLength = $textArea.data('character-count');
+      var remainingCount = maxLength - value.length;
+
+      function updateCount() {
+        self.$currentCounter = $(self.characterCounter({
+          count: remainingCount,
+          counter_class: remainingCount < LOW_CHAR_COUNT ? 'counter-low' : ''
+        }));
+
+        return self.$currentCounter;
+      }
+
+      if(remainingCount < 0) {
+        $textArea.val(value.slice(0, maxLength));
+        return;
+      }
+
+      if(this.$currentCounter) {
+        this.$currentCounter.replaceWith(updateCount());
+      } else {
+        $textArea.after(updateCount());
+      }
+    },
+
+    removeCounter: function() {
+      this.$currentCounter.remove();
+      this.$currentCounter = null;
+    },
+
+    bindEvents: function() {
+      this.textAreasWithCharCount
+        .on('keyup', $.proxy(this.renderCounter, this))
+        .focus($.proxy(this.renderCounter, this))
+        .blur($.proxy(this.removeCounter, this));
+    },
+
+    cacheEls: function() {
+      this.textAreasWithCharCount = $('textarea[data-character-count]')
+        .filter(function() {
+          return typeof $(this).data('character-count') === 'number';
+        });
+    },
+
+    templates: function() {
+      this.characterCounter = _.template($('#characterCounter').html());
+    }
+  };
+}());

--- a/cla_public/static-src/stylesheets/_forms.scss
+++ b/cla_public/static-src/stylesheets/_forms.scss
@@ -8,6 +8,7 @@
 @import 'forms/form-group';
 @import 'forms/form-row';
 @import 'forms/form-option-list';
+@import 'forms/character-counter';
 
 .form-actions {
   margin-top: 40px;

--- a/cla_public/static-src/stylesheets/forms/character-counter.scss
+++ b/cla_public/static-src/stylesheets/forms/character-counter.scss
@@ -1,0 +1,28 @@
+.character-counter {
+  font-size: 13px;
+  color: $grey-1;
+  margin-top: 5px;
+
+  &.counter-low {
+    -webkit-animation: pulsate 220ms infinite alternate;
+    animation: pulsate 220ms infinite alternate;
+    color: $mellow-red;
+  }
+}
+
+@-webkit-keyframes pulsate {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: .7;
+  }
+}
+@keyframes pulsate {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: .7;
+  }
+}

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -69,7 +69,9 @@
     {{ Subform.address(form.address) }}
 
     {% call Form.fieldset(form.extra_notes, as_label=True) %}
-      {{ form.extra_notes(class_='form-control m-full', rows=7) }}
+      {% set max_length_validator = form.extra_notes.validators|selectattr('max')|first %}
+      {% set max_length = max_length_validator.max if max_length_validator %}
+      {{ form.extra_notes(class_='form-control m-full', rows=7, **{ 'data-character-count': max_length }) }}
     {% endcall %}
 
     {{ Subform.adaptations(form.adaptations) }}
@@ -127,6 +129,12 @@
           <option value="<%= index %>"><%= address %></option>
         <% }); %>
       </select>
+    </div>
+  </script>
+
+  <script type="text/html" id="characterCounter">
+    <div class="character-counter <%= counter_class %>">
+      <%= count %> {{ _('characters remaining') }}
     </div>
   </script>
 {% endblock %}

--- a/tests/nightwatch/specs/current/contact-page.js
+++ b/tests/nightwatch/specs/current/contact-page.js
@@ -44,6 +44,33 @@ module.exports = {
 
     willCallWithNotes(client, text(4000));
     assertConfirmation(client);
+  },
+
+  'Notes have counter': function(client) {
+    contactPage(client);
+
+    client
+      .setValue('textarea[name="extra_notes"]', text(2000), function() {
+        console.log('     • Adding 2000 characters in notes field');
+      })
+      .assert.containsText('.character-counter', 2000,
+        'Checking that notes counter shows 2000 left')
+      .setValue('textarea[name="extra_notes"]', text(1980), function() {
+        console.log('     • Adding another 1980 characters');
+      })
+      .assert.containsText('.character-counter', 20,
+        'Checking that notes counter shows 20 left')
+      .assert.cssClassPresent('.character-counter', 'counter-low',
+        'Counter class should change to ‘low character’ mode')
+      .setValue('textarea[name="extra_notes"]', text(30), function() {
+        console.log('     • Overflowing notes field with 10 characters over the limit');
+      })
+      .assert.containsText('.character-counter', 0,
+        'Checking that notes counter shows 0')
+      .getValue('textarea[name="extra_notes"]', function(response) {
+        this.assert.ok(response.value.length === 4000,
+          'Ensure that number of characters in notes field is still 4000');
+      });
 
     client.end();
   }

--- a/tests/nightwatch/specs/current/contact-page.js
+++ b/tests/nightwatch/specs/current/contact-page.js
@@ -37,11 +37,6 @@ module.exports = {
   'Notes max length is 4000 chars': function (client) {
     contactPage(client);
 
-    willCallWithNotes(client, text(4001));
-    assertNotesError(client);
-
-    client.clearValue('textarea[name="extra_notes"]');
-
     willCallWithNotes(client, text(4000));
     assertConfirmation(client);
   },


### PR DESCRIPTION
Usage:
Add `data-character-count='4000'` as attribute on textarea.

The value has to be a number. A small template for counter is also required (see contact.html)

[#92355174]