### PR TITLE
Fix Sentry errors

### DIFF
--- a/cla_public/apps/checker/api.py
+++ b/cla_public/apps/checker/api.py
@@ -129,11 +129,11 @@ def log_api_errors_to_sentry(fn):
             except ValueError:
                 errors = {}
 
+            if errors.get('eligibility_check', None) == API_MESSAGE_WARNINGS:
+                raise AlreadySavedApiError(API_MESSAGE_WARNINGS[0])
+
             if sentry:
-                if errors.get('eligibility_check', None) == API_MESSAGE_WARNINGS:
-                    raise AlreadySavedApiError(API_MESSAGE_WARNINGS[0])
-                else:
-                    sentry.captureException(data=errors)
+                sentry.captureException(data=errors)
             else:
                 log.warning(
                     'Failed posting to API: {0}, Response: {1}'.format(

--- a/cla_public/apps/checker/tests/test_api_already_saved_error.py
+++ b/cla_public/apps/checker/tests/test_api_already_saved_error.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+import json
+import unittest
+from cla_public.apps.contact.views import session
+from mock import patch
+from slumber.exceptions import SlumberHttpBaseException
+
+from cla_common.constants import ELIGIBILITY_STATES
+from cla_public import app
+from cla_public.apps.checker.api import post_to_case_api, AlreadySavedApiError
+from cla_public.apps.contact.forms import ContactForm
+from cla_public.apps.contact.views import Contact
+
+
+def _mock_session_send(*args, **kwargs):
+    raise SlumberHttpBaseException(
+        content=json.dumps({
+            'eligibility_check': [
+                'Case with this Eligibility check already exists.'
+            ]
+        })
+    )
+
+
+def _mock_post_to_case_api(*args, **kwargs):
+    raise AlreadySavedApiError()
+
+
+def _mock_post_to_eligibility_check_api(*args, **kwargs):
+    session.checker['eligibility_check'] = 'EC'
+    session.checker._eligibility = ELIGIBILITY_STATES.UNKNOWN
+
+
+def _mock_get_case_ref_from_api(*args, **kwargs):
+    session.checker['case_ref'] = 'CR'
+
+
+def _mock_post_to_is_eligible_api(*args, **kwargs):
+    return ELIGIBILITY_STATES.YES, []
+
+
+class ApiAlreadySavedErrorTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.app = app.create_app('config/testing.py')
+        self._ctx = self.app.test_request_context()
+        self._ctx.push()
+        self.client = self.app.test_client()
+
+    def test_mock_session_send_post_to_case_api(self):
+        form = ContactForm()
+        with patch('requests.Session.send', _mock_session_send), \
+             patch('cla_public.apps.contact.views.get_case_ref_from_api',
+                   _mock_get_case_ref_from_api):
+
+            self.assertRaises(AlreadySavedApiError, post_to_case_api, form)
+
+    def test_contact_on_valid_submit(self):
+        with patch('cla_public.apps.contact.views.post_to_case_api',
+                   _mock_post_to_case_api), \
+             patch('cla_public.apps.contact.views.get_case_ref_from_api',
+                   _mock_get_case_ref_from_api), \
+             patch('cla_public.apps.contact.views.post_to_eligibility_check_api',
+                   _mock_post_to_eligibility_check_api), \
+             patch('cla_public.apps.checker.session.post_to_is_eligible_api',
+                   _mock_post_to_is_eligible_api):
+
+            resp = Contact().on_valid_submit()
+
+            self.assertEqual(resp.headers['Location'], '/result/confirmation')
+            self.assertEqual(resp.status_code, 302)
+
+
+

--- a/cla_public/apps/checker/tests/test_validation.py
+++ b/cla_public/apps/checker/tests/test_validation.py
@@ -4,8 +4,11 @@ from mock import Mock
 
 import flask
 from werkzeug.datastructures import MultiDict
+from wtforms import ValidationError, Form
+from wtforms.fields.html5 import EmailField
 
 from cla_public.apps.checker.forms import AboutYouForm
+from cla_public.apps.contact.validators import EmailValidator
 from cla_public.libs.utils import override_locale
 
 
@@ -38,3 +41,31 @@ class TestValidation(unittest.TestCase):
             u'Number must be between 1 and 50',
             form.num_children.errors,
             '{0} is not too many kids'.format(num))
+
+    def test_email_validator(self):
+        form = Form()
+        field = EmailField()
+        message = u'Email incorrect.'
+        validator = EmailValidator(message=message)
+
+        field.data = 'emailwithspace @example.com'
+        self.assertRaises(ValidationError, validator, form, field)
+
+        field.data = ' emailwithspace@example.com'
+        self.assertRaises(ValidationError, validator, form, field)
+
+        field.data = 'email withspace@example.com'
+        self.assertRaises(ValidationError, validator, form, field)
+
+        field.data = 'emailwithspace@ example.com'
+        self.assertRaises(ValidationError, validator, form, field)
+
+        field.data = 'emailwithspace@example.com '
+        self.assertRaises(ValidationError, validator, form, field)
+
+        field.data = 'emailwithspace@example.com'
+        try:
+            validator(form, field)
+        except ValidationError:
+            self.fail(u'%s should not raise email validation error' %
+                      field.data)

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -9,7 +9,7 @@ from wtforms import Form as NoCsrfForm
 from wtforms import BooleanField, RadioField, SelectField, \
     StringField, TextAreaField
 from wtforms.validators import InputRequired, Optional, Required, \
-    Length, Email
+    Length
 
 from cla_common.constants import ADAPTATION_LANGUAGES, THIRDPARTY_RELATIONSHIP
 from cla_public.apps.contact.fields import AvailabilityCheckerField, \
@@ -19,6 +19,7 @@ from cla_public.apps.checker.constants import CONTACT_SAFETY, \
 from cla_public.apps.base.forms import BabelTranslationsFormMixin
 from cla_public.apps.checker.validators import IgnoreIf, \
     FieldValue
+from cla_public.apps.contact.validators import EmailValidator
 from cla_public.libs.honeypot import Honeypot
 from cla_public.libs.utils import get_locale
 
@@ -186,7 +187,7 @@ class ContactForm(Honeypot, BabelTranslationsFormMixin, Form):
             Length(max=255, message=_(
                 u'Your address must be 255 characters '
                 u'or less')),
-            Email(message=_(u'Invalid email address')),
+            EmailValidator(message=_(u'Invalid email address')),
             Optional()]
     )
     address = ValidatedFormField(
@@ -260,6 +261,6 @@ class ConfirmationForm(Honeypot, BabelTranslationsFormMixin, Form):
             Length(max=255, message=_(
                 u'Your address must be 255 characters '
                 u'or less')),
-            Email(message=_(u'Invalid email address')),
+            EmailValidator(message=_(u'Invalid email address')),
             InputRequired()]
     )

