### PR TITLE
Check time in a system agnostic way

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           command: docker run --rm --tty --interactive application:$CIRCLE_SHA1 python --version | grep "2.7"
       - run:
           name: Validate that image runs on Europe/London timezone
-          command: docker run --rm --tty --interactive application:$CIRCLE_SHA1 stat --format=%N /etc/localtime | grep "Europe/London"
+          command: docker run --rm --tty --interactive application:$CIRCLE_SHA1 date '+%Z' | egrep "(GMT|BST)"
       - run:
           name: Tag and push Docker images
           command: |


### PR DESCRIPTION
## What does this pull request do?

Changes how timezones are checked to be more robust.

It is not guaranteed that the `/etc/localtime` file will stay symlinked. We could also copy the original timezone file and the behaviour would still be the same, but the test would fail.

This changeset proposes an alternative test for this behaviour, based on the default format of the `date` command:
```
Fri Feb  2 12:32:42 GMT 2018   # During winter
Tue Aug 28 14:02:43 BST 2018   # During summer
```

Since the command displays the abbreviated name of the timezone, we can match on those abbreviations.

Notes:
- `GMT` stands for Greenwich Mean Time
- `BST` stands for British Summer Time