### PR TITLE
LGA-284 Configure Kubernetes to use HTTP liveness-probe

### DIFF
--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -15,8 +15,16 @@ spec:
           httpGet:
             path: /ping.json
             port: 80
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /ping.json
+            port: 80
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+          periodSeconds: 10
         ports:
         - containerPort: 80
           name: http

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -8,6 +8,7 @@ spec:
       labels:
         app: laa-cla-public-app
     spec:
+      replicas: 3
       containers:
       - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:master
         name: app

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -3,12 +3,12 @@ kind: Deployment
 metadata:
   name: laa-cla-public
 spec:
+  replicas: 3
   template:
     metadata:
       labels:
         app: laa-cla-public-app
     spec:
-      replicas: 3
       containers:
       - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:master
         name: app

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -15,8 +15,16 @@ spec:
           httpGet:
             path: /ping.json
             port: 80
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /ping.json
+            port: 80
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+          periodSeconds: 10
         ports:
         - containerPort: 80
           name: http

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -3,12 +3,12 @@ kind: Deployment
 metadata:
   name: laa-cla-public
 spec:
+  replicas: 2
   template:
     metadata:
       labels:
         app: laa-cla-public-app
     spec:
-      replicas: 2
       containers:
       - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:master
         name: app

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -8,6 +8,7 @@ spec:
       labels:
         app: laa-cla-public-app
     spec:
+      replicas: 2
       containers:
       - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:master
         name: app


### PR DESCRIPTION
## What does this pull request do?

This pull requests configures Kubernetes to use liveness-probe to determine the health of the application.

The liveness probe will return a success if the application end point `ping.json` responds with a 200. If it doesn't, Kubernetes will attempt to restart the container. 

I have also set replicas to 2 for `staging` and 3 for `production`. This is [Kerin's comment](https://mojdt.slack.com/archives/CACTAK5FG/p1538486123000100) on why 3 is a good number:

>Yep default is one - personally I’d recommend 3, so you can still tolerate a failure during a deployment
>That also matches the number of AZs in AWS Ireland, and your containers will get spread across them evenly

By having pod replicas, Kubernetes will not terminate a running pod until deployed containers are running and ready, as deemed by the readiness check. This results in no downtime between releases. This image shows the lifecycle of the pods:

<img width="573" alt="screen shot 2018-10-02 at 16 36 43" src="https://user-images.githubusercontent.com/89347/46360090-a1e47a00-c662-11e8-83f8-3d70881fe317.png">

## Any other changes that would benefit highlighting?

I have upped the seconds in which the readiness check first takes place so it safely takes longer than the time the app usually takes to start up. At the moment, the app takes a few seconds to start.

We can set `staging` replicas back to one. It's set to 2 at the moment to see it working before this pull request is merged with master.
