### PR TITLE
LGA-498 - Remove legacy statsd as those stats are provided by kubernetes

### DIFF
--- a/cla_public/app.py
+++ b/cla_public/app.py
@@ -19,7 +19,6 @@ from cla_public.apps.contact.views import contact
 from cla_public.apps.checker.views import checker
 from cla_public.apps.scope.urls import scope
 from cla_public.apps.checker.session import CheckerSessionInterface, CustomJSONEncoder
-from cla_public.middleware import StatsdMiddleware
 from cla_public.libs import honeypot
 from cla_public.libs.utils import get_locale
 
@@ -62,8 +61,6 @@ def create_app(config_file=None):
     logging.config.dictConfig(app.config["LOGGING"])
     # quiet markdown module
     logging.getLogger("MARKDOWN").setLevel(logging.WARNING)
-
-    app.wsgi_app = StatsdMiddleware(app.wsgi_app, app.config)
 
     if app.debug:
         from werkzeug.debug import DebuggedApplication

--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -73,10 +73,6 @@ GA_ID = os.environ.get("GA_ID")
 
 CACHE_TYPE = "simple"
 
-STATSD_PREFIX = "public"
-STATSD_HOST = os.environ.get("STATSD_HOST", "localhost")
-STATSD_PORT = os.environ.get("STATSD_PORT", 8125)
-
 EXTENSIONS = []
 
 CLA_ENV = os.environ.get("CLA_ENV", "dev")

--- a/cla_public/middleware.py
+++ b/cla_public/middleware.py
@@ -1,21 +1,4 @@
 import logging
-import time
-
-import statsd
-
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
-
-
-class StatsdMiddleware(object):
-    def __init__(self, app, config):
-        self.app = app
-        self.client = statsd.StatsClient(config["STATSD_HOST"], config["STATSD_PORT"], prefix=config["STATSD_PREFIX"])
-
-    def __call__(self, environ, start_response):
-        request_start = time.time()
-        response = self.app(environ, start_response)
-        ms = int((time.time() - request_start) * 1000)
-        self.client.timing("{REQUEST_METHOD}.{PATH_INFO}", ms)
-        return response

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,6 @@ python-dateutil==2.2
 pytz==2018.5
 raven==6.9.0
 requests==2.19.1
-statsd==3.0.1
 wsgiref==0.1.2
 Babel==1.3
 beautifulsoup4==4.6.3


### PR DESCRIPTION
## What does this pull request do?
statsd is not required as we have instrumentation in Kubernetes for free. This PR remove statsd monitoring code from the code base

