### PR TITLE
Revert "Remove redundant install of pip, wheel, setuptools"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ RUN add-apt-repository ppa:nginx/stable && \
     rm -f /etc/nginx/sites-enabled/default && \
     mkdir -p /var/log/nginx/cla_public
 
+# Install global Python packages
+RUN pip install -U setuptools pip wheel
+
 # Install uwsgi
 RUN pip install GitPython uwsgi && \
     mkdir -p /var/log/wsgi && \


### PR DESCRIPTION
## What does this pull request do?

This reverts commit 5cce3b76ad105c6bf1b9acd186e979bcba5da5a3, as it broke the service:

```
  File "/usr/local/lib/python2.7/dist-packages/extended_choices/__init__.py", line 6, in <module>
    from setuptools.config import read_configuration
ImportError: No module named config
```

The version installed by `apt-get` is too low and I seem to have misinterpreted the installation messages. I thought they meant nothing happens but in reality all of those packages were upgraded.