### PR TITLE
LGA-529 - Enable TLS using new cloud platform spec

### DIFF
--- a/kubernetes_deploy/production/ingress.yml
+++ b/kubernetes_deploy/production/ingress.yml
@@ -4,6 +4,9 @@ metadata:
   name: laa-cla-public
   namespace: laa-cla-public-production
 spec:
+  tls:
+  - hosts:
+    - laa-cla-public-production.apps.cloud-platform-live-0.k8s.integration.dsd.io
   rules:
   - host: laa-cla-public-production.apps.cloud-platform-live-0.k8s.integration.dsd.io
     http:

--- a/kubernetes_deploy/staging/ingress.yml
+++ b/kubernetes_deploy/staging/ingress.yml
@@ -4,6 +4,9 @@ metadata:
   name: laa-cla-public
   namespace: laa-cla-public-staging
 spec:
+  tls:
+  - hosts:
+    - laa-cla-public-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
   rules:
   - host: laa-cla-public-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
     http:


### PR DESCRIPTION
## What does this pull request do?

Enable TLS in the Ingress resource by adding a new certificate resource.

## Any other changes that would benefit highlighting?
This was implicitly been done by the cloud platforms team before however recent changes mean that we need to explicitly do this.

The circleci service account needed extra permission to be able to create the certificate resource which was cover in this PR https://github.com/ministryofjustice/cloud-platform-environments/pull/501
