### PR TITLE
Add environment, service area and team labels

### DIFF
--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -8,6 +8,9 @@ spec:
     metadata:
       labels:
         app: laa-cla-public-app
+        env: production
+        service_area: laa-get-access
+        service_team: cla-fala
     spec:
       containers:
       - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:master

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -8,6 +8,9 @@ spec:
     metadata:
       labels:
         app: laa-cla-public-app
+        env: staging
+        service_area: laa-get-access
+        service_team: cla-fala
     spec:
       containers:
       - image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:master


### PR DESCRIPTION
## What does this pull request do?

I have been introduced to the alertmanager.apps.cloud-platform-live-0.k8s.integration.dsd.io service which lets us filter alerts by the labels in Kubernetes.

To make filtering easier, I added three new labels:

- `env` for labelling the environment without having to filter for the namespace
- `service_area` for searching for all applications without our service area
- `service_team` to examine applications belonging to a single service team

## Any other changes that would benefit highlighting?

None.

## Related

Example query: https://alertmanager.apps.cloud-platform-live-0.k8s.integration.dsd.io/#/alerts?silenced=false&inhibited=false&filter=%7Bnamespace%3D%22laa-cla-public-staging%22%7D

It's also possible to filter for `app="laa-cla-public-app"` now. Following these changes, we will be able to filter for `service_team="cla-fala"` as well.