### PR TITLE
LGA-657 - Switch to using gov-notify for sending emails over send-grid

### DIFF
--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -95,16 +95,8 @@ TIMEZONE = "Europe/London"
 
 LAALAA_API_HOST = os.environ.get("LAALAA_API_HOST", "https://prod.laalaa.dsd.io")
 
-MAIL_SERVER = os.environ.get("SMTP_HOST")
-MAIL_PORT = os.environ.get("SMTP_PORT", 465)
-MAIL_USE_TLS = False
-MAIL_USE_SSL = True
-
-MAIL_USERNAME = os.environ.get("SMTP_USER")
-MAIL_PASSWORD = os.environ.get("SMTP_PASSWORD")
-
-MAIL_DEFAULT_SENDER = ("Civil Legal Advice", "no-reply@civillegaladvice.service.gov.uk")
-
+GOV_NOTIFY_API_KEY = os.getenv("GOV_NOTIFY_API_KEY")
+GOV_NOTIFY_TEMPLATES = {"confirmation": "d82e9228-7dd4-4153-b43a-0d18be8203f7"}
 # local.py overrides all the common settings.
 try:
     from cla_public.config.local import *  # noqa: F401,F403

--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -96,7 +96,7 @@ TIMEZONE = "Europe/London"
 LAALAA_API_HOST = os.environ.get("LAALAA_API_HOST", "https://prod.laalaa.dsd.io")
 
 GOV_NOTIFY_API_KEY = os.getenv("GOV_NOTIFY_API_KEY")
-GOV_NOTIFY_TEMPLATES = {"confirmation": "d82e9228-7dd4-4153-b43a-0d18be8203f7"}
+GOV_NOTIFY_TEMPLATES = {"confirmation": os.getenv("GOV_NOTIFY_TEMPLATE_CONFIRMATION")}
 # local.py overrides all the common settings.
 try:
     from cla_public.config.local import *  # noqa: F401,F403

--- a/cla_public/config/deployment.py
+++ b/cla_public/config/deployment.py
@@ -12,7 +12,7 @@ settings_required = (
 )
 
 for key in settings_required:
-    if key not in os.environ:
+    if not os.environ.get(key):
         raise Exception("'{}' Environment variable is required. please provide".format(key))
 
 from cla_public.config.common import *

--- a/cla_public/config/deployment.py
+++ b/cla_public/config/deployment.py
@@ -11,9 +11,10 @@ settings_required = (
     "GOV_NOTIFY_TEMPLATE_CONFIRMATION",
 )
 
-for key in settings_required:
-    if not os.environ.get(key):
-        raise Exception("'{}' Environment variable is required. please provide".format(key))
+if os.environ.get("CLA_ENV") != "development":
+    for key in settings_required:
+        if not os.environ.get(key):
+            raise Exception("'{}' Environment variable is required. please provide".format(key))
 
 from cla_public.config.common import *
 

--- a/cla_public/config/deployment.py
+++ b/cla_public/config/deployment.py
@@ -3,13 +3,11 @@ import os
 settings_required = (
     "ZENDESK_API_USERNAME",
     "ZENDESK_API_TOKEN",
-    "SMTP_HOST",
-    "SMTP_USER",
-    "SMTP_PASSWORD",
     "RAVEN_CONFIG_DSN",
     "RAVEN_CONFIG_SITE",
     "BACKEND_BASE_URI",
     "LAALAA_API_HOST",
+    "GOV_NOTIFY_API_KEY",
 )
 
 for key in settings_required:

--- a/cla_public/config/deployment.py
+++ b/cla_public/config/deployment.py
@@ -8,6 +8,7 @@ settings_required = (
     "BACKEND_BASE_URI",
     "LAALAA_API_HOST",
     "GOV_NOTIFY_API_KEY",
+    "GOV_NOTIFY_TEMPLATE_CONFIRMATION",
 )
 
 for key in settings_required:

--- a/kubernetes_deploy/development/deployment.yml
+++ b/kubernetes_deploy/development/deployment.yml
@@ -60,3 +60,7 @@ spec:
           value: ""
         - name: RAVEN_CONFIG_SITE
           value: ""
+        - name: GOV_NOTIFY_API_KEY
+          value: ""
+        - name: GOV_NOTIFY_TEMPLATE_CONFIRMATION
+          value: ""

--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -90,3 +90,13 @@ spec:
             secretKeyRef:
               name: raven-config
               key: RAVEN_CONFIG_SITE
+        - name: GOV_NOTIFY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: gov-notify
+              key: API_KEY
+        - name: GOV_NOTIFY_TEMPLATE_CONFIRMATION
+          valueFrom:
+            secretKeyRef:
+              name: gov-notify
+              key: TEMPLATE_CONFIRMATION

--- a/kubernetes_deploy/staging/deployment.yml
+++ b/kubernetes_deploy/staging/deployment.yml
@@ -88,3 +88,13 @@ spec:
             secretKeyRef:
               name: raven-config
               key: RAVEN_CONFIG_SITE
+        - name: GOV_NOTIFY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: gov-notify
+              key: API_KEY
+        - name: GOV_NOTIFY_TEMPLATE_CONFIRMATION
+          valueFrom:
+            secretKeyRef:
+              name: gov-notify
+              key: TEMPLATE_CONFIRMATION

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,3 +34,6 @@ postcodeinfo>=0.0,<0.1
 # fork of https://github.com/samgiles/slumber
 # with custom parameters for timeouts and additional headers on requests
 git+git://github.com/ministryofjustice/slumber.git@da38360d6d158ee7ed445b43228fefc6f7e430e6#egg=slumber==0.6.3moj
+
+# Gov-notify
+notifications-python-client==5.3.0


### PR DESCRIPTION
## What does this pull request do?

Switch to using gov-notify for sending emails over send-grid

## Any other changes that would benefit highlighting?

Before the "To" field in the message was "Full name, email-address" however gov-notify seem to be validating this and only accepting an e-mail address in the "To" field.

GOV_NOTIFY_API_KEY environment variable must be set on environments that wish to send out emails

## Todo

~~Simplify on_valid_submit method~~
~~Update https://github.com/ministryofjustice/laa-architecture-documentation/tree/master/diagrams/get-access~~ https://github.com/ministryofjustice/laa-architecture-documentation/pull/29

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
