### PR TITLE
scope graphs use "permanent" IDs

### DIFF
--- a/cla_public/apps/checker/tests/test_integration.py
+++ b/cla_public/apps/checker/tests/test_integration.py
@@ -32,8 +32,8 @@ SPREADSHEET_PATH = os.path.join(
 
 
 SCOPE_PATHS = {
-    'debt': ['n43::n2', 'n2'],
-    'benefits': ['n43::n13', 'n20']
+    'debt': ['n43n2', 'n2'],
+    'benefits': ['n43n13', 'n20']
 }
 
 

--- a/cla_public/apps/scope/tests/test_diagnosis_api.py
+++ b/cla_public/apps/scope/tests/test_diagnosis_api.py
@@ -21,11 +21,11 @@ class TestReviewPage(unittest.TestCase):
     def test_outcome(self):
         paths = [
             # family > disputes over children > with ex over children > domestic abuse > no immediate harm risk
-            ('INSCOPE', ['n43::n14', 'n105', 'n106', 'n62', 'n19']),
+            ('INSCOPE', ['n43n14', 'n105', 'n106', 'n62', 'n19']),
             # family > disputes over children > with ex over children > domestic abuse > immediate harm risk
-            ('CONTACT', ['n43::n14', 'n105', 'n106', 'n62', 'n18']),
+            ('CONTACT', ['n43n14', 'n105', 'n106', 'n62', 'n18']),
             # family > any other problem
-            ('INELIGIBLE', ['n43::n14', 'n53']),
+            ('INELIGIBLE', ['n43n14', 'n53']),
         ]
 
         for outcome, choices in paths:
@@ -37,15 +37,15 @@ class TestReviewPage(unittest.TestCase):
 
     def test_direct_link(self):
         # family > problem with ex > dispute over children > family mediation
-        resp = api.move(['n43::n14', 'n51', 'n57', 'n59'])
+        resp = api.move(['n43n14', 'n51', 'n57', 'n59'])
         self.assertResponseHasNNodes(resp, 4)
 
         # family > problem with ex
-        resp = api.move(['n43::n14', 'n51'])
+        resp = api.move(['n43n14', 'n51'])
         self.assertResponseHasNNodes(resp, 2)
 
         # family
-        resp = api.move(['n43::n14'])
+        resp = api.move(['n43n14'])
         self.assertResponseHasNNodes(resp, 1)
 
         resp = api.move([])


### PR DESCRIPTION
so that graph node rearrangement does not affect tests nor URLs (important for google analytics)
depends on [cla_backend#361](https://github.com/ministryofjustice/cla_backend/pull/361)
[Fixes #95035940]