### PR TITLE
Fix multiple properties JS bug

### DIFF
--- a/cla_public/static-src/javascripts/modules/properties.js
+++ b/cla_public/static-src/javascripts/modules/properties.js
@@ -29,7 +29,7 @@
     _updateForm: function(res) {
       this.$form.replaceWith($(res).find('#PropertiesForm'));
 
-      this.init();
+      moj.init();
     },
 
     handleAddRemoveButton: function(button) {


### PR DESCRIPTION
When property is injected via XHR it loses form field bindings (such as conditional fields, label select etc)
Reinitialise all moj modules when the page is updated.