--- a/cla_public/apps/contact/validators.py
+++ b/cla_public/apps/contact/validators.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import re
+
+from wtforms.validators import Email, HostnameValidation
+
+
+class EmailValidator(Email):
+    def __init__(self, message=None):
+        self.validate_hostname = HostnameValidation(
+            require_tld=True,
+        )
+        super(Email, self).__init__(
+            r'^[-0-9a-zA-Z.+_\'*+-/=?^_`{|}~]+@([^.@][^@]+)$',
+            re.IGNORECASE,
+            message)

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -70,7 +70,7 @@ class Contact(
         try:
             get_case_ref_from_api()
             session.store_checker_details()
-            return redirect(url_for('.confirmation'))
+            return redirect(url_for('contact.confirmation'))
         except ApiError:
             error_text = _(
                 u'There was an error submitting your data. '
@@ -92,7 +92,7 @@ class Contact(
             session.store_checker_details()
             if self.form.email.data and current_app.config['MAIL_SERVER']:
                 current_app.mail.send(create_confirmation_email(self.form.data))
-            return redirect(url_for('.confirmation'))
+            return redirect(url_for('contact.confirmation'))
         except AlreadySavedApiError:
             return self.already_saved()
         except ApiError as e:
@@ -166,7 +166,7 @@ class ContactConfirmation(HasFormMixin, ValidFormOnOptions, views.MethodView):
                     u'There was an error submitting your email. '
                     u'Please check and try again or try without it.'))
                 return self.get()
-        return redirect(url_for('.confirmation'))
+        return redirect(url_for('contact.confirmation'))
 
 contact.add_url_rule(
     '/result/confirmation',

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 "Contact views"
 from smtplib import SMTPAuthenticationError
-import itertools
+from collections import Mapping
 
 from flask import abort, redirect, render_template, session, url_for, views, \
     current_app
@@ -97,7 +97,16 @@ class Contact(
             return self.already_saved()
         except ApiError as e:
             errors = getattr(e, 'errors', {})
-            error_list = list(itertools.chain(*errors.values()))
+            error_list = []
+
+            def add_errors(el):
+                for error in el:
+                    if isinstance(error, basestring):
+                        error_list.append(error)
+                    elif isinstance(error, Mapping):
+                        add_errors(error.values())
+
+            add_errors(errors.values())
 
             error_text = _(
                 u'There was an error submitting your data. '

--- a/cla_public/templates/macros/review.html
+++ b/cla_public/templates/macros/review.html
@@ -48,7 +48,7 @@
 {% macro render_choices(field) %}
   {% if field.data is string %}
     <strong>{{ field|selected_option }}</strong>
-  {% else %}
+  {% elif field.data %}
     <ul class="multiple-answers">
       {% for item in field.data %}
         <li>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,10 +29,8 @@ urllib3==1.10.4
 pyopenssl==0.15.1
 ndg-httpsclient==0.4.0
 pyasn1==0.1.7
+wtforms==2.1
 
 # fork of https://github.com/samgiles/slumber
 # with custom parameters for timeouts and additional headers on requests
 git+git://github.com/ministryofjustice/slumber.git@da38360d6d158ee7ed445b43228fefc6f7e430e6#egg=slumber==0.6.3moj
-
-# Fork of WTForms with welsh translations - PR added
-git+git://github.com/s-block/wtforms.git@47f9f6d789cdb3eef3bf659e047f1bbd1f42af24


### PR DESCRIPTION
- if backend returns case already exists error then retrieve the case ref form the backend and redirect to confirmation without re-saving case