### PR TITLE
Bump markdown2 dependency

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ git+git://github.com/ministryofjustice/cla_common.git@0.2.4#egg=cla_common==0.2.
 itsdangerous==0.24
 jinja-moj-template==0.19.0
 logstash_formatter==0.5.9
-markdown2==2.3.0
+markdown2==2.3.5
 python-dateutil==2.2
 pytz==2014.9
 raven==4.2.3


### PR DESCRIPTION
## What does this pull request do?

Bumps `markdown2` dependency.

~~This fixes [CVE-2018-5773](https://nvd.nist.gov/vuln/detail/CVE-2018-5773).~~