### PR TITLE
Add staging-deploy to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
               tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.$short_sha"
             fi
             tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch"
+            tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"
             tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.latest"
 
   test:
@@ -107,12 +108,14 @@ jobs:
       - deploy:
           name: Deploy laa-cla-public docker image
           command: |
-            kubectl set image -f kubernetes_deploy/staging/deployment.yml \
-              app=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} \
-              --local -o yaml | kubectl apply -f -
-            kubectl apply \
-                -f kubernetes_deploy/staging/service.yml \
-                -f kubernetes_deploy/staging/ingress.yml
+            short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
+
+            kubectl set image --filename=kubernetes_deploy/staging/deployment.yml --local --output=yaml \
+              app=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:$short_sha | \
+              kubectl apply \
+                --filename=- \
+                --filename=kubernetes_deploy/staging/service.yml \
+                --filename=kubernetes_deploy/staging/ingress.yml
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,29 @@ jobs:
             source env/bin/activate
             python manage.py test
 
+  staging_deploy:
+    docker:
+      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+        environment:
+          GITHUB_TEAM_NAME_SLUG: laa-get-access
+          APPLICATION_DEPLOY_NAME: laa-cla-public
+    steps:
+      - checkout
+      - run:
+          name: Kubectl deployment
+          command: |
+            setup-kube-auth
+            kubectl config use-context staging
+      - deploy:
+          name: Deploy laa-cla-public docker image
+          command: |
+            kubectl set image -f kubernetes_deploy/staging/deployment.yml \
+              app=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} \
+              --local -o yaml | kubectl apply -f -
+            kubectl apply \
+                -f kubernetes_deploy/staging/service.yml \
+                -f kubernetes_deploy/staging/ingress.yml
+
 workflows:
   version: 2
   build_and_test:
@@ -99,3 +122,10 @@ workflows:
       - build:
           requires:
             - test
+      - staging_deploy_approval:
+          type: approval
+          requires:
+            - build
+      - staging_deploy:
+          requires:
+            - staging_deploy_approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
             kubectl set image --filename=kubernetes_deploy/staging/deployment.yml --local --output=yaml \
               app=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${APPLICATION_DEPLOY_NAME}:$safe_git_branch.$short_sha | \
               kubectl apply \
-                --filename=- \
+                --filename=/dev/stdin \
                 --filename=kubernetes_deploy/staging/service.yml \
                 --filename=kubernetes_deploy/staging/ingress.yml
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,10 +108,11 @@ jobs:
       - deploy:
           name: Deploy laa-cla-public docker image
           command: |
+            safe_git_branch=${CIRCLE_BRANCH//\//-}
             short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
 
             kubectl set image --filename=kubernetes_deploy/staging/deployment.yml --local --output=yaml \
-              app=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:$short_sha | \
+              app=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${APPLICATION_DEPLOY_NAME}:$safe_git_branch.$short_sha | \
               kubectl apply \
                 --filename=- \
                 --filename=kubernetes_deploy/staging/service.yml \

--- a/README.md
+++ b/README.md
@@ -88,14 +88,15 @@ where the `context` directory is set to the root of the cla_public directory.
 ### Releasing to non-production
 
 1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/cla_public) for the feature branch.
-1. Copy the `feature_branch.<sha>` reference from the `build` job's "Push Docker image" step. Eg:
+1. Approve the pending staging deployment on CircleCI.
+    [Watch the how-to video:](https://www.youtube.com/watch?v=9JovuQK-XnA)<br/>
+    [![How to approve staging deployments](https://img.youtube.com/vi/9JovuQK-XnA/1.jpg)](https://www.youtube.com/watch?v=9JovuQK-XnA)
+1. :rotating_light: Unfortunately, our deployment process does not _yet_ fail the build if the deployment fails.
+    To see if the deploy was successful, follow Kubernetes deployments, pods and events for any feedback:
     ```
-    Pushing tag for rev [24519b4325d0] on {https://registry.service.dsd.io/v1/repositories/cla_public/tags/switch-default-branch-to-master.b8f57d9}
+    kubectl --namespace laa-cla-public-staging get pods,deployments -o wide
+    kubectl --namespace laa-cla-public-staging get events
     ```
-1. [Deploy `feature_branch.<sha>`](https://ci.service.dsd.io/job/DEPLOY-cla_public/build?delay=0sec).
-    * `ENVIRONMENT` is the target environment, select depending on your needs, eg. "demo", "staging", etc.
-    * `CONTAINER_BRANCH` is the branch that needs to be released (`switch-default-branch-to-master` in the above example).
-    * `VERSION` is either `latest` for the last successful build on that branch, or a specific 7-character prefix of the Git SHA (`b8f57d9` in the above example).
 
 ### Releasing to production
 
@@ -107,6 +108,9 @@ where the `context` directory is set to the root of the cla_public directory.
     Pushing tag for rev [d64474359f5d] on {https://registry.service.dsd.io/v1/repositories/cla_public/tags/master.54c165b}
     ```
 1. [Deploy `master.<sha>` to **prod**uction](https://ci.service.dsd.io/job/DEPLOY-cla_public/build?delay=0sec).
+    * `ENVIRONMENT` is the target environment, select depending on your needs. Select `prod` for production.
+    * `CONTAINER_BRANCH` is the branch that needs to be released (`master` in the above example).
+    * `VERSION` is the specific 7-character prefix of the Git SHA (`54c165b` in the above example).
 
 :tada: :shipit:
 

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -11,6 +11,12 @@ spec:
       containers:
       - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:master
         name: app
+        readinessProbe:
+          httpGet:
+            path: /ping.json
+            port: 80
+          initialDelaySeconds: 3
+          periodSeconds: 3
         ports:
         - containerPort: 80
           name: http


### PR DESCRIPTION
## What does this pull request do?

Adds staging-deploy to CircleCI behind a manual approval step.

This has been mostly copied from the [laa-fee-calculator](https://github.com/ministryofjustice/laa-fee-calculator) project.

📝 We are using `kubectl` commands to deploy into staging environment before `helm` because it's quicker to implement. The intention is to use Helm in the future.

Pairing with: @sldblog

## Implementation notes

To make `kubectl config use-context staging` work, we had to create a `circleci` `ServiceAccount` in https://github.com/ministryofjustice/cloud-platform-environments/pull/140 and create the following environment variables in CircleCI:

- `KUBE_ENV_STAGING_CACERT`
- `KUBE_ENV_STAGING_NAME`
- `KUBE_ENV_STAGING_NAMESPACE`
- `KUBE_ENV_STAGING_TOKEN`

This is documented in [cloud-platform-user-docs](https://github.com/ministryofjustice/cloud-platform-user-docs/blob/648a435250eb11bb07b64b280249ca05db156943/02-deploying-an-app/004-use-circleci-to-upgrade-app.md#add-variables-to-circleci).

Using the `setup-kube-auth` script bundled in the `cloud-platforms/tools:circleci` image sets up the "staging" context based on these environment variables:

<img width="499" alt="screen shot 2018-09-13 at 12 48 23" src="https://user-images.githubusercontent.com/1526295/45486520-53bf1380-b753-11e8-822b-2dcb27b25e89.png">
