### PR TITLE
progress bar fix

### DIFF
--- a/cla_public/templates/checker/_progress.html
+++ b/cla_public/templates/checker/_progress.html
@@ -2,7 +2,7 @@
 {% set total_step_count = steps|count + 1 %}
 {% set completed_step_count = steps|selectattr('is_completed')|list|count + 1 %}
 {% set completion_percentage = completed_step_count / total_step_count * 100 %}
-{% set current_percentage = current_step.count / total_step_count * 100 %}
+{% set current_percentage = current_step.count / total_step_count * 100 if current_step else 0 %}
 {% set is_contact_page = request.path.startswith('/result/') %}
 {% set completion_perc_offset = 0 if is_contact_page else -5 %}
 


### PR DESCRIPTION
sometimes when navigating around, perhaps after session expires, users could land on a page that was unavailable in their flow. this is a quick fix to prevent the progress bar causing a 500. a full fix would redirect users to a different page (e.g. start or review)