### PR TITLE
Add step to install gulp

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,6 +22,8 @@ Next, create the environment and start it up:
 
     pip install -r requirements/local.txt
 
+    npm install -g gulp
+
     npm install && bower install && gulp
 
 Create a ``local.py`` settings file from the example file:


### PR DESCRIPTION
## What does this pull request do?

The readme assumes you have gulp already installed - this command makes sure it's installed globally.

## Any other changes that would benefit highlighting?

I also needed to install bower, but I've left this out of the readme as it's going to be removed soon.