### PR TITLE
LGA-457: Add Google Analytics ID to Kubernetes

### DIFF
--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -41,6 +41,8 @@ spec:
           value: https://prod.laalaa.dsd.io
         - name: LOG_LEVEL
           value: INFO
+        - name: GA_ID
+          value: UA-37377084-21
         - name: SECRET_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## What does this pull request do?

This variable missing does not cause any errors on booting up the application, so we did not detect it before.

As we now have 10% traffic over to Kubernetes, quickly adding `GA_ID` environment variable to the production Kubernetes configuration.

## Any other changes that would benefit highlighting?

None.