### PR TITLE
start page copy – what does legal aid cover?

### DIFF
--- a/cla_public/templates/index.html
+++ b/cla_public/templates/index.html
@@ -9,7 +9,7 @@
 
 {% block inner_content %}
   <h1>Check if you can get legal aid</h1>
-  <p>Legal aid can help pay for legal advice or family mediation.</p>
+  <p>Legal aid can help pay for legal advice.</p>
   <p>This service will check that your problem is covered by legal aid.</p>
   <ul>
     <li>If it looks like you can get legal aid, you may be able to get help over the phone or we’ll suggest that you speak to an adviser face to face.</li>
@@ -33,7 +33,7 @@
   {% endcall %}
 
   <div class="meta-data group">
-    <p class="modified-date">Last updated: 6 July 2015</p>
+    <p class="modified-date">Last updated: 17 July 2015</p>
   </div>
 
 {% endblock %}


### PR DESCRIPTION
no longer mentioning family mediation as it was throwing users off
