### PR TITLE
reasons for contacting are now stored in DB

### DIFF
--- a/cla_public/apps/base/constants.py
+++ b/cla_public/apps/base/constants.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from flask.ext.babel import lazy_gettext as _
+from cla_common.constants import REASONS_FOR_CONTACTING
 
 # Feedback: feel about service
 FEEL_ABOUT_SERVICE_LABELS = [
@@ -23,17 +24,14 @@ HELP_FILLING_IN_FORM_LABELS = [
 HELP_FILLING_IN_FORM = zip(HELP_FILLING_IN_FORM_LABELS,
         HELP_FILLING_IN_FORM_LABELS)
 
-
-REASONS_FOR_CONTACTING_OTHER = u'Another reason'
-REASONS_FOR_CONTACTING = [
-    u'I don’t know how to answer a question',
-    u'I don’t have the paperwork I need',
-    u'I’d prefer to speak to someone',
-    u'I have trouble using online services',
-    u'I don’t understand how this service can help me',
-    u'My problem area isn’t covered',
-    u'I’d prefer not to say',
-    REASONS_FOR_CONTACTING_OTHER,
-]
-# NB: keys are deliberately not localised
-REASONS_FOR_CONTACTING = map(lambda reason: (reason, _(reason)), REASONS_FOR_CONTACTING)
+REASONS_FOR_CONTACTING_CHOICES = (
+    # NB: these are duplicated (untranslated) in cla_common so change both when necessary!
+    (REASONS_FOR_CONTACTING.CANT_ANSWER, _(u'I don’t know how to answer a question')),
+    (REASONS_FOR_CONTACTING.MISSING_PAPERWORK, _(u'I don’t have the paperwork I need')),
+    (REASONS_FOR_CONTACTING.PREFER_SPEAKING, _(u'I’d prefer to speak to someone')),
+    (REASONS_FOR_CONTACTING.DIFFICULTY_ONLINE, _(u'I have trouble using online services')),
+    (REASONS_FOR_CONTACTING.HOW_SERVICE_HELPS, _(u'I don’t understand how this service can help me')),
+    (REASONS_FOR_CONTACTING.AREA_NOT_COVERED, _(u'My problem area isn’t covered')),
+    (REASONS_FOR_CONTACTING.PNS, _(u'I’d prefer not to say')),
+    (REASONS_FOR_CONTACTING.OTHER, _(u'Another reason')),
+)

--- a/cla_public/apps/base/tests/test_reasons_for_contacting.py
+++ b/cla_public/apps/base/tests/test_reasons_for_contacting.py
@@ -1,0 +1,38 @@
+from random import choice
+import unittest
+
+from flask import url_for
+from werkzeug.datastructures import MultiDict
+
+from cla_public import app
+from cla_public.apps.base.constants import REASONS_FOR_CONTACTING_CHOICES
+from cla_public.apps.base.forms import ReasonsForContactingForm
+from cla_public.apps.checker.api import post_reasons_for_contacting
+
+
+class ReasonsForContactingTestCase(unittest.TestCase):
+    def setUp(self):
+        self.app = app.create_app('config/testing.py')
+        self.app.test_request_context().push()
+        self.client = self.app.test_client()
+
+    def test_submission(self):
+        income_page_url = url_for('checker.wizard', step='income')
+        random_reason = str(choice(REASONS_FOR_CONTACTING_CHOICES)[0])
+
+        api_payload = ReasonsForContactingForm(formdata=MultiDict({
+            'referrer': income_page_url,
+            'other_reasons': 'other reasons',
+            'reasons': [random_reason],
+        })).api_payload()
+
+        response = post_reasons_for_contacting(payload=api_payload)
+        self.assertIsInstance(response, dict,
+                              'Reason for contacting response not a dict')
+        self.assertDictContainsSubset({
+            'referrer': income_page_url,
+            'other_reasons': 'other reasons',
+            'reasons': [{'category': random_reason}],
+        }, response)
+        self.assertTrue(response['reference'],
+                        'Reason for contacting not given a reference')

--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -106,6 +106,9 @@ class ReasonsForContacting(ZendeskView):
         posts to Zendesk. If feedback is ever redirected to the
         database as well, move the code here up into ZendeskView
     """
+    MODEL_REF_SESSION_KEY = 'reason_for_contact'
+    GA_SESSION_KEY = 'reason_for_contact_ga'
+
     form_class = ReasonsForContactingForm
     template = 'reasons-for-contacting.html'
     redirect_to = 'contact.get_in_touch'
@@ -117,10 +120,11 @@ class ReasonsForContacting(ZendeskView):
                 # allows skipping form if nothing is selected
                 return self.success_redirect()
 
+            session[self.GA_SESSION_KEY] = ', '.join(self.form.reasons.data)
             response = post_reasons_for_contacting(form=self.form)
             # ignore if reasons not saved as they're not vital
             if response and 'reference' in response:
-                session['reasons_for_contacting'] = response['reference']
+                session[self.MODEL_REF_SESSION_KEY] = response['reference']
 
             return self.success_redirect()
 

--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -7,13 +7,13 @@ from urlparse import urlparse, urljoin
 
 from flask import abort, current_app, jsonify, redirect, render_template, \
     session, url_for, request, views
-from flask.ext.babel import lazy_gettext as _, gettext
+from flask.ext.babel import lazy_gettext as _
 
-from cla_common.smoketest import smoketest
 from cla_public.apps.base import base
 from cla_public.apps.base.forms import FeedbackForm, ReasonsForContactingForm
 import cla_public.apps.base.filters
 import cla_public.apps.base.extensions
+from cla_public.apps.checker.api import post_reasons_for_contacting
 from cla_public.libs import zendesk
 from cla_public.libs.views import HasFormMixin, ValidFormOnOptions
 
@@ -101,17 +101,30 @@ class ReasonsForContacting(ZendeskView):
     """
     Interstitial form to ascertain why users are dropping out of
     the checker service
+
+    NB: Shares code with Feedback view, but no longer in fact
+        posts to Zendesk. If feedback is ever redirected to the
+        database as well, move the code here up into ZendeskView
     """
     form_class = ReasonsForContactingForm
     template = 'reasons-for-contacting.html'
     redirect_to = 'contact.get_in_touch'
 
     def post(self):
+        error = None
         if self.form.validate_on_submit():
             if len(self.form.reasons.data) == 0:
                 # allows skipping form if nothing is selected
                 return self.success_redirect()
-        return super(ReasonsForContacting, self).post()
+
+            response = post_reasons_for_contacting(form=self.form)
+            # ignore if reasons not saved as they're not vital
+            if response and 'reference' in response:
+                session['reasons_for_contacting'] = response['reference']
+
+            return self.success_redirect()
+
+        return self.render_form(error)
 
 
 base.add_url_rule(
@@ -204,7 +217,6 @@ def smoke_tests():
     """
     Run smoke tests and return results as JSON datastructure
     """
-
     from cla_common.smoketest import smoketest
     from cla_public.apps.checker.tests.smoketests import SmokeTests
 

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -9,7 +9,7 @@ from flask.ext.mail import Message
 from cla_public.apps.contact import contact
 from cla_public.apps.contact.forms import ContactForm
 from cla_public.apps.checker.api import post_to_case_api, \
-    post_to_eligibility_check_api, ApiError
+    post_to_eligibility_check_api, update_reasons_for_contacting, ApiError
 from cla_public.apps.checker.views import UpdatesMeansTest
 from cla_public.libs.views import AllowSessionOverride, SessionBackedFormView, \
     EnsureSessionExists
@@ -51,6 +51,9 @@ class Contact(
         try:
             post_to_eligibility_check_api(session.checker.notes_object())
             post_to_case_api(self.form)
+            if 'reasons_for_contacting' in session:
+                update_reasons_for_contacting(session['reasons_for_contacting'], payload={'case': session.checker['case_ref']})
+                del session['reasons_for_contacting']
         except ApiError:
             self.form.errors['timeout'] = _(
                 u'There was an error submitting your data. '

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -6,6 +6,7 @@ from flask import abort, redirect, render_template, session, url_for, views, \
 from flask.ext.babel import lazy_gettext as _, gettext
 from flask.ext.mail import Message
 
+from cla_public.apps.base.views import ReasonsForContacting
 from cla_public.apps.contact import contact
 from cla_public.apps.contact.forms import ContactForm
 from cla_public.apps.checker.api import post_to_case_api, \
@@ -44,6 +45,14 @@ class Contact(
     form_class = ContactForm
     template = 'contact.html'
 
+    def get(self, *args, **kwargs):
+        if ReasonsForContacting.GA_SESSION_KEY in session:
+            self.template_context = {
+                'reasons_for_contacting': session[ReasonsForContacting.GA_SESSION_KEY]
+            }
+            del session[ReasonsForContacting.GA_SESSION_KEY]
+        return super(Contact, self).get(*args, **kwargs)
+
     def on_valid_submit(self):
 
         if self.form.extra_notes.data:
@@ -51,9 +60,10 @@ class Contact(
         try:
             post_to_eligibility_check_api(session.checker.notes_object())
             post_to_case_api(self.form)
-            if 'reasons_for_contacting' in session:
-                update_reasons_for_contacting(session['reasons_for_contacting'], payload={'case': session.checker['case_ref']})
-                del session['reasons_for_contacting']
+            if ReasonsForContacting.MODEL_REF_SESSION_KEY in session:
+                update_reasons_for_contacting(session[ReasonsForContacting.MODEL_REF_SESSION_KEY],
+                                              payload={'case': session.checker['case_ref']})
+                del session[ReasonsForContacting.MODEL_REF_SESSION_KEY]
         except ApiError:
             self.form.errors['timeout'] = _(
                 u'There was an error submitting your data. '

--- a/cla_public/libs/views.py
+++ b/cla_public/libs/views.py
@@ -83,14 +83,14 @@ class SessionBackedFormView(
     """
     Saves and loads form data to and from the session
     """
-
     template = None
+    template_context = {}
 
     def get(self, *args, **kwargs):
         """
         Render template with form
         """
-        return render_template(self.template, form=self.form)
+        return render_template(self.template, form=self.form, **self.template_context)
 
     def post(self, *args, **kwargs):
         """

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -107,6 +107,15 @@
 {% endblock %}
 
 
+{% block ga_pageview -%}
+    {{ super() }}
+
+    {% if reasons_for_contacting -%}
+      ga('send', 'event', 'reasons_for_contacting', '{{ reasons_for_contacting }}');
+    {%- endif -%}
+{%- endblock %}
+
+
 {% block javascripts %}
   {{ super() }}
 

--- a/cla_public/templates/emails/zendesk-reasons-for-contacting.txt
+++ b/cla_public/templates/emails/zendesk-reasons-for-contacting.txt
@@ -1,5 +1,5 @@
 ** Reasons for contacting **
-{% for reason in form.reasons.data -%}
+{% for reason in form.reason_descriptions -%}
 - {{ reason }}
 {% endfor %}
 

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CLA Public\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-06-19 16:56+0100\n"
+"POT-Creation-Date: 2015-06-18 14:44+0100\n"
 "PO-Revision-Date: 2015-05-26 12:41+0000\n"
 "Last-Translator: Welsh Language Unit <welsh.language.unit.manager@hmcts.gsi.gov.uk>\n"
 "Language-Team: Welsh (http://www.transifex.com/projects/p/cla-public/language/cy/)\n"
@@ -20,41 +20,73 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 1.3\n"
 
-#: cla_public/apps/base/constants.py:6
+#: cla_public/apps/base/constants.py:7
 msgid "Very satisfied"
 msgstr "Bodlon iawn"
 
-#: cla_public/apps/base/constants.py:7
+#: cla_public/apps/base/constants.py:8
 msgid "Satisfied"
 msgstr "Bodlon"
 
-#: cla_public/apps/base/constants.py:8
+#: cla_public/apps/base/constants.py:9
 msgid "Neither satisfied or dissatisfied"
 msgstr "Ddim yn fodlon nac yn anfodlon"
 
-#: cla_public/apps/base/constants.py:9
+#: cla_public/apps/base/constants.py:10
 msgid "Dissatisfied"
 msgstr "Anfodlon"
 
-#: cla_public/apps/base/constants.py:10
+#: cla_public/apps/base/constants.py:11
 msgid "Very dissatisfied"
 msgstr "Anfodlon iawn"
 
-#: cla_public/apps/base/constants.py:17
+#: cla_public/apps/base/constants.py:18
 msgid "No, I filled in this form myself"
 msgstr "Na, llenwais y ffurflen hon fy hun"
 
-#: cla_public/apps/base/constants.py:18
+#: cla_public/apps/base/constants.py:19
 msgid "I have difficulty using computers so someone filled in this form for me"
 msgstr "Rwyf yn cael trafferth defnyddio cyfrifiaduron, felly llenwodd rhywun arall y ffurflen hon ar fy rhan"
 
-#: cla_public/apps/base/constants.py:19
+#: cla_public/apps/base/constants.py:20
 msgid "I used an accessibility tool such as a screen reader"
 msgstr "Defnyddiais offer hygyrchedd megis darllenydd sgrîn"
 
-#: cla_public/apps/base/constants.py:20
+#: cla_public/apps/base/constants.py:21
 msgid "I had some other kind of help"
 msgstr "Cefais rhyw fath arall o help"
+
+#: cla_public/apps/base/constants.py:29
+msgid "I don’t know how to answer a question"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:30
+msgid "I don’t have the paperwork I need"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:31
+msgid "I’d prefer to speak to someone"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:32
+msgid "I have trouble using online services"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:33
+msgid "I don’t understand how this service can help me"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:34
+msgid "My problem area isn’t covered"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:35
+msgid "I’d prefer not to say"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:36
+msgid "Another reason"
+msgstr ""
 
 #: cla_public/apps/base/forms.py:82
 msgid "Did you have any difficulty with this service?"

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-06-19 16:56+0100\n"
+"POT-Creation-Date: 2015-06-18 14:44+0100\n"
 "PO-Revision-Date: 2014-12-04 12:47+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -17,40 +17,72 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 1.3\n"
 
-#: cla_public/apps/base/constants.py:6
+#: cla_public/apps/base/constants.py:7
 msgid "Very satisfied"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:7
+#: cla_public/apps/base/constants.py:8
 msgid "Satisfied"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:8
+#: cla_public/apps/base/constants.py:9
 msgid "Neither satisfied or dissatisfied"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:9
+#: cla_public/apps/base/constants.py:10
 msgid "Dissatisfied"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:10
+#: cla_public/apps/base/constants.py:11
 msgid "Very dissatisfied"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:17
+#: cla_public/apps/base/constants.py:18
 msgid "No, I filled in this form myself"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:18
+#: cla_public/apps/base/constants.py:19
 msgid "I have difficulty using computers so someone filled in this form for me"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:19
+#: cla_public/apps/base/constants.py:20
 msgid "I used an accessibility tool such as a screen reader"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:20
+#: cla_public/apps/base/constants.py:21
 msgid "I had some other kind of help"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:29
+msgid "I don’t know how to answer a question"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:30
+msgid "I don’t have the paperwork I need"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:31
+msgid "I’d prefer to speak to someone"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:32
+msgid "I have trouble using online services"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:33
+msgid "I don’t understand how this service can help me"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:34
+msgid "My problem area isn’t covered"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:35
+msgid "I’d prefer not to say"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:36
+msgid "Another reason"
 msgstr ""
 
 #: cla_public/apps/base/forms.py:82

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-06-19 16:56+0100\n"
+"POT-Creation-Date: 2015-06-18 14:44+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,40 +17,72 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 1.3\n"
 
-#: cla_public/apps/base/constants.py:6
+#: cla_public/apps/base/constants.py:7
 msgid "Very satisfied"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:7
+#: cla_public/apps/base/constants.py:8
 msgid "Satisfied"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:8
+#: cla_public/apps/base/constants.py:9
 msgid "Neither satisfied or dissatisfied"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:9
+#: cla_public/apps/base/constants.py:10
 msgid "Dissatisfied"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:10
+#: cla_public/apps/base/constants.py:11
 msgid "Very dissatisfied"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:17
+#: cla_public/apps/base/constants.py:18
 msgid "No, I filled in this form myself"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:18
+#: cla_public/apps/base/constants.py:19
 msgid "I have difficulty using computers so someone filled in this form for me"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:19
+#: cla_public/apps/base/constants.py:20
 msgid "I used an accessibility tool such as a screen reader"
 msgstr ""
 
-#: cla_public/apps/base/constants.py:20
+#: cla_public/apps/base/constants.py:21
 msgid "I had some other kind of help"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:29
+msgid "I don’t know how to answer a question"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:30
+msgid "I don’t have the paperwork I need"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:31
+msgid "I’d prefer to speak to someone"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:32
+msgid "I have trouble using online services"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:33
+msgid "I don’t understand how this service can help me"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:34
+msgid "My problem area isn’t covered"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:35
+msgid "I’d prefer not to say"
+msgstr ""
+
+#: cla_public/apps/base/constants.py:36
+msgid "Another reason"
 msgstr ""
 
 #: cla_public/apps/base/forms.py:82

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ PyYAML==3.11
 Werkzeug==0.9.6
 argparse==1.2.1
 blinker==1.3
-git+git://github.com/ministryofjustice/cla_common.git@0.2.2#egg=cla_common==0.2.2
+git+git://github.com/ministryofjustice/cla_common.git@0.2.4#egg=cla_common==0.2.4
 itsdangerous==0.24
 jinja-moj-template==0.19.0
 logstash_formatter==0.5.9

--- a/tests/nightwatch/specs/reasons-for-contacting.js
+++ b/tests/nightwatch/specs/reasons-for-contacting.js
@@ -1,0 +1,50 @@
+function reasonsForContactingForm(client) {
+  client
+    .startService()
+    .click('#callback-link', function() {
+      console.log('     ⟡ "Get in touch" link clicked');
+    })
+    .waitForElementVisible('.reasons-for-contacting-form', 3000,
+      '  - "Reasons for contacting" form exists');
+  return client;
+}
+
+function submitReasonsForContacting(client) {
+  client.submitForm('.reasons-for-contacting-form', function() {
+    console.log('     ⟡ "Continue to contact CLA" button clicked');
+  }).waitForElementVisible('.contact-form', 3000,
+    '  - Contact form loaded'
+  );
+}
+
+module.exports = {
+  'Reasons for contacting do not need to be filled in': function(client) {
+    reasonsForContactingForm(client);
+    submitReasonsForContacting(client);
+    client.end();
+  },
+
+  'Reasons for contacting with one reason': function(client) {
+    reasonsForContactingForm(client);
+    client
+      .click('input[value="PREFER_SPEAKING"]', function() {
+        console.log('     ⟡ "I’d prefer to speak to someone" clicked');
+      });
+    submitReasonsForContacting(client);
+    client.end();
+  },
+
+  'Reasons for contacting with more details': function(client) {
+    reasonsForContactingForm(client);
+    client
+      .click('input[value="OTHER"]', function() {
+        console.log('     ⟡ "Another reason" clicked');
+      })
+      .click('input[value="PREFER_SPEAKING"]', function() {
+        console.log('     ⟡ "I’d prefer to speak to someone" clicked');
+      });
+    // free text field is no longer visible
+    submitReasonsForContacting(client);
+    client.end();
+  }
+};


### PR DESCRIPTION
when a user drops out of the scope/means test flow, they are presented with a form to find out why they want to get in touch. the form was previously sent to zendesk
[Fixes #96775836]
depends on [cla_backend#363](https://github.com/ministryofjustice/cla_backend/pull/363) and [cla_common#31](https://github.com/ministryofjustice/cla_common/pull/31)