### PR TITLE
Notify Slack channel on deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,26 +40,7 @@ jobs:
           command: docker run --rm --tty --interactive application:$CIRCLE_SHA1 date '+%Z' | egrep "(GMT|BST)"
       - run:
           name: Tag and push Docker images
-          command: |
-            built_tag="application:$CIRCLE_SHA1"
-            safe_git_branch=${CIRCLE_BRANCH//\//-}
-            short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
-
-            function tag_and_push() {
-              tag="$1"
-              echo "Tagging and pushing $tag..."
-              docker tag $built_tag $tag
-              docker push $tag
-            }
-
-            if [ "$CIRCLE_BRANCH" == "master" ]; then
-              tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$CIRCLE_SHA1"
-              tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$CIRCLE_SHA1"
-              tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.$short_sha"
-            fi
-            tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch"
-            tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"
-            tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.latest"
+          command: .circleci/tag_and_push_docker_image application:$CIRCLE_SHA1
 
   test:
     docker:
@@ -96,42 +77,23 @@ jobs:
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
         environment:
+          ECR_DOCKER_REGISTRY: "926803513772.dkr.ecr.eu-west-1.amazonaws.com"
+          ECR_DOCKER_IMAGE: "laa-get-access/laa-cla-public"
           GITHUB_TEAM_NAME_SLUG: laa-get-access
           APPLICATION_DEPLOY_NAME: laa-cla-public
     steps:
       - checkout
       - run:
-          name: Kubectl deployment
+          name: Initialise Kubernetes staging context
           command: |
             setup-kube-auth
             kubectl config use-context staging
       - deploy:
-          name: Deploy laa-cla-public docker image
-          command: |
-            safe_git_branch=${CIRCLE_BRANCH//\//-}
-            short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
-
-            kubectl set image --filename=kubernetes_deploy/staging/deployment.yml --local --output=yaml \
-              app=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${APPLICATION_DEPLOY_NAME}:$safe_git_branch.$short_sha | \
-              kubectl apply \
-                --filename=/dev/stdin \
-                --filename=kubernetes_deploy/staging/service.yml \
-                --filename=kubernetes_deploy/staging/ingress.yml
+          name: Deploy laa-cla-public to staging
+          command: .circleci/deploy_to_staging
       - run:
           name: Notify Slack channel
-          command: |
-            cat <<-END > payload.json
-            {
-              "text": ":tada: Deployed \`${GITHUB_TEAM_NAME_SLUG}/${APPLICATION_DEPLOY_NAME}:$safe_git_branch.$short_sha\` to *staging*.",
-              "attachments": [
-                {
-                  "fallback": "<$CIRCLE_BUILD_URL|View build>",
-                  "actions": [{"type": "button", "text": "View build", "url": "$CIRCLE_BUILD_URL"}]
-                }
-              ]
-            }
-            END
-            curl --request POST --data @payload.json --header "Content-Type: application/json" $SLACK_WEBHOOK_URL
+          command: .circleci/notify_slack_channel staging
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,21 @@ jobs:
                 --filename=/dev/stdin \
                 --filename=kubernetes_deploy/staging/service.yml \
                 --filename=kubernetes_deploy/staging/ingress.yml
+      - run:
+          name: Notify Slack channel
+          command: |
+            cat <<-END > payload.json
+            {
+              "text": ":tada: Deployed \`${GITHUB_TEAM_NAME_SLUG}/${APPLICATION_DEPLOY_NAME}:$safe_git_branch.$short_sha\` to *staging*.",
+              "attachments": [
+                {
+                  "fallback": "<$CIRCLE_BUILD_URL|View build>",
+                  "actions": [{"type": "button", "text": "View build", "url": "$CIRCLE_BUILD_URL"}]
+                }
+              ]
+            }
+            END
+            curl --request POST --data @payload.json --header "Content-Type: application/json" $SLACK_WEBHOOK_URL
 
 workflows:
   version: 2

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+safe_git_branch=${CIRCLE_BRANCH//\//-}
+short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
+ECR_DEPLOY_IMAGE="$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -1,4 +1,5 @@
 #!/bin/sh -e
 safe_git_branch=${CIRCLE_BRANCH//\//-}
 short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
-ECR_DEPLOY_IMAGE="$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"
+deploy_image_and_tag="$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"
+ECR_DEPLOY_IMAGE="$ECR_DOCKER_REGISTRY/$deploy_image_and_tag"

--- a/.circleci/deploy_to_staging
+++ b/.circleci/deploy_to_staging
@@ -3,6 +3,8 @@
 root=$(dirname "$0")
 source $root/define_build_environment_variables
 
+echo "Deploying $ECR_DEPLOY_IMAGE to staging..."
+
 kubectl set image --filename=$root/../kubernetes_deploy/staging/deployment.yml --local --output=yaml \
   app=$ECR_DEPLOY_IMAGE | \
   kubectl apply \

--- a/.circleci/deploy_to_staging
+++ b/.circleci/deploy_to_staging
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+
+root=$(dirname "$0")
+source $root/define_build_environment_variables
+
+kubectl set image --filename=$root/../kubernetes_deploy/staging/deployment.yml --local --output=yaml \
+  app=$ECR_DEPLOY_IMAGE | \
+  kubectl apply \
+    --filename=/dev/stdin \
+    --filename=$root/../kubernetes_deploy/staging/service.yml \
+    --filename=$root/../kubernetes_deploy/staging/ingress.yml

--- a/.circleci/notify_slack_channel
+++ b/.circleci/notify_slack_channel
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+
+source $(dirname "$0")/define_build_environment_variables
+environment="$1"
+
+cat <<END > payload.json
+{
+  "text": ":tada: Deployed \`$ECR_DEPLOY_IMAGE\` to *$environment*.",
+  "attachments": [
+    {
+      "fallback": "<$CIRCLE_BUILD_URL|View build>",
+      "actions": [{"type": "button", "text": "View build", "url": "$CIRCLE_BUILD_URL"}]
+    }
+  ]
+}
+END
+
+curl --request POST --data @payload.json --header "Content-Type: application/json" $SLACK_WEBHOOK_URL

--- a/.circleci/notify_slack_channel
+++ b/.circleci/notify_slack_channel
@@ -5,7 +5,7 @@ environment="$1"
 
 cat <<END > payload.json
 {
-  "text": ":tada: Deployed \`$ECR_DEPLOY_IMAGE\` to *$environment*.",
+  "text": ":tada: Deployed \`$deploy_image_and_tag\` to *$environment*.",
   "attachments": [
     {
       "fallback": "<$CIRCLE_BUILD_URL|View build>",

--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -1,0 +1,21 @@
+#!/bin/sh -e
+
+source $(dirname "$0")/define_build_environment_variables
+built_tag="$1"
+
+function tag_and_push() {
+  tag="$1"
+  echo
+  echo "Tagging and pushing $tag..."
+  docker tag $built_tag $tag
+  docker push $tag
+}
+
+if [ "$CIRCLE_BRANCH" == "master" ]; then
+  tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$CIRCLE_SHA1"
+  tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$CIRCLE_SHA1"
+  tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.$short_sha"
+fi
+tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch"
+tag_and_push "$ECR_DEPLOY_IMAGE"
+tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.latest"


### PR DESCRIPTION
## What does this pull request do?

Adds a notification to our Slack channel about deployments. For now, only _staging_ deploys are supported.

<img width="660" alt="screen shot 2018-09-18 at 11 11 19" src="https://user-images.githubusercontent.com/1526295/45680751-a32a8880-bb33-11e8-81ed-ac10784935a5.png">

## Any other changes that would benefit highlighting?

#### Moved all lengthy CI scripts to separate files in the `.circleci` folder

Docker builds and deployments share a lot of environment variables. One way would be to redefine all the variables. Another would be to reuse the definitions.

We took the approach of reusing the definitions from a shared shell script which is `source`d into all CI scripts.

#### Extend CI scripts with explicit messages

Moving the scripts to files has a side-effect of the deployment script showing only this output:

```
$ #!/bin/bash -eo pipefail
  .circleci/deploy_to_staging

deployment.extensions "laa-cla-public" configured
service "laa-cla-public" unchanged
ingress.extensions "laa-cla-public" unchanged
```

This information is not useful enough to see _what_ was deployed. We extended the deploy script with an explicit message about what is being deployed.