### PR TITLE
LGA-587 - Update LAALAA_API_HOST env var on dev and staging pods

### DIFF
--- a/kubernetes_deploy/development/deployment.yml
+++ b/kubernetes_deploy/development/deployment.yml
@@ -39,7 +39,7 @@ spec:
         - name: BACKEND_BASE_URI
           value: https://staging-backend.cla.dsd.io/
         - name: LAALAA_API_HOST
-          value: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk/
+          value: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
         - name: LOG_LEVEL
           value: DEBUG
         - name: SECRET_KEY

--- a/kubernetes_deploy/development/deployment.yml
+++ b/kubernetes_deploy/development/deployment.yml
@@ -39,7 +39,7 @@ spec:
         - name: BACKEND_BASE_URI
           value: https://staging-backend.cla.dsd.io/
         - name: LAALAA_API_HOST
-          value: https://staging.laalaa.dsd.io
+          value: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk/
         - name: LOG_LEVEL
           value: DEBUG
         - name: SECRET_KEY

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -40,7 +40,7 @@ spec:
         - name: BACKEND_BASE_URI
           value: https://staging-backend.cla.dsd.io/
         - name: LAALAA_API_HOST
-          value: https://staging.laalaa.dsd.io
+          value: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk/
         - name: LOG_LEVEL
           value: INFO
         - name: SECRET_KEY

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -40,7 +40,7 @@ spec:
         - name: BACKEND_BASE_URI
           value: https://staging-backend.cla.dsd.io/
         - name: LAALAA_API_HOST
-          value: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk/
+          value: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
         - name: LOG_LEVEL
           value: INFO
         - name: SECRET_KEY


### PR DESCRIPTION
## What does this pull request do?
Configures `staging` and `development` deployments of the site to use the new domain for the staging instance of the legal adviser API, which is the kubernetes-deployed version.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
