### PR TITLE
Annotate deployments with change-cause

### DIFF
--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -23,7 +23,7 @@ echo "Deploying $ECR_DEPLOY_IMAGE to $NAMESPACE..."
 cat "$NAMESPACE_DIR/deployment.yml" | \
   kubectl set image app="$ECR_DEPLOY_IMAGE" --filename=/dev/stdin --local --output=yaml | \
   kubectl annotate kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --filename=/dev/stdin --local --output=yaml | \
-  kubectl apply \
+  kubectl apply --record=false \
     --filename=/dev/stdin \
     --filename="$NAMESPACE_DIR/service.yml" \
     --filename="$NAMESPACE_DIR/ingress.yml"

--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -1,4 +1,5 @@
 #!/bin/sh -eu
+set -o pipefail
 
 ROOT=$(dirname "$0")
 NAMESPACE="$1"

--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -5,7 +5,6 @@ NAMESPACE="$1"
 NAMESPACE_DIR="$ROOT/../kubernetes_deploy/$NAMESPACE"
 
 if ! [ $NAMESPACE ] ; then
-
   echo "usage: deploy_to_kubernetes namespace\n"
   echo "namespace is a directory in ../kubernetes_deploy/ directory"
   exit 1;
@@ -20,8 +19,9 @@ source "$ROOT/define_build_environment_variables"
 
 echo "Deploying $ECR_DEPLOY_IMAGE to $NAMESPACE..."
 
-kubectl set image --filename="$NAMESPACE_DIR/deployment.yml" --local --output=yaml \
-  app="$ECR_DEPLOY_IMAGE" | \
+cat "$NAMESPACE_DIR/deployment.yml" | \
+  kubectl set image app="$ECR_DEPLOY_IMAGE" --filename=/dev/stdin --local --output=yaml | \
+  kubectl annotate kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --file=/dev/stdin --local --output=yaml | \
   kubectl apply \
     --filename=/dev/stdin \
     --filename="$NAMESPACE_DIR/service.yml" \

--- a/.circleci/deploy_to_kubernetes
+++ b/.circleci/deploy_to_kubernetes
@@ -21,7 +21,7 @@ echo "Deploying $ECR_DEPLOY_IMAGE to $NAMESPACE..."
 
 cat "$NAMESPACE_DIR/deployment.yml" | \
   kubectl set image app="$ECR_DEPLOY_IMAGE" --filename=/dev/stdin --local --output=yaml | \
-  kubectl annotate kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --file=/dev/stdin --local --output=yaml | \
+  kubectl annotate kubernetes.io/change-cause="$CIRCLE_BUILD_URL" --filename=/dev/stdin --local --output=yaml | \
   kubectl apply \
     --filename=/dev/stdin \
     --filename="$NAMESPACE_DIR/service.yml" \

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    kubernetes.io/change-cause: "<to be filled in deploy_to_kubernetes script>"
   name: laa-cla-public
 spec:
   replicas: 3

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -1,6 +1,8 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  annotations:
+    kubernetes.io/change-cause: "<to be filled in deploy_to_kubernetes script>"
   name: laa-cla-public
 spec:
   replicas: 2


### PR DESCRIPTION
## What does this pull request do?

Automatically annotate the deployments caused by CircleCI so we can see the rollout history:

```
$ kubectl rollout history deployment/laa-cla-public --namespace=laa-cla-public-production
deployment.extensions/laa-cla-public
REVISION  CHANGE-CAUSE
1         <none>
2         <none>
3         https://circleci.com/gh/ministryofjustice/cla_public/960
```

The intention is to easily identify why deployments happened and link back to the job that caused the rollout.

Reference: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#checking-rollout-history-of-a-deployment

## Any other changes that would benefit highlighting?

Added `-o pipefail` to the shebang. If any of the `kubectl set` or `kubectl annotate` commands fail, we should fail the deployment.

Example: https://circleci.com/gh/ministryofjustice/cla_public/964 was green, despite the failed commands.