### PR TITLE
LGA-551 Make contact form resilient to long free text input

### DIFF
--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -40,7 +40,13 @@ class AdaptationsForm(BabelTranslationsFormMixin, NoCsrfForm):
     other_language = SelectField(_(u"Language required:"), choices=(LANG_CHOICES))
     is_other_adaptation = BooleanField(_(u"Any other communication needs"))
     other_adaptation = TextAreaField(
-        _(u"Other communication needs"), description=_(u"Please tell us what you need in the box below")
+        _(u"Other communication needs"),
+        description=_(u"Please tell us what you need in the box below"),
+        validators=[
+            IgnoreIf("is_other_adaptation", FieldValue(False)),
+            Length(max=4000, message=_(u"Your other communication needs must be 4000 characters " u"or less")),
+            Optional(),
+        ],
     )
 
     def __init__(self, formdata=None, obj=None, prefix="", data=None, meta=None, **kwargs):
@@ -155,9 +161,7 @@ class ContactForm(Honeypot, BabelTranslationsFormMixin, Form):
         _(u"Tell us more about your problem"),
         validators=[Length(max=4000, message=_(u"Your notes must be 4000 characters " u"or less")), Optional()],
     )
-    adaptations = ValidatedFormField(
-        AdaptationsForm, _(u"Do you have any special communication needs?"), validators=[Optional()]
-    )
+    adaptations = ValidatedFormField(AdaptationsForm, _(u"Do you have any special communication needs?"))
 
     def api_payload(self):
         "Form data as data structure ready to send to API"

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -89,6 +89,12 @@ class Contact(AllowSessionOverride, UpdatesMeansTest, SessionBackedFormView):
         if self.form.extra_notes.data:
             session.checker.add_note(u"User problem", self.form.extra_notes.data)
         try:
+            if not self.form.adaptations.is_other_adaptation.data:
+                self.form.adaptations.other_adaptation.data = ""
+                try:
+                    session.checker["ContactForm"]["adaptations"]["other_adaptation"] = ""
+                except KeyError:
+                    pass
             post_to_eligibility_check_api(session.checker.notes_object())
             post_to_case_api(self.form)
             if ReasonsForContacting.MODEL_REF_SESSION_KEY in session:


### PR DESCRIPTION
## What does this pull request do?

- Adds a max length validator to the `other_adaptation` field of the contact form, which is ignored if the `is_other_adaptation` field is false
- Removes the `optional` validator from the `adaptations` ValidatedFormField, as that was short-circuiting validation on the form
- Removes the value of `other_adaptation` from the form and from the session if `is_other_adaptation` is false

## Any other changes that would benefit highlighting?

As the value of other_adaptation is (rightly) not validated if is_other_adaptation is false, we can end up passing very long values to the back end still (if the user fills in the field and then unticks the box to hide and ignore that field), and it's the use of these in the session which appears to cause the session to break, leading to the server error. Therefore, we now remove the value if is_other_adaptation is false (it was already not passed to the API in this case).

The ticket reported that the `notes` field also didn't work with over-long content but I couldn't replicate that, so I think the two concepts had been conflated.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
