### PR TITLE
Fix tests failing due to lack of backend

### DIFF
--- a/cla_public/apps/scope/tests/test_diagnosis_api.py
+++ b/cla_public/apps/scope/tests/test_diagnosis_api.py
@@ -18,6 +18,21 @@ class TestReviewPage(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.json().get('nodes')), n)
 
+    def test_diagnosis_pathway(self):
+        diagnosis_paths = [
+            '/scope/diagnosis/',
+            '/scope/diagnosis/n43n14/',
+            '/scope/diagnosis/n43n14/n105/',
+            '/scope/diagnosis/n43n14/n105/n106/',
+            '/scope/refer/family',
+        ]
+
+        self.client.get('/start')
+
+        for path in diagnosis_paths:
+            response = self.client.get(path)
+            self.assertEqual(response.status_code, 200)
+
     def test_outcome(self):
         paths = [
             # family > disputes over children > with ex over children > domestic abuse > no immediate harm risk

--- a/docker/cla_public.ini
+++ b/docker/cla_public.ini
@@ -7,7 +7,6 @@ chmod-socket = 666
 chown-socket = www-data
 master = true
 enable-threads = true
-plugin = python
 processes = 2
 chdir = /home/app/flask
 module = cla_public.wsgi


### PR DESCRIPTION
Several tests failed when run on their own. In some cases they could be
fixed with a basic mock, in another I moved it to an integration
test module.