### PR TITLE
Deploy Docker image digest instead of Docker tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
               tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.$short_sha"
             fi
             tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch"
+            tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"
             tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.latest"
 
   test:
@@ -103,12 +104,14 @@ jobs:
       - deploy:
           name: Deploy laa-cla-public docker image
           command: |
-            kubectl set image -f kubernetes_deploy/staging/deployment.yml \
-              app=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} \
-              --local -o yaml | kubectl apply -f -
-            kubectl apply \
-                -f kubernetes_deploy/staging/service.yml \
-                -f kubernetes_deploy/staging/ingress.yml
+            short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
+
+            kubectl set image --filename=kubernetes_deploy/staging/deployment.yml --local --output=yaml \
+              app=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:$short_sha | \
+              kubectl apply \
+                --filename=- \
+                --filename=kubernetes_deploy/staging/service.yml \
+                --filename=kubernetes_deploy/staging/ingress.yml
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,10 +104,11 @@ jobs:
       - deploy:
           name: Deploy laa-cla-public docker image
           command: |
+            safe_git_branch=${CIRCLE_BRANCH//\//-}
             short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
 
             kubectl set image --filename=kubernetes_deploy/staging/deployment.yml --local --output=yaml \
-              app=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:$short_sha | \
+              app=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${APPLICATION_DEPLOY_NAME}:$safe_git_branch.$short_sha | \
               kubectl apply \
                 --filename=- \
                 --filename=kubernetes_deploy/staging/service.yml \


### PR DESCRIPTION
## What does this pull request do?

Changes the deployment so we deploy `branch_name.7_char_git_sha`.

Our current operational model is:

- Build, tag and push Docker images in the `build` CI job
- Deploy the `repo:$CIRCLE_SHA1` Docker image to Kubernetes

Ultimately, it would be nice if we could avoid pushing the `$CIRCLE_SHA1` Docker tags to the repository for feature branches. This is because these references are superseded by the `master` build once the feature branch is merged.

Because they are superseded, we do not have to keep them around after the merge happens. Since our "Maximum number of images per repository" is 1000, we want to delete old, unnecessary tags.

We cannot _easily_ delete tags that are git SHA references, as we have no easy way to match and delete them.

In contrast, it's easy to set up a lifecycle policy for any branch that is not `master`.

... But.

Kubernetes with `kubectl` will detect that a deployment is unchanged if we use branch names. (Yeah, `master` is already deployed, duh.)

So we need a mechanism to identify each "changed" image without leaving unqualified git SHA references.

We could think of these options:

- Tag `branch.short_git_sha` for all builds.
- Use Docker's SHA256 digest on images, as Docker images can be pulled by their digests. This is mentioned in [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/overview/#container-images).

This changeset tries the first one as it's easier to understand and identify what is deployed.