### PR TITLE
LGA-579 Tests and iterable default categories

### DIFF
--- a/cla_public/libs/laalaa.py
+++ b/cla_public/libs/laalaa.py
@@ -55,6 +55,8 @@ def decode_categories(result):
 
 
 def find(postcode, categories=None, page=1):
+    if not categories:
+        categories = [None]
     merged_data = {"results": [], "count": 0}
     for category in categories:
         data = laalaa_search(postcode=postcode, category=category, page=page)


### PR DESCRIPTION
## What does this pull request do?

- Add an iterable default for categories
- Test `count` key included in results
- Test searching with no categories
- Test results are merged

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [X] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"