### PR TITLE
Feature/reference k8s os places secret key

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -61,3 +61,18 @@ If you need to deploy manually because, for example, CircleCI is offline, follow
    ```
    ECR_DEPLOY_IMAGE=926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:awesometag .circleci/deploy_to_kubernetes staging
    ```
+
+
+## Secrets
+See the [Kubernetes Secrets documentation](https://kubernetes.io/docs/concepts/configuration/secret/)
+
+And keep the following in mind:
+
+Remember to namespace e.g. to list secrets
+
+```
+kubectl --namespace laa-cla-public-staging get secrets
+kubectl --namespace laa-cla-public-production get secrets
+```
+
+If adding a secret with a temp file, do *not* git commit the actual secret, whether base64 encoded or not!  

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -43,3 +43,8 @@ spec:
             secretKeyRef:
               name: clasecret
               key: flask_secret_key
+        - name: OS_PLACES_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: os-places
+              key: apiKey

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -43,3 +43,8 @@ spec:
             secretKeyRef:
               name: clasecret
               key: flask_secret_key
+        - name: OS_PLACES_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: os-places
+              key: apiKey


### PR DESCRIPTION
## What does this pull request do?

Set OS_PLACES_API_KEY env var from Kubernetes secret (created separately on local dev machine for both staging and production)

This is a counterpart piece to the [key provisioning work for older Template Deploy](https://github.com/ministryofjustice/cla_public-deploy/commit/beafb7cb2bd4676132883fda35fd49e9da739e16)

## Any other changes that would benefit highlighting?

Added brief documenting steps, with important note for less experienced devs.