### PR TITLE
LGA-47 Redact postcode from GA title and location before pageview send

### DIFF
--- a/cla_public/templates/checker/result/face-to-face.html
+++ b/cla_public/templates/checker/result/face-to-face.html
@@ -74,4 +74,9 @@
     {% include '_ga-outcome-pageview.html' %}
   {% endblock %}
 
+  {% block ga_pageview -%}
+    ga('set', 'title', 'Results for [postcode redacted] | Seek legal advice');
+    ga('set', 'location', window.location.href.replace(/postcode=[^&]+/gi, 'postcode=redacted'));
+    {{ super() }}
+  {%- endblock %}
 {% endif %}


### PR DESCRIPTION
## What does this pull request do?

Explicitly sets postcode redacted title and location for GA before pageview send

## Any other changes that would benefit highlighting?

Intentionally left blank.