### PR TITLE
LGA-597 - adding feedback link to emails

### DIFF
--- a/cla_public/templates/emails/confirmation.txt
+++ b/cla_public/templates/emails/confirmation.txt
@@ -56,6 +56,9 @@
 
 {%- endif %}
 
+{{ _('Take a short survey. Help improve the service.') }}
+
+{{ _('https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you') }}
 
 ---
 


### PR DESCRIPTION
## What does this pull request do?

This PR updates the confirmation.txt file with the feedback survey link. The email is triggered when someone adds an email address on the callback page or confirmation page.

## Any other changes that would benefit highlighting?

None.

## Checklist

This relates to ticket LGA-597.

Image of how the email looks when triggered is attached.
![Screen Shot 2019-04-24 at 10 39 15](https://user-images.githubusercontent.com/19589707/56651077-30acf880-6680-11e9-9afa-f7a4a2a02284.png)


