### PR TITLE
Consolidate configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can run the server with:
 
     CLA_PUBLIC_CONFIG=config/testing.py ./manage.py runserver
 
-With the `testing` configuration, you can use `CLA_BACKEND_PORT` and `LAALAA_PORT`
+With the `testing` configuration, you can use `BACKEND_BASE_URI` and `LAALAA_API_HOST`
 environment variables to configure the dependent service API ports.
 
 

--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -66,7 +66,7 @@ APP_SETTINGS = {
 API_CLIENT_TIMEOUT = 10
 
 BACKEND_API = {
-    'url': 'http://localhost:8000/checker/api/v1/'
+    'url': '{url}/checker/api/v1/'.format(url=BACKEND_BASE_URI)
 }
 
 SENTRY_DSN = os.environ.get('RAVEN_CONFIG_DSN', '')
@@ -112,10 +112,7 @@ OPERATOR_HOURS = {
 
 TIMEZONE = 'Europe/London'
 
-LAALAA_API_HOST = os.environ.get(
-    'LAALAA_API_HOST',
-    'https://prod.laalaa.dsd.io')
-
+LAALAA_API_HOST = os.environ.get('LAALAA_API_HOST', 'https://prod.laalaa.dsd.io')
 
 MAIL_SERVER = os.environ.get('SMTP_HOST')
 MAIL_PORT = os.environ.get('SMTP_PORT', 465)

--- a/cla_public/config/docker.py
+++ b/cla_public/config/docker.py
@@ -5,14 +5,14 @@ DEBUG = os.environ.get('SET_DEBUG', False) == 'True'
 
 SECRET_KEY = os.environ['SECRET_KEY']
 
-# TODO - change this to True when serving over HTTPS
 SESSION_COOKIE_SECURE = os.environ.get('CLA_ENV', '') in ['prod', 'staging']
 
 HOST_NAME = os.environ.get('HOST_NAME') or os.environ.get('HOSTNAME')
 
-BACKEND_API = {
-    'url': os.environ['BACKEND_BASE_URI'] + '/checker/api/v1/'
-}
+BACKEND_BASE_URI = os.environ['BACKEND_BASE_URI']
+
+LAALAA_API_HOST = os.environ.get(
+    'LAALAA_API_HOST', 'https://prod.laalaa.dsd.io')
 
 if DEBUG:
     LOGGING['handlers']['debug_file'] = {

--- a/cla_public/config/docker.py
+++ b/cla_public/config/docker.py
@@ -14,6 +14,7 @@ BACKEND_BASE_URI = os.environ['BACKEND_BASE_URI']
 LAALAA_API_HOST = os.environ.get(
     'LAALAA_API_HOST', 'https://prod.laalaa.dsd.io')
 
+LOGGING['handlers']['console']['formatter'] = 'logstash'
 LOGGING['loggers'] = {
     '': {
         'handlers': ['console'],

--- a/cla_public/config/docker.py
+++ b/cla_public/config/docker.py
@@ -14,32 +14,9 @@ BACKEND_BASE_URI = os.environ['BACKEND_BASE_URI']
 LAALAA_API_HOST = os.environ.get(
     'LAALAA_API_HOST', 'https://prod.laalaa.dsd.io')
 
-if DEBUG:
-    LOGGING['handlers']['debug_file'] = {
-        'level': 'DEBUG',
-        'class': 'logging.handlers.RotatingFileHandler',
-        'filename': '/var/log/wsgi/debug.log',
-        'maxBytes': 1024 * 1024 * 5,  # 5MB
-        'backupCount': 7,
-        'formatter': 'verbose'}
-    LOGGING['loggers'] = {
-        '': {
-            'handlers': ['debug_file'],
-            'level': 'DEBUG'
-        }
+LOGGING['loggers'] = {
+    '': {
+        'handlers': ['console'],
+        'level': os.environ.get('LOG_LEVEL', 'INFO')
     }
-
-else:
-    LOGGING['handlers']['production_file'] = {
-        'level': 'INFO',
-        'class': 'logging.handlers.RotatingFileHandler',
-        'filename': '/var/log/wsgi/app.log',
-        'maxBytes': 1024 * 1024 * 5,  # 5MB
-        'backupCount': 7,
-        'formatter': 'logstash'}
-    LOGGING['loggers'] = {
-        '': {
-            'handlers': ['production_file'],
-            'level': 'DEBUG'
-        }
-    }
+}

--- a/cla_public/config/testing.py
+++ b/cla_public/config/testing.py
@@ -11,9 +11,4 @@ LOGGING['loggers']['']['level'] = 'WARNING'
 
 WTF_CSRF_ENABLED = False
 
-BACKEND_API = {
-    'url': 'http://localhost:{port}/checker/api/v1/'.format(
-        port=os.environ.get('CLA_BACKEND_PORT', 8000))
-}
-
-LAALAA_API_HOST = 'http://localhost:{port}'.format(port=os.environ.get('LAALAA_PORT', 8001))
+LAALAA_API_HOST = os.environ.get('LAALAA_API_HOST', 'http://localhost:8001')

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -27,6 +27,8 @@ spec:
           value: https://staging-backend.cla.dsd.io/
         - name: LAALAA_API_HOST
           value: https://staging.laalaa.dsd.io
+        - name: LOG_LEVEL
+          value: INFO
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -21,10 +21,12 @@ spec:
         - containerPort: 80
           name: http
         env:
-        - name: ENV
+        - name: CLA_ENV
           value: staging
         - name: BACKEND_BASE_URI
           value: https://staging-backend.cla.dsd.io/
+        - name: LAALAA_API_HOST
+          value: https://staging.laalaa.dsd.io
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## What does this pull request do?

- Consolidates how [laalaa](https://github.com/ministryofjustice/laa-legal-adviser-api/) and [backend](https://github.com/ministryofjustice/cla_backend) are configured.
- Changes Flask logging inside Docker containers to use the default "console" output.
- Amends the Kubernetes staging deployment to reflect the new configurations.

## Any other changes that would benefit highlighting?

Currently, configuring the `cla_backend` and `laa-legal-adviser-api` URLs is not straightforward.

The backend can be configured through `BACKEND_API` or `BACKEND_BASE_URI` or `CLA_BACKEND_PORT`, depending on the environment.

The legal adviser API can be configured through `LAALAA_API_HOST` or `LAALAA_PORT`, depending on the environment.

This changeset consolidates so that all environments can be configured via:

- `BACKEND_BASE_URI` environment variable for the `cla_backend` base URL, including scheme and port.
- `LAALAA_API_HOST` environment variable for the `laa-legal-adviser-api` base URL, including scheme and port.

The default values on the test environment are always on `localhost`.