### PR TITLE
Allow branches with slashes to build Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,18 +19,25 @@ jobs:
           name: Build Docker image
           command: |
             docker build --tag $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 .
-            docker tag $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_BRANCH.$(git rev-parse --short=7 $CIRCLE_SHA1)
-            docker tag $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_BRANCH.latest
       - run:
           name: Validate Python version
           command: |
             docker run --rm --tty --interactive $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 python --version | grep "2.7"
       - run:
-          name: Push Docker image
+          name: Tag and push Docker images
           command: |
-            docker push $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1
-            docker push $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_BRANCH.$(git rev-parse --short=7 $CIRCLE_SHA1)
-            docker push $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_BRANCH.latest
+            export built_tag="$DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1"
+            docker push $built_tag
+
+            export safe_git_branch=${CIRCLE_BRANCH//\//-}
+            export branch_shortsha_tag="$DOCKER_REGISTRY/$DOCKER_IMAGE:$safe_git_branch.$(git rev-parse --short=7 $CIRCLE_SHA1)"
+            export branch_latest_tag="$DOCKER_REGISTRY/$DOCKER_IMAGE:$safe_git_branch.latest"
+
+            for tag in "$branch_shortsha_tag" "$branch_latest_tag"; do
+              echo "Tagging and pushing $tag..."
+              docker tag $built_tag $tag
+              docker push $tag
+            done
 
   test:
     docker:


### PR DESCRIPTION
## What does this pull request do?

Replaces `/` characters with `-` characters in Docker tag names.

Currently, builds on branches that have slashes (`/`) in them will always fail the Docker build as we try to incorporate the branch names into the tags.

However, Docker specifies in https://docs.docker.com/engine/reference/commandline/tag/#usage:

> A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.

Out of these constraints, this changeset only replaces slashes with dashes.

Our current example of such branch names come from dependabot, which typically creates names like `dependabot/pip/raven-6.9.0`.

## Any other changes that would benefit highlighting?

Related to https://github.com/ministryofjustice/laa-legal-adviser-api/pull/57.