### PR TITLE
LGA-87: Schedule same day calls after 2+ hours during summer time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,10 @@ jobs:
             docker build --tag $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 .
       - run:
           name: Validate Python version
-          command: |
-            docker run --rm --tty --interactive $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 python --version | grep "2.7"
+          command: docker run --rm --tty --interactive $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 python --version | grep "2.7"
+      - run:
+          name: Validate that image runs on Europe/London timezone
+          command: docker run --rm --tty --interactive $DOCKER_REGISTRY/$DOCKER_IMAGE:$CIRCLE_SHA1 stat --format=%N /etc/localtime | grep "Europe/London"
       - run:
           name: Tag and push Docker images
           command: |

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,71 @@
-.git
-node_modules
+Dockerfile
+.git/
+
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+*.log
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Complexity
+output/*.html
+output/*/index.html
+
+# Sphinx
+docs/_build
+
+.webassets-cache
+
+# Virtualenvs
+env
+env*
+venv
+
+# intellij
+.idea/
+*.ipr
+*.iml
+*.iws
+
+.DS_Store
+
+# node
+node_modules/
+
+.sass-cache/
+
+cla_public/config/local.py
+cla_public/static-src/vendor/**
+cla_public/static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN DEBIAN_FRONTEND='noninteractive' apt-get update && \
   nodejs npm tzdata
 
 # Set timezone
-RUN echo "Europe/London" > /etc/timezone  &&  dpkg-reconfigure -f noninteractive tzdata
+RUN ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime
 
 # Install Nginx.
 RUN DEBIAN_FRONTEND='noninteractive' add-apt-repository ppa:nginx/stable && apt-get update


### PR DESCRIPTION
## What does this pull request do?

Fixes scheduling same day calls during summer time (more details in the example below).

Our `cla_public` containers need to run on `Europe/London` timezone due to the code involved around scheduling calls is timezone agnostic.

Rewriting the code involved to be timezone-aware is a massive undertaking due to arching into other shared dependencies.

Given these considerations and our nature of deployment being in UK only, the prudent thing seems to be to ensure the timezone of our deployments to be set to London.

### Example

10:43 in London time is 9:43 in UTC (the current setting), which means callbacks for the same day would be available from 12:00 (9:43 + 2 hours), instead of the expected 13:00.

## Any other changes that would benefit highlighting?

✨ A test has been added to the Docker build on CI to validate that the resulting images are correctly running on `Europe/London` timezone to avoid accidental breaks in the future.

🐳 `.dockerignore` has been extended with `.gitignore`'s contents to reduce the build context locally.

## Other, relevant context

We confirmed that the intention for `cla_public` containers was always to run on `Europe/London` timezone but this was broken when the base image was upgraded from `phusion/baseimage:0.9.11` to `phusion/baseimage:0.9.22` (which upgraded Ubuntu, breaking the previous timezone settings).

The change was made during December 2017 so the effects were undetected until daylight savings started in 2018.