### PR TITLE
LGA-481: Match deployment process to documentation

### DIFF
--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -1,5 +1,6 @@
-#!/bin/sh -e
-safe_git_branch=${CIRCLE_BRANCH//\//-}
-short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
-deploy_image_and_tag="$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"
-ECR_DEPLOY_IMAGE="$ECR_DOCKER_REGISTRY/$deploy_image_and_tag"
+#!/bin/bash -eu
+short_sha="$(git rev-parse --short=7 "$CIRCLE_SHA1")"
+export short_sha
+export safe_git_branch=${CIRCLE_BRANCH//\//-}
+export deploy_image_and_tag="$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"
+export ECR_DEPLOY_IMAGE="$ECR_DOCKER_REGISTRY/$deploy_image_and_tag"

--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -16,7 +16,9 @@ if ! [ -d "$NAMESPACE_DIR" ] ; then
   exit 1
 fi
 
-source "$ROOT/define_build_environment_variables"
+if [ -z "$ECR_DEPLOY_IMAGE" ] ; then
+  source "$ROOT"/define_build_environment_variables
+fi
 
 echo "Deploying $ECR_DEPLOY_IMAGE to $NAMESPACE..."
 

--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -1,25 +1,28 @@
-#!/bin/sh -eu
+#!/bin/bash -e
 set -o pipefail
 
 ROOT=$(dirname "$0")
 NAMESPACE="$1"
 NAMESPACE_DIR="$ROOT/../kubernetes_deploy/$NAMESPACE"
 
-if ! [ $NAMESPACE ] ; then
-  echo "usage: deploy_to_kubernetes namespace\n"
+if [ -z "$NAMESPACE" ] ; then
+  printf "usage: deploy_to_kubernetes namespace\n"
   echo "namespace is a directory in ../kubernetes_deploy/ directory"
-  exit 1;
+  exit 1
 fi
 
-if ! [ -d $NAMESPACE_DIR ] ; then
+if ! [ -d "$NAMESPACE_DIR" ] ; then
   echo "$NAMESPACE_DIR not found"
-  exit 1;
+  exit 1
 fi
 
 source "$ROOT/define_build_environment_variables"
 
 echo "Deploying $ECR_DEPLOY_IMAGE to $NAMESPACE..."
 
+# shellcheck disable=SC2002 # Useless cat, https://www.shellcheck.net/wiki/SC2002
+# Using a separate cat command here helps in separating the pipe of
+# "altering" kubectl commands which all take something from stdin and write to stdout.
 cat "$NAMESPACE_DIR/deployment.yml" | \
   kubectl set image app="$ECR_DEPLOY_IMAGE" --filename=/dev/stdin --local --output=yaml | \
   kubectl annotate kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --filename=/dev/stdin --local --output=yaml | \

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -53,12 +53,13 @@ If you need to deploy manually because, for example, CircleCI is offline, follow
     ```
 1. Deploy changes to Kubernetes by applying changes to the `deployment.yml`. This example takes the `deployment.yml` as input, changes the value of `image` for the container named `app` to `926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:awesometag`, then pipes the updated yaml to the next command. The `kubectl apply` applies the yaml from stdin:
     ```
-    kubectl set image --filename="kubernetes_deploy/staging/deployment.yml" --local --output=yaml app="926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:awesometag" | kubectl apply --filename=/dev/stdin
+    kubectl set image --filename="kubernetes_deploy/staging/deployment.yml" --local --output=yaml app="926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:awesometag" | kubectl apply --namespace=laa-cla-public-staging --filename=/dev/stdin
     ```
    A similiar technique is used in [deploy_to_kubernetes](https://github.com/ministryofjustice/cla_public/blob/master/.circleci/deploy_to_kubernetes) script. Of course, you could simply update the `deployment.yml` file directly and apply the changes.
    
    To use [deploy_to_kubernetes](https://github.com/ministryofjustice/cla_public/blob/master/.circleci/deploy_to_kubernetes), requires an environment variable called `ECR_DEPLOY_IMAGE` and a positional argument for the namespace to deploy to, i.e. `staging` or `production`. Here's an example:
    ```
+   kubectl config set-context $(kubectl config current-context) --namespace=laa-cla-public-staging
    ECR_DEPLOY_IMAGE=926803513772.dkr.ecr.eu-west-1.amazonaws.com/laa-get-access/laa-cla-public:awesometag .circleci/deploy_to_kubernetes staging
    ```
 


### PR DESCRIPTION
## Where should the reviewer start?

Please read the below description then review commit-by-commit.

## What does this pull request do?

This pull request changes the deployment scripts to match the deployment instructions and adds further setup steps to make the deployment reproducible on local machines.

### Deployment instructions

The documentation related to deployment did not mention that Kubernetes namespaces have to be defined. On CircleCI, the namespace is set in the [`setup-kube-auth`](https://github.com/ministryofjustice/cloud-platform-tools-image/blob/006d7cf8ad332bc21c7aaa996595f8cd926ac1be/circleci/setup-kube-auth#L28-L31) script, but they do not work locally.

The deployment instructions now explicitly mention namespace setup.

### Deployment scripts

Despite the deployment guide's instructions, `.circleci/deploy_to_kubernetes` does not **only** require an `ECR_DEPLOY_IMAGE` environment variable but a range of other CircleCI specific variables too.

The main change in this pull request is to allow that script to operate with only the `ECR_DEPLOY_IMAGE` variable.

## Any other changes that would benefit highlighting?

All other changes in the scripts are [`shellcheck`](https://github.com/koalaman/shellcheck) changes. Please see commit messages for details fixes.