### PR TITLE
LGA-422 Set autocomplete and type attributes on contact_number input

### DIFF
--- a/cla_public/templates/macros/subform.html
+++ b/cla_public/templates/macros/subform.html
@@ -20,7 +20,7 @@
         <li>{{ _('If you miss the call you’ll need to complete this form again.') }}</li>
       </ul>
     </div>
-    {{ Form.group(form.callback.contact_number, field_attrs={'class': 'm-large'}) }}
+    {{ Form.group(form.callback.contact_number, field_attrs={'class': 'm-large', 'autocomplete': 'tel', 'type': 'tel'}) }}
     {{ Form.group(form.callback.safe_to_contact) }}
     {{ time_picker(form.callback.time) }}
   {% endcall %}
@@ -50,7 +50,7 @@
     </div>
     {{ Form.group(form.thirdparty.full_name, field_attrs={'class': 'm-large'}) }}
     {{ Form.group(form.thirdparty.relationship) }}
-    {{ Form.group(form.thirdparty.contact_number, field_attrs={'class': 'm-large'}) }}
+    {{ Form.group(form.thirdparty.contact_number, field_attrs={'class': 'm-large', 'autocomplete': 'tel', 'type': 'tel'}) }}
     {{ Form.group(form.thirdparty.safe_to_contact) }}
     {{ time_picker(form.thirdparty.time) }}
   {% endcall %}


### PR DESCRIPTION
## What does this pull request do?

Add `autocomplete="tel"` and `type="tel"` to `contact_number` input fields.

This is to fix "callback requests are being received with no phone number recorded against the case".

## Any other changes that would benefit highlighting?

Intentionally left blank.
