### PR TITLE
Add Browser Sync HTML Injector

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "engineStrict": true,
   "devDependencies": {
     "browser-sync": "~2.7",
+    "bs-html-injector": "^2.0.4",
     "del": "^0.1.3",
     "govuk_frontend_toolkit": "^2.0.1",
     "gulp": "^3.8.11",

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -2,7 +2,8 @@
 
 var gulp = require('gulp');
 var paths = require('./_paths');
-var browserSync = require('browser-sync');
+var browserSync = require('browser-sync').create();
+var htmlInjector = require("bs-html-injector");
 var argv = require('yargs').argv;
 
 
@@ -11,13 +12,17 @@ gulp.task('serve', ['build'], function() {
   var host = argv.host || argv.h || 'localhost';
   var port = argv.port || argv.p || 5000;
 
-  browserSync({
+  browserSync.use(htmlInjector, {
+    files: '*.html'
+  });
+
+  browserSync.init({
     proxy: host + ':' + port,
     open: false,
     port: 3000
   });
 
-  gulp.watch(paths.templates, browserSync.reload);
+  gulp.watch(paths.templates, htmlInjector);
   gulp.watch(paths.images, ['images']);
   gulp.watch(paths.ie_styles, ['ie-css']);
   gulp.watch(paths.styles, ['sass']);


### PR DESCRIPTION
HTML Injector attempts to watch template files edits and reload
only corresponding part of edited HTML instead of the whole page.