### PR TITLE
Use 18.1 pip version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,8 @@ jobs:
           command: |
             pip install virtualenv
             virtualenv env
+            source env/bin/activate
+            pip install pip==18.1
 
       - restore_cache:
           keys:

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN add-apt-repository ppa:nginx/stable && \
     mkdir -p /var/log/nginx/cla_public
 
 # Install global Python packages
-RUN pip install -U setuptools pip wheel
+RUN pip install -U setuptools pip==18.1 wheel
 
 # Install uwsgi
 RUN pip install GitPython uwsgi && \


### PR DESCRIPTION
## What does this pull request do?

On CircleCI, the `test` jobs are currently failing: [example 1](https://circleci.com/gh/ministryofjustice/cla_public/992), [example 2](https://circleci.com/gh/ministryofjustice/cla_public/994), [example 3](https://circleci.com/gh/ministryofjustice/cla_public/996).

https://www.python.org/dev/peps/pep-0517/ causes problems with `cla_common` and pip 19 uses it by default.

Using `--no-use-pep517` does not work with `pip install -r requirements.txt`. The workaround is to downgrade to the previous version of pip.

## Any other changes that would benefit highlighting?

We can upgrade to the next `pip` version if `cla_common` is made compatible with https://www.python.org/dev/peps/pep-0517/.

@farrepa @said-moj @Katy600 Is the above statement correct?