### PR TITLE
LGA-380 Custom working hours for 2018-12

### DIFF
--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -106,8 +106,8 @@ FORM_CONFIG_TRANSLATIONS = {l: config_path(l) for l, label in LANGUAGES}
 OPERATOR_HOURS = {
     'weekday': (datetime.time(9, 0), datetime.time(20, 0)),
     'saturday': (datetime.time(9, 0), datetime.time(12, 30)),
-    '2014-12-24': (datetime.time(9, 0), datetime.time(18, 30)),
-    '2014-12-31': (datetime.time(9, 0), datetime.time(18, 30)),
+    '2018-12-24': (datetime.time(9, 0), datetime.time(17, 30)),
+    '2018-12-31': (datetime.time(9, 0), datetime.time(17, 30)),
 }
 
 TIMEZONE = 'Europe/London'


### PR DESCRIPTION
## What does this pull request do?

Set custom working hours to match Operator Service's reduced hours on Christmas Eve and New Year's Eve 2018.

## Any other changes that would benefit highlighting?

See accompanying changes in related repos:

- [cla_backend#488](
https://github.com/ministryofjustice/cla_backend/pull/488)
- [cla_common/call_centre_availability/__init__.py#L173](https://github.com/ministryofjustice/cla_common/blob/0.2.7/cla_common/call_centre_availability/__init__.py#L173)