### PR TITLE
Allows forked pull requests to build Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,14 @@ jobs:
       - run:
           name: Login to the ECR Docker registry
           command: |
-            apk add --no-cache --no-progress py2-pip
-            pip install awscli
-            ecr_login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
-            ${ecr_login}
+            if [ -z "$CIRCLE_PR_NUMBER" ]; then
+              apk add --no-cache --no-progress py2-pip
+              pip install awscli
+              ecr_login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
+              ${ecr_login}
+            else
+              echo "We do not need to authenticate for forked pull requests."
+            fi
       - run:
           name: Build Docker image
           command: |
@@ -43,7 +47,12 @@ jobs:
           command: docker run --rm --tty --interactive application:$CIRCLE_SHA1 date '+%Z' | egrep "(GMT|BST)"
       - run:
           name: Tag and push Docker images
-          command: .circleci/tag_and_push_docker_image application:$CIRCLE_SHA1
+          command: |
+            if [ -z "$CIRCLE_PR_NUMBER" ]; then
+              .circleci/tag_and_push_docker_image application:$CIRCLE_SHA1
+            else
+              echo "We do not need to push Docker images for forked pull requests."
+            fi
   lint:
     docker:
       - image: circleci/python:3.7


### PR DESCRIPTION
## What does this pull request do?

Allows forked pull requests to build Docker images without pushing.

The end goal is a workflow that runs all the tests but does not produce testable artefacts. I think this is a workable state for public contributions.

## Any other changes that would benefit highlighting?

The `$CIRCLE_PR_NUMBER` environment variable is only populated on forked pull requests. (https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project)

Using this behaviour we can split the control flow of the Docker build step to build and test the Docker image, but do not attempt to login and push.

Initially, I wanted to separate the jobs to (`docker-build` and `docker-push`) but then I realised making the image built in the first job available for the second job would not be trivial, so I lazied out.