### PR TITLE
LGA-153: Allow application to use pagination URLs that are missing page numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ You can run the server with:
 
 *OR*
 
-    tools/start-dev
+    CLA_PUBLIC_CONFIG=config/testing.py ./manage.py runserver
 
-to run the server with foreman, which will monitor and
-automatically reload CSS and JS changes and enables other whizzy things.
+With the `testing` configuration, you can use `CLA_BACKEND_PORT` and `LAALAA_PORT`
+environment variables to configure the dependent service API ports.
 
 
 ## Development

--- a/cla_public/apps/base/filters.py
+++ b/cla_public/apps/base/filters.py
@@ -31,6 +31,7 @@ def human_to_url(value):
 @base.app_template_filter()
 def query_to_dict(value, prop=None):
     result = parse_qs(urlparse(value).query)
-    if prop:
-        result = result[prop]
-    return result
+    if not prop:
+        return result
+
+    return result.get(prop, [])

--- a/cla_public/apps/base/tests/test_filters.py
+++ b/cla_public/apps/base/tests/test_filters.py
@@ -1,0 +1,21 @@
+import unittest
+
+from cla_public.apps.base import filters
+
+
+class QueryToDictTest(unittest.TestCase):
+
+    def test_returns_the_parsed_query_parameters_when_no_prop_is_given(self):
+        result = filters.query_to_dict('http://localhost:8000/?postcode=SW1A&page=3')
+        self.assertEqual({'postcode': ['SW1A'], 'page': ['3']}, result)
+
+
+    def test_returns_the_value_of_a_query_parameter_when_a_prop_is_given(self):
+        result = filters.query_to_dict('http://localhost:8000/?postcode=SW1A&page=3', 'page')
+        self.assertEqual(['3'], result)
+
+
+    def test_returns_an_empty_list_when_a_prop_is_given_but_does_not_exist(self):
+        result = filters.query_to_dict('http://localhost:8000/?postcode=SW1A&page=3', 'potato')
+        self.assertEqual([], result)
+

--- a/cla_public/config/testing.py
+++ b/cla_public/config/testing.py
@@ -15,3 +15,5 @@ BACKEND_API = {
     'url': 'http://localhost:{port}/checker/api/v1/'.format(
         port=os.environ.get('CLA_BACKEND_PORT', 8000))
 }
+
+LAALAA_API_HOST = 'http://localhost:{port}'.format(port=os.environ.get('LAALAA_PORT', 8001))


### PR DESCRIPTION
## What does this pull request do?

The Legal Adviser Location Search API this application currently uses to query postcodes has a pagination component in the response.

The API's expected response on the first page is:

```
{
    "count": 3768,
    "next": "https://staging.laalaa.dsd.io/legal-advisers/?page=2&postcode=BS20BL",
    "previous": null,
    "results": [<snip>
```

The API's expected response on the second page is:

```
{
    "count": 3768,
    "next": "https://staging.laalaa.dsd.io/legal-advisers/?page=3&postcode=BS20BL",
    "previous": "https://staging.laalaa.dsd.io/legal-advisers/?page=1&postcode=BS20BL",
    "results": [<snip>
```

If we upgrade the API application's dependencies then the `previous` link will change by losing the `page=1` query parameter:

```diff
-"previous": "https://staging.laalaa.dsd.io/legal-advisers/?page=1&postcode=BS20BL",
+"previous": "https://staging.laalaa.dsd.io/legal-advisers/?postcode=BS20BL",
```

The removal of the `page` argument breaks the context filter, as it makes the assumption that it will always be available:

```
  File ".../cla_public/templates/checker/result/_find-legal-adviser.html", line 97, in top-level template code
    {% set prev_page = data.previous|query_to_dict('page') %}
  File ".../cla_public/apps/base/filters.py", line 35, in query_to_dict
    result = result[prop]
KeyError: 'page'
```

This changeset removes the assumption that "prop"s have to exist.

## Any other changes which would benefit highlighting?

I've slightly changed `cla_public/settings/testing.py` to include a `LAALAA_PORT` environment variable next to the pre-existing `CLA_BACKEND_PORT`. This allows us to setup local testing a little bit quicker.

## Related tickets

- Caused by https://github.com/ministryofjustice/laa-legal-adviser-api/pull/46
- Related to https://github.com/ministryofjustice/fala/pull/7