### PR TITLE
Fix link to kubernetes.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ The website address is https://checklegalaid.service.gov.uk/.
 * [Installation](docs/installation.md)
 * [Development](docs/development.md)
 * [Testing](docs/testing.md)
-* [Using Kubernetes](docs/testing.md)
+* [Using Kubernetes](docs/kubernetes.md)
 * [Releasing](docs/releasing.md)
 * [Monitoring](docs/monitoring.md)


### PR DESCRIPTION
## What does this pull request do?

Fixes the link in README that _should_ point to your kubernates doc.  

## Any other changes that would benefit highlighting?

Not at this time.
