### PR TITLE
LGA-112: Add disk size to healthchecks

### DIFF
--- a/cla_public/apps/base/healthchecks.py
+++ b/cla_public/apps/base/healthchecks.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+import requests
+from flask import current_app
+
+
+def check_backend_api():
+    backend_healthcheck_url = '%s/%s' % (
+        current_app.config['BACKEND_BASE_URI'], 'status/healthcheck.json')
+    status = False
+    response_content = None
+
+    try:
+        backend_healthcheck_response = requests.get(backend_healthcheck_url)
+        status = True if backend_healthcheck_response.ok else backend_healthcheck_response.error
+        response_content = backend_healthcheck_response.json()
+    except requests.exceptions.RequestException as e:
+        status = False
+        response_content = e.__class__.__name__
+
+    return {
+        'status': status,
+        'url': backend_healthcheck_url,
+        'response': response_content
+    }

--- a/cla_public/apps/base/healthchecks.py
+++ b/cla_public/apps/base/healthchecks.py
@@ -5,13 +5,17 @@ import requests
 from flask import current_app
 
 
+HEALTHY = 'healthy'
+UNHEALTHY = 'unhealthy'
+
+
 def check_disk():
     stat = os.statvfs(os.getcwd())
     available_mb = (stat.f_bavail * stat.f_frsize) / (1024.0 ** 2)
     total_mb = (stat.f_blocks * stat.f_frsize) / (1024.0 ** 2)
 
     available_percent = available_mb / total_mb * 100
-    status = True if available_percent > 2.0 else False
+    status = HEALTHY if available_percent > 2.0 else UNHEALTHY
 
     return {
         'status': status,
@@ -24,16 +28,16 @@ def check_disk():
 def check_backend_api():
     backend_healthcheck_url = '%s/%s' % (
         current_app.config['BACKEND_BASE_URI'], 'status/healthcheck.json')
-    status = False
+    status = UNHEALTHY
     response_content = None
 
     try:
         backend_healthcheck_response = requests.get(backend_healthcheck_url)
         if backend_healthcheck_response.ok:
-            status = True
+            status = HEALTHY
         response_content = backend_healthcheck_response.json()
     except requests.exceptions.RequestException as e:
-        status = False
+        status = UNHEALTHY
         response_content = e.__class__.__name__
 
     return {

--- a/cla_public/apps/base/healthchecks.py
+++ b/cla_public/apps/base/healthchecks.py
@@ -29,7 +29,8 @@ def check_backend_api():
 
     try:
         backend_healthcheck_response = requests.get(backend_healthcheck_url)
-        status = True if backend_healthcheck_response.ok else backend_healthcheck_response.error
+        if backend_healthcheck_response.ok:
+            status = True
         response_content = backend_healthcheck_response.json()
     except requests.exceptions.RequestException as e:
         status = False

--- a/cla_public/apps/base/healthchecks.py
+++ b/cla_public/apps/base/healthchecks.py
@@ -1,7 +1,24 @@
 # -*- coding: utf-8 -*-
 
+import os
 import requests
 from flask import current_app
+
+
+def check_disk():
+    stat = os.statvfs(os.getcwd())
+    available_mb = (stat.f_bavail * stat.f_frsize) / (1024.0 ** 2)
+    total_mb = (stat.f_blocks * stat.f_frsize) / (1024.0 ** 2)
+
+    available_percent = available_mb / total_mb * 100
+    status = True if available_percent > 2.0 else False
+
+    return {
+        'status': status,
+        'available_percent': available_percent,
+        'available_mb': available_mb,
+        'total_mb': total_mb,
+    }
 
 
 def check_backend_api():

--- a/cla_public/apps/base/tests/test_healthchecks.py
+++ b/cla_public/apps/base/tests/test_healthchecks.py
@@ -1,0 +1,36 @@
+import unittest
+import mock
+
+from cla_public.apps.base import healthchecks
+
+
+class DiskSpaceHealthcheckTest(unittest.TestCase):
+    @mock.patch('os.statvfs')
+    def test_disk_space_check_reports_on_available_and_total_space(self, stat_mock):
+        stat_mock.return_value.f_bavail = 50 * 1024
+        stat_mock.return_value.f_blocks = 100 * 1024
+        stat_mock.return_value.f_frsize = 1024
+
+        result = healthchecks.check_disk()
+        self.assertDictContainsSubset(
+            {'available_percent': 50.0, 'available_mb': 50.0, 'total_mb': 100.0}, result)
+
+    @mock.patch('os.statvfs')
+    def test_disk_space_check_passes_when_more_than_2_percent_space_is_available(self, stat_mock):
+        stat_mock.return_value.f_bavail = 3 * 1024
+        stat_mock.return_value.f_blocks = 100 * 1024
+        stat_mock.return_value.f_frsize = 1024
+
+        result = healthchecks.check_disk()
+        self.assertDictContainsSubset(
+            {'status': True, 'available_percent': 3.0}, result)
+
+    @mock.patch('os.statvfs')
+    def test_disk_space_check_fails_when_less_than_2_percent_space_is_available(self, stat_mock):
+        stat_mock.return_value.f_bavail = 2 * 1024
+        stat_mock.return_value.f_blocks = 100 * 1024
+        stat_mock.return_value.f_frsize = 1024
+
+        result = healthchecks.check_disk()
+        self.assertDictContainsSubset(
+            {'status': False, 'available_percent': 2.0}, result)

--- a/cla_public/apps/base/tests/test_healthchecks.py
+++ b/cla_public/apps/base/tests/test_healthchecks.py
@@ -1,6 +1,8 @@
 import unittest
 import mock
+import requests
 
+from cla_public import app
 from cla_public.apps.base import healthchecks
 
 
@@ -34,3 +36,35 @@ class DiskSpaceHealthcheckTest(unittest.TestCase):
         result = healthchecks.check_disk()
         self.assertDictContainsSubset(
             {'status': False, 'available_percent': 2.0}, result)
+
+
+class BackendAPIHealthcheckTest(unittest.TestCase):
+    def setUp(self):
+        self.app = app.create_app('config/testing.py')
+        self.app.test_request_context().push()
+
+    @mock.patch('requests.get')
+    def test_backend_check_fails_if_request_fails(self, request_mock):
+        request_mock.side_effect = requests.exceptions.ConnectionError()
+
+        result = healthchecks.check_backend_api()
+        self.assertDictContainsSubset(
+            {'status': False, 'response': 'ConnectionError'}, result)
+
+    @mock.patch('requests.get')
+    def test_backend_check_fails_if_backend_is_unhealthy(self, request_mock):
+        request_mock.return_value.ok = False
+        request_mock.return_value.json.return_value = {'status': 'DOWN'}
+
+        result = healthchecks.check_backend_api()
+        self.assertDictContainsSubset(
+            {'status': False, 'response': {'status': 'DOWN'}}, result)
+
+    @mock.patch('requests.get')
+    def test_backend_check_passes_if_backend_is_healthy(self, request_mock):
+        request_mock.return_value.ok = True
+        request_mock.return_value.json.return_value = {'status': 'UP'}
+
+        result = healthchecks.check_backend_api()
+        self.assertDictContainsSubset(
+            {'status': True, 'response': {'status': 'UP'}}, result)

--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -6,13 +6,12 @@ import logging
 import datetime
 import re
 from urlparse import urlparse, urljoin
-import requests
 
 from flask import abort, current_app, jsonify, redirect, render_template, \
     session, url_for, request, views
 from flask.ext.babel import lazy_gettext as _
 
-from cla_public.apps.base import base
+from cla_public.apps.base import base, healthchecks
 from cla_public.apps.base.forms import FeedbackForm, ReasonsForContactingForm
 import cla_public.apps.base.filters
 import cla_public.apps.base.extensions
@@ -250,20 +249,7 @@ def ping():
 
 @base.route('/healthcheck.json')
 def healthcheck():
-    backend_healthcheck_uri = '%s/%s' % (current_app.config['BACKEND_BASE_URI'], 'status/healthcheck.json')
-    backend_healthcheck_response = requests.get(backend_healthcheck_uri)
-    backend_healthcheck_json = backend_healthcheck_response.json()
-
     response = {
-
-        'Backend API test': {
-
-            'status': True if backend_healthcheck_response.ok else backend_healthcheck_response.error,
-            'url': backend_healthcheck_uri,
-            'response': backend_healthcheck_json
-
-        }
-
+        'Backend API test': healthchecks.check_backend_api(),
     }
-
     return jsonify(response)

--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -253,7 +253,7 @@ def healthcheck():
         'disk': healthchecks.check_disk(),
         'Backend API test': healthchecks.check_backend_api(),
     }
-    ok = all(item['status'] for _key, item in response.iteritems())
+    ok = all(item['status'] == healthchecks.HEALTHY for _key, item in response.iteritems())
     result = jsonify(response)
     result.status_code = 200 if ok else 503
     return result

--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -250,6 +250,7 @@ def ping():
 @base.route('/healthcheck.json')
 def healthcheck():
     response = {
+        'disk': healthchecks.check_disk(),
         'Backend API test': healthchecks.check_backend_api(),
     }
     return jsonify(response)

--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -253,4 +253,7 @@ def healthcheck():
         'disk': healthchecks.check_disk(),
         'Backend API test': healthchecks.check_backend_api(),
     }
-    return jsonify(response)
+    ok = all(item['status'] for _key, item in response.iteritems())
+    result = jsonify(response)
+    result.status_code = 200 if ok else 503
+    return result

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,13 +19,13 @@ markdown2==2.3.0
 python-dateutil==2.2
 pytz==2014.9
 raven==4.2.3
-requests==2.6.0
+requests==2.19.1
 statsd==3.0.1
 wsgiref==0.1.2
 Babel==1.3
 beautifulsoup4==4.3.2
 xlrd==0.9.3
-urllib3==1.10.4
+urllib3==1.23
 pyopenssl==16.2.0
 ndg-httpsclient==0.4.0
 pyasn1==0.1.7


### PR DESCRIPTION
## What does this pull request do?

Extends the healthcheck endpoint with a disk size check.

It reports on the available and total disk space in megabytes and percent. It will **fail** the check when the available disk space gets at or under 2.0%.

💚 Test coverage has been added for `/healthcheck.json` and the two checks.

## Any other changes that would benefit highlighting?

The response code of `/healthcheck.json` now changes to `503 Service Unavailable` if any of the checks return falsey (`False` or `None`).

`requests` and `urllib3` have been upgraded to their latest versions. I wanted to update `requests` only but `urllib3` is required both by that and our application so they had to be upgraded together.