### PR TITLE
LGA-350: Add warning message about split deployments

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -15,6 +15,10 @@
 
 ## Releasing to production
 
+:warning: This project is currently deployed to _both_ template-deploy and Kubernetes.
+
+:rotating_light: To ensure correctness for end users, please **always deploy to both environments**.
+
 ### Template Deploy
 1. Please make sure you tested on a non-production environment before merging.
 1. Merge your feature branch pull request to `master`.


### PR DESCRIPTION
## What does this pull request do?

We need to remember to deploy to both environments while the split between template-deploy and Kubernetes is running.

This change mentions this in the deployment readme.

## Any other changes that would benefit highlighting?

None.