### PR TITLE
Update Read me to use config/local.py for local setup

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ Next, you can run the management command like this:
 
 You can run the server with:
 
-    ./manage.py runserver
+    CLA_PUBLIC_CONFIG=config/local.py ./manage.py runserver
 
 *OR*
 


### PR DESCRIPTION
## What does this pull request do?

The sensible defaults provided in https://github.com/ministryofjustice/cla_public/pull/807 have to be used for local development if no env variables are going to be required.

There is a ticket in refactoring this to match the way that this done on fala https://github.com/ministryofjustice/fala/pull/29/files

## Any other changes that would benefit highlighting?

Intentionally left blank.

