### PR TITLE
LGA-481: Remove template-deploy Docker registry from build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,21 +12,14 @@ references:
 jobs:
   build:
     docker:
-      - image: docker:17.03-git
+      - image: docker:18.09-git
     environment:
-      DSD_DOCKER_REGISTRY: "registry.service.dsd.io"
-      DSD_DOCKER_IMAGE: "cla_public"
       ECR_DOCKER_REGISTRY: "926803513772.dkr.ecr.eu-west-1.amazonaws.com"
       ECR_DOCKER_IMAGE: "laa-get-access/laa-cla-public"
     steps:
       - checkout
       - setup_remote_docker:
-          version: 17.03.0-ce
           docker_layer_caching: true
-      - run:
-          name: Login to the DSD Docker registry
-          command: |
-            docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD --email "${DOCKER_USERNAME}@digital.justice.gov.uk" $DSD_DOCKER_REGISTRY
       - run:
           name: Login to the ECR Docker registry
           command: |

--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -13,9 +13,6 @@ function tag_and_push() {
 
 if [ "$CIRCLE_BRANCH" == "master" ]; then
   tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$CIRCLE_SHA1"
-  tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$CIRCLE_SHA1"
-  tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.$short_sha"
 fi
 tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch"
 tag_and_push "$ECR_DEPLOY_IMAGE"
-tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.latest"


### PR DESCRIPTION
## What does this pull request do?

We are 100% on Kubernetes! ~~(Well, not _yet_, but it will be applied today.)~~

We no longer need to deploy on template-deploy, so we no longer need to build for the Docker registry used by that environment.

This pull request removes the use of the old registry.

## Any other changes that would benefit highlighting?

The change speeds up the Docker build job by about 2.5 minutes (7 minutes 50 seconds &rarr; 5 minutes 10 seconds).

## Dependencies

- [x] 🚨 ~~Do not merge until Kubernetes 100% split is applied, please.~~ 100% split is live.