### PR TITLE
Add badges with links to relevant pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![Runbook](https://img.shields.io/badge/runbook-edit-172B4D.svg?logo=confluence)](https://dsdmoj.atlassian.net/wiki/spaces/laagetaccess/pages/1388150812/Applications+details)
+[![Exceptions](https://img.shields.io/badge/exceptions-view-FB4226.svg?logo=sentry)](https://sentry.service.dsd.io/mojds/prod-public/)
+[![Logs](https://img.shields.io/badge/logs-view-005571.svg?logo=kibana)](https://kibana.apps.cloud-platform-live-0.k8s.integration.dsd.io/_plugin/kibana/goto/5593d9bee2fffcfbb6d93dabee450dfb)
+[![Feature tests](https://img.shields.io/badge/feature%20tests-view-brightgreen.svg?logo=github)](https://github.com/ministryofjustice/laa-cla-e2e-tests)
+[![CircleCI](https://circleci.com/gh/ministryofjustice/cla_public/tree/master.svg?style=svg)](https://circleci.com/gh/ministryofjustice/cla_public/tree/master)
+
 # Civil Legal Advice
   
 Civil Legal Advice is a service provided to the general public in England and Wales where users can obtain free legal advice from specialist legal providers relating to a range of Civil matters. This is subject to the user's matter being within scope of the service and the user passing the means eligibility test. The advice can either be given via telephone or in person depending upon the client's unique circumstances. 


### PR DESCRIPTION
## What does this pull request do?

Our new hires in another team in the service area have highlighted that it is hard to find something related to an application unless we know where to look.

One of the ideas to deal with this difficulty is to make the application Readmes the starting point for everything.

In the above spirit, this pull request introduces new badges that will link directly to:

- Where to find the application runbook.
- Where to find the runtime exceptions.
- Where to find the runtime logs.
- Where to find the feature tests.
- Where to find the continuous integration system, with a representation of the latest production build.

<img width="995" alt="Screen Shot 2019-06-28 at 13 59 21" src="https://user-images.githubusercontent.com/1526295/60343810-f546e700-99ac-11e9-9c6d-14e2c4820884.png">

## Any other changes that would benefit highlighting?

Not at this time.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title" **Not applicable.**