### PR TITLE
LGA-192 Add redirect to gov.uk start page

### DIFF
--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -26,8 +26,7 @@ log = logging.getLogger(__name__)
 @base.route('/')
 def index():
     session.clear()
-    return render_template('index.html')
-
+    return redirect(current_app.config.get('GOV_UK_START_PAGE'))
 
 @base.route('/cookies')
 def cookies():

--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -11,6 +11,8 @@ TESTING = False
 
 CLEAR_SESSION = True
 
+GOV_UK_START_PAGE = 'https://www.gov.uk/check-legal-aid'
+
 BACKEND_BASE_URI = os.environ.get('BACKEND_BASE_URI', 'http://127.0.0.1:8000')  # For healthcheck.json requests
 
 # Disable eligibility check and allow users to request a callback only


### PR DESCRIPTION
## What does this pull request do?

This pull request redirects the route `/` to https://www.gov.uk/check-legal-aid, the GOV.UK start page for Civil Legal Advice.

It is not possible to change the link in the header directly because it is buried inside `base.jinja` template, which lives inside the `jinja-moj-template` package.

## Any other changes that would benefit highlighting?

None.
