### PR TITLE
LGA-464: Document rolling back to previous versions

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,6 +20,7 @@
 :rotating_light: To ensure correctness for end users, please **always deploy to both environments**.
 
 ### Template Deploy
+
 1. Please make sure you tested on a non-production environment before merging.
 1. Merge your feature branch pull request to `master`.
 1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/cla_public/tree/master) for the `master` branch.
@@ -31,6 +32,10 @@
     * `ENVIRONMENT` is the target environment, select depending on your needs. Select `prod` for production.
     * `CONTAINER_BRANCH` is the branch that needs to be released (`master` in the above example).
     * `VERSION` is the specific 7-character prefix of the Git SHA (`54c165b` in the above example).
+
+#### Rolling back
+
+1. Redo the last step above with the last known good `master` branch git SHA.
 
 :tada: :shipit:
 
@@ -49,3 +54,9 @@
     kubectl --namespace laa-cla-public-production get pods,deployments -o wide
     kubectl --namespace laa-cla-public-production get events
     ```
+
+#### Rolling back
+
+1. Check the rollout history with `kubectl rollout history deployment/laa-cla-public --namespace=laa-cla-public-production`
+1. Roll back to the previous version with
+   `kubectl rollout undo deployment/laa-cla-public --namespace=laa-cla-public-production`


### PR DESCRIPTION
## What does this pull request do?

Add instructions for rolling back on both of our deployments.

[Fancy diff link](https://github.com/ministryofjustice/cla_public/pull/798/files?short_path=f5758d3#diff-f5758d353c2bb60f873830856c7ce6e0).

## Any other changes that would benefit highlighting?

None.