### PR TITLE
Add flake8 and Black configs and requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.black]
+line-length = 119
+verbose = true
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.tx
+  | env
+  | scripts
+  | build
+)/
+'''

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,3 +1,3 @@
 -r jenkins.txt
 Flask-DebugToolbar==0.9.2
-
+flake8==3.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[flake8]
+max-line-length = 119
+max-complexity = 10
+ignore = E501
+exclude =
+    .git,
+    __pycache__,
+    build,
+    dist,
+    env,
+    node_modules


### PR DESCRIPTION
## What does this pull request do?

Introduce configs for flake8 and Black, in line with [other cla repos](https://github.com/ministryofjustice/cla_backend/pull/490)

## Any other changes that would benefit highlighting?

Intentionally left blank.
