### PR TITLE
Add app version standard env support

### DIFF
--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -241,7 +241,7 @@ def smoke_tests():
 @base.route('/ping.json')
 def ping():
     return jsonify({
-        'version_number': os.environ.get('APPVERSION'),
+        'version_number': os.environ.get('APPVERSION', os.environ.get('APP_VERSION')),
         'build_date': os.environ.get('APP_BUILD_DATE'),
         'commit_id': os.environ.get('APP_GIT_COMMIT'),
         'build_tag': os.environ.get('APP_BUILD_TAG')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,6 +5,7 @@ Flask-Cache==0.13.1
 Flask-Mail==0.9.1
 Flask-Markdown==0.3
 Jinja2==2.7.3
+django>=1.3,<2
 MarkupSafe==0.23
 PyYAML==3.11
 Werkzeug==0.9.6
@@ -25,7 +26,7 @@ Babel==1.3
 beautifulsoup4==4.3.2
 xlrd==0.9.3
 urllib3==1.10.4
-pyopenssl==0.15.1
+pyopenssl==16.2.0
 ndg-httpsclient==0.4.0
 pyasn1==0.1.7
 wtforms==2.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,2 +1,1 @@
-django>=1.3,<2
 -r base.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,1 +1,2 @@
+django>=1.3,<2
 -r base.txt


### PR DESCRIPTION
Add missing dependencies and upgrade pyopenssl

Django version needs to be pinned < 2.0.0 to avoid a major version
upgrade. Additionally, pyopenssl needs to be upgraded to avoid an error
on no attribute 'SSL_ST_INIT'