### PR TITLE
LGA-497 - Stop application from booting up without essential configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
           name: Run unit tests
           command: |
             source env/bin/activate
-            python manage.py test
+            CLA_PUBLIC_CONFIG=config/testing.py python manage.py test
 
   staging_deploy:
     <<: *container_config

--- a/cla_public/apps/contact/fields.py
+++ b/cla_public/apps/contact/fields.py
@@ -12,7 +12,7 @@ from wtforms.validators import InputRequired, ValidationError
 
 from cla_common import call_centre_availability
 from cla_common.call_centre_availability import OpeningHours
-from cla_public.config import common as settings
+from cla_public.config import operating_hours as settings
 from cla_public.apps.contact.constants import DAY_CHOICES, DAY_TODAY, DAY_SPECIFIC
 from cla_public.apps.checker.validators import IgnoreIf, FieldValueNot
 from cla_public.libs.call_centre_availability import (

--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -2,6 +2,7 @@ import os
 import datetime
 
 from flask.ext.babel import lazy_gettext as _
+from cla_public.config.operating_hours import *
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
@@ -54,8 +55,8 @@ API_CLIENT_TIMEOUT = 10
 
 BACKEND_API = {"url": "{url}/checker/api/v1/".format(url=BACKEND_BASE_URI)}
 
-SENTRY_DSN = os.environ.get("RAVEN_CONFIG_DSN", "")
-SENTRY_SITE_NAME = os.environ.get("RAVEN_CONFIG_SITE", "")
+SENTRY_DSN = os.environ["RAVEN_CONFIG_DSN"]
+SENTRY_SITE_NAME = os.environ["RAVEN_CONFIG_SITE"]
 
 POSTCODEINFO_API = {
     "auth_token": os.environ.get("POSTCODEINFO_API_TOKEN"),
@@ -65,8 +66,8 @@ POSTCODEINFO_API = {
 
 OS_PLACES_API_KEY = os.environ.get("OS_PLACES_API_KEY")
 
-ZENDESK_API_USERNAME = os.environ.get("ZENDESK_API_USERNAME")
-ZENDESK_API_TOKEN = os.environ.get("ZENDESK_API_TOKEN")
+ZENDESK_API_USERNAME = os.environ["ZENDESK_API_USERNAME"]
+ZENDESK_API_TOKEN = os.environ["ZENDESK_API_TOKEN"]
 ZENDESK_DEFAULT_REQUESTER = 649762516  # anonymous feedback <noreply@ministryofjustice.zendesk.com>
 
 GA_ID = os.environ.get("GA_ID")
@@ -99,13 +100,13 @@ TIMEZONE = "Europe/London"
 
 LAALAA_API_HOST = os.environ.get("LAALAA_API_HOST", "https://prod.laalaa.dsd.io")
 
-MAIL_SERVER = os.environ.get("SMTP_HOST")
+MAIL_SERVER = os.environ["SMTP_HOST"]
 MAIL_PORT = os.environ.get("SMTP_PORT", 465)
 MAIL_USE_TLS = False
 MAIL_USE_SSL = True
 
-MAIL_USERNAME = os.environ.get("SMTP_USER")
-MAIL_PASSWORD = os.environ.get("SMTP_PASSWORD")
+MAIL_USERNAME = os.environ["SMTP_USER"]
+MAIL_PASSWORD = os.environ["SMTP_PASSWORD"]
 
 MAIL_DEFAULT_SENDER = ("Civil Legal Advice", "no-reply@civillegaladvice.service.gov.uk")
 

--- a/cla_public/config/local.py.example
+++ b/cla_public/config/local.py.example
@@ -17,5 +17,3 @@ DEBUG = True
 SESSION_COOKIE_SECURE = False
 
 DEBUG_TB_INTERCEPT_REDIRECTS = False
-#EXTENSIONS.append(DebugToolbarExtension())
-

--- a/cla_public/config/local.py.example
+++ b/cla_public/config/local.py.example
@@ -1,6 +1,15 @@
 from flask_debugtoolbar import DebugToolbarExtension
 
-from .common import *
+import os
+os.environ.setdefault("SMTP_HOST", "")
+os.environ.setdefault("SMTP_USER", "")
+os.environ.setdefault("SMTP_PASSWORD", "")
+os.environ.setdefault("RAVEN_CONFIG_DSN", "")
+os.environ.setdefault("RAVEN_CONFIG_SITE", "")
+os.environ.setdefault("ZENDESK_API_USERNAME", "")
+os.environ.setdefault("ZENDESK_API_TOKEN", "")
+
+from cla_public.config.common import *
 
 SECRET_KEY = 'secret'
 
@@ -8,11 +17,5 @@ DEBUG = True
 SESSION_COOKIE_SECURE = False
 
 DEBUG_TB_INTERCEPT_REDIRECTS = False
-EXTENSIONS.append(DebugToolbarExtension())
+#EXTENSIONS.append(DebugToolbarExtension())
 
-ZENDESK_API_USERNAME = os.environ.get(
-    'ZENDESK_USERNAME',
-    'your_service_username')
-ZENDESK_API_TOKEN = os.environ.get(
-    'ZENDESK_API_TOKEN',
-    'your_service_token')

--- a/cla_public/config/operating_hours.py
+++ b/cla_public/config/operating_hours.py
@@ -1,0 +1,7 @@
+import datetime
+OPERATOR_HOURS = {
+    "weekday": (datetime.time(9, 0), datetime.time(20, 0)),
+    "saturday": (datetime.time(9, 0), datetime.time(12, 30)),
+    "2018-12-24": (datetime.time(9, 0), datetime.time(17, 30)),
+    "2018-12-31": (datetime.time(9, 0), datetime.time(17, 30)),
+}

--- a/cla_public/config/operating_hours.py
+++ b/cla_public/config/operating_hours.py
@@ -1,4 +1,5 @@
 import datetime
+
 OPERATOR_HOURS = {
     "weekday": (datetime.time(9, 0), datetime.time(20, 0)),
     "saturday": (datetime.time(9, 0), datetime.time(12, 30)),

--- a/cla_public/config/testing.py
+++ b/cla_public/config/testing.py
@@ -1,3 +1,12 @@
+import os
+os.environ.setdefault("SMTP_HOST", "")
+os.environ.setdefault("SMTP_USER", "")
+os.environ.setdefault("SMTP_PASSWORD", "")
+os.environ.setdefault("RAVEN_CONFIG_DSN", "")
+os.environ.setdefault("RAVEN_CONFIG_SITE", "")
+os.environ.setdefault("ZENDESK_API_USERNAME", "")
+os.environ.setdefault("ZENDESK_API_TOKEN", "")
+
 from cla_public.config.common import *
 
 

--- a/cla_public/config/testing.py
+++ b/cla_public/config/testing.py
@@ -1,4 +1,5 @@
 import os
+
 os.environ.setdefault("SMTP_HOST", "")
 os.environ.setdefault("SMTP_USER", "")
 os.environ.setdefault("SMTP_PASSWORD", "")

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,6 +24,8 @@ Next, create the environment and start it up:
 
     npm install -g gulp
 
+    npm install && gulp
+
 Create a ``local.py`` settings file from the example file:
 
     cp cla_public/config/local.py.example cla_public/config/local.py


### PR DESCRIPTION
## What does this pull request do?

Currently, it’s possible for the application to be deployed without having

- SMTP (confirmation e-mail) configuration
- Zendesk (feedback) configuration
- Sentry (exception monitoring) configuration

This leads to application silently failing to do any of the above tasks.

This PR prevents the application starting up without those configurations

## Any other changes that would benefit highlighting?

It seems the debug toolbar extension is registered when DEBUG is True. Also having the `EXTENSIONS.append(DebugToolbarExtension())` in the local.py was causing app to fail complaining about the view method already being registered. I have commented this snippet out

The opening hours config was moved to a separate config file as this is required before the flask app has been created. The previous method was getting the open hours settings directly from commons.py instead of reading the current application config.

Added sensible default configuration for local and test environments.