### PR TITLE
Check dependency integrity after installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
           command: |
             source env/bin/activate
             pip install --requirement requirements.txt --requirement requirements/test.txt
+            pip check
       - save_cache:
           key: pip-v2-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/test.txt" }}
           paths:


### PR DESCRIPTION
## What does this pull request do?

In the https://circleci.com/gh/ministryofjustice/cla_public/427 build, our tests failed with the message

```
ImportError: No module named ext.script
Exited with code 1
```

After investigating the cause, we saw that the installation of dependencies were unsuccessful, but the job step was still green, meaning `pip install` still exited with a 0 status.

This change will force the installation to exit with a non-zero status if broken dependencies are detected:

```
cla_public$ pip check
flask 1.0 has requirement Jinja2>=2.10, but you have jinja2 2.7.3.
flask 1.0 has requirement Werkzeug>=0.14, but you have werkzeug 0.9.6.

cla_public$ echo $?
1
```