### PR TITLE
LGA-584 Time out warning

### DIFF
--- a/cla_public/templates/checker/about.html
+++ b/cla_public/templates/checker/about.html
@@ -37,7 +37,11 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue')) }}
   </form>
-
+  <p>
+    {% trans %}
+    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    {% endtrans %}
+  </p>
   {{ Element.get_in_touch_link() }}
 
   <script>

--- a/cla_public/templates/checker/about.html
+++ b/cla_public/templates/checker/about.html
@@ -51,4 +51,5 @@
       num_dependants: '{{ _('How many?') }}'
     };
   </script>
+  {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/checker/about.html
+++ b/cla_public/templates/checker/about.html
@@ -37,11 +37,7 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue')) }}
   </form>
-  <p>
-    {% trans %}
-    Your session will time out after 30 minutes of inactivity. We do this for your security.
-    {% endtrans %}
-  </p>
+  {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}
 
   <script>
@@ -51,5 +47,5 @@
       num_dependants: '{{ _('How many?') }}'
     };
   </script>
-  {% include "checker/time-out-warning.html" %}
+
 {% endblock %}

--- a/cla_public/templates/checker/about.html
+++ b/cla_public/templates/checker/about.html
@@ -39,7 +39,7 @@
   </form>
   <p>
     {% trans %}
-    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    Your session will time out after 30 minutes of inactivity. We do this for your security.
     {% endtrans %}
   </p>
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/checker/additional-benefits.html
+++ b/cla_public/templates/checker/additional-benefits.html
@@ -19,11 +19,7 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue')) }}
   </form>
-  <p>
-    {% trans %}
-    Your session will time out after 30 minutes of inactivity. We do this for your security.
-    {% endtrans %}
-  </p>
+  {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}
 
   <script>

--- a/cla_public/templates/checker/additional-benefits.html
+++ b/cla_public/templates/checker/additional-benefits.html
@@ -21,7 +21,7 @@
   </form>
   <p>
     {% trans %}
-    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    Your session will time out after 30 minutes of inactivity. We do this for your security.
     {% endtrans %}
   </p>
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/checker/additional-benefits.html
+++ b/cla_public/templates/checker/additional-benefits.html
@@ -19,7 +19,11 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue')) }}
   </form>
-
+  <p>
+    {% trans %}
+    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    {% endtrans %}
+  </p>
   {{ Element.get_in_touch_link() }}
 
   <script>

--- a/cla_public/templates/checker/benefits.html
+++ b/cla_public/templates/checker/benefits.html
@@ -20,11 +20,7 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue')) }}
   </form>
-  <p>
-    {% trans %}
-    Your session will time out after 30 minutes of inactivity. We do this for your security.
-    {% endtrans %}
-  </p>
+  {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}
 {% endblock %}
 

--- a/cla_public/templates/checker/benefits.html
+++ b/cla_public/templates/checker/benefits.html
@@ -22,7 +22,7 @@
   </form>
   <p>
     {% trans %}
-    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    Your session will time out after 30 minutes of inactivity. We do this for your security.
     {% endtrans %}
   </p>
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/checker/benefits.html
+++ b/cla_public/templates/checker/benefits.html
@@ -20,7 +20,11 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue')) }}
   </form>
-
+  <p>
+    {% trans %}
+    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    {% endtrans %}
+  </p>
   {{ Element.get_in_touch_link() }}
 {% endblock %}
 

--- a/cla_public/templates/checker/income.html
+++ b/cla_public/templates/checker/income.html
@@ -60,6 +60,10 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue')) }}
   </form>
-
+  <p>
+    {% trans %}
+    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    {% endtrans %}
+  </p>
   {{ Element.get_in_touch_link() }}
 {% endblock %}

--- a/cla_public/templates/checker/income.html
+++ b/cla_public/templates/checker/income.html
@@ -62,7 +62,7 @@
   </form>
   <p>
     {% trans %}
-    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    Your session will time out after 30 minutes of inactivity. We do this for your security.
     {% endtrans %}
   </p>
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/checker/income.html
+++ b/cla_public/templates/checker/income.html
@@ -60,10 +60,6 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue')) }}
   </form>
-  <p>
-    {% trans %}
-    Your session will time out after 30 minutes of inactivity. We do this for your security.
-    {% endtrans %}
-  </p>
+  {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}
 {% endblock %}

--- a/cla_public/templates/checker/outgoings.html
+++ b/cla_public/templates/checker/outgoings.html
@@ -18,10 +18,6 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Review your answers')) }}
   </form>
-  <p>
-    {% trans %}
-    Your session will time out after 30 minutes of inactivity. We do this for your security.
-    {% endtrans %}
-  </p>
+  {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}
 {% endblock %}

--- a/cla_public/templates/checker/outgoings.html
+++ b/cla_public/templates/checker/outgoings.html
@@ -18,6 +18,10 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Review your answers')) }}
   </form>
-
+  <p>
+    {% trans %}
+    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    {% endtrans %}
+  </p>
   {{ Element.get_in_touch_link() }}
 {% endblock %}

--- a/cla_public/templates/checker/outgoings.html
+++ b/cla_public/templates/checker/outgoings.html
@@ -20,7 +20,7 @@
   </form>
   <p>
     {% trans %}
-    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    Your session will time out after 30 minutes of inactivity. We do this for your security.
     {% endtrans %}
   </p>
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/checker/property.html
+++ b/cla_public/templates/checker/property.html
@@ -50,7 +50,11 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue')) }}
   </form>
-
+  <p>
+    {% trans %}
+    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    {% endtrans %}
+  </p>
   {{ Element.get_in_touch_link() }}
 
   <script>

--- a/cla_public/templates/checker/property.html
+++ b/cla_public/templates/checker/property.html
@@ -50,11 +50,7 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue')) }}
   </form>
-  <p>
-    {% trans %}
-    Your session will time out after 30 minutes of inactivity. We do this for your security.
-    {% endtrans %}
-  </p>
+  {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}
 
   <script>

--- a/cla_public/templates/checker/property.html
+++ b/cla_public/templates/checker/property.html
@@ -52,7 +52,7 @@
   </form>
   <p>
     {% trans %}
-    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    Your session will time out after 30 minutes of inactivity. We do this for your security.
     {% endtrans %}
   </p>
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/checker/result/confirmation.html
+++ b/cla_public/templates/checker/result/confirmation.html
@@ -167,7 +167,7 @@
   <p>
     <a class="button button-larger" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" role="button">{{ _('Finish') }}</a>
   </p>
-
+{% include "checker/time-out-warning.html" %}
 {% endblock %}
 
 {% block javascripts %}

--- a/cla_public/templates/checker/result/eligible-f2f.html
+++ b/cla_public/templates/checker/result/eligible-f2f.html
@@ -40,6 +40,7 @@
     </p>
 
     {% include 'checker/result/_find-legal-adviser.html' %}
+    {% include "checker/time-out-warning.html" %}
   {% endblock %}
 
   {% block javascripts %}

--- a/cla_public/templates/checker/result/eligible.html
+++ b/cla_public/templates/checker/result/eligible.html
@@ -33,4 +33,5 @@
     {% endtrans %}
   </p>
   <p>{{ _('You’ll need to provide evidence of the financial information you’ve given us through this service.') }}</p>
+  {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/checker/result/eligible.html
+++ b/cla_public/templates/checker/result/eligible.html
@@ -33,5 +33,4 @@
     {% endtrans %}
   </p>
   <p>{{ _('You’ll need to provide evidence of the financial information you’ve given us through this service.') }}</p>
-  {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/checker/result/face-to-face.html
+++ b/cla_public/templates/checker/result/face-to-face.html
@@ -71,7 +71,7 @@
     {% endif %}
 
     {% include "checker/result/_find-legal-adviser.html" %}
-
+    {% include "checker/time-out-warning.html" %}
   {% endblock %}
 
   {% block javascripts %}

--- a/cla_public/templates/checker/result/ineligible.html
+++ b/cla_public/templates/checker/result/ineligible.html
@@ -94,7 +94,7 @@
   </p>
 
   {{ HelpOrganisations.org_list_container(organisations, category_name, truncate=5) }}
-
+  {% include "checker/time-out-warning.html" %}
 {% endblock %}
 
 {% block javascripts %}

--- a/cla_public/templates/checker/review.html
+++ b/cla_public/templates/checker/review.html
@@ -72,5 +72,11 @@
     {{ form.csrf_token }}
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Confirm')) }}
+
+    <p>
+    {% trans %}
+    Your session will time out after 30 minutes of inactivity. We do this for your security.
+    {% endtrans %}
+  </p>
   </form>
 {% endblock %}

--- a/cla_public/templates/checker/review.html
+++ b/cla_public/templates/checker/review.html
@@ -79,4 +79,5 @@
     {% endtrans %}
   </p>
   </form>
+  {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/checker/review.html
+++ b/cla_public/templates/checker/review.html
@@ -73,11 +73,6 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Confirm')) }}
 
-    <p>
-    {% trans %}
-    Your session will time out after 30 minutes of inactivity. We do this for your security.
-    {% endtrans %}
-  </p>
   </form>
   {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/checker/savings.html
+++ b/cla_public/templates/checker/savings.html
@@ -34,6 +34,10 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue')) }}
   </form>
-
+  <p>
+    {% trans %}
+    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    {% endtrans %}
+  </p>
   {{ Element.get_in_touch_link() }}
 {% endblock %}

--- a/cla_public/templates/checker/savings.html
+++ b/cla_public/templates/checker/savings.html
@@ -34,10 +34,6 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue')) }}
   </form>
-  <p>
-    {% trans %}
-    Your session will time out after 30 minutes of inactivity. We do this for your security.
-    {% endtrans %}
-  </p>
+    {% include "time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}
 {% endblock %}

--- a/cla_public/templates/checker/savings.html
+++ b/cla_public/templates/checker/savings.html
@@ -34,6 +34,6 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue')) }}
   </form>
-    {% include "time-out-warning.html" %}
+    {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}
 {% endblock %}

--- a/cla_public/templates/checker/savings.html
+++ b/cla_public/templates/checker/savings.html
@@ -36,7 +36,7 @@
   </form>
   <p>
     {% trans %}
-    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    Your session will time out after 30 minutes of inactivity. We do this for your security.
     {% endtrans %}
   </p>
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/checker/time-out-warning.html
+++ b/cla_public/templates/checker/time-out-warning.html
@@ -1,0 +1,5 @@
+  <p>
+    {% trans %}
+    Your session will time out after 30 minutes of inactivity. We do this for your security.
+    {% endtrans %}
+  </p>

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -174,4 +174,5 @@
       </p>
     </div>
   </script>
+  {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -107,7 +107,7 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Submit details')) }}
   </form>
-
+  {% include "checker/time-out-warning.html" %}
   {% block notice %}
     <p class="notice">
       {% trans privacy_link=Element.link_new_window(url_for('base.privacy'), _('Civil Legal Advice Privacy Statement')) %}
@@ -174,5 +174,4 @@
       </p>
     </div>
   </script>
-  {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/cookies.html
+++ b/cla_public/templates/cookies.html
@@ -131,4 +131,5 @@
       You can read more about {{ govuk_cookies_link }}.
     {% endtrans %}
   </p>
+  {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/feedback-confirmation.html
+++ b/cla_public/templates/feedback-confirmation.html
@@ -15,4 +15,5 @@
       {{ _('Back to home page') }}
     </a>
   </p>
+  {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/feedback.html
+++ b/cla_public/templates/feedback.html
@@ -39,4 +39,5 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Send feedback')) }}
   </form>
+  {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/interstitial.html
+++ b/cla_public/templates/interstitial.html
@@ -90,5 +90,5 @@
       </p>
     {% endcall %}
   {% endif %}
-
+{% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/online-safety.html
+++ b/cla_public/templates/online-safety.html
@@ -41,4 +41,5 @@
     <li>{{ _('<strong>Incognito</strong> on Google Chrome') }}</li>
     <li>{{ _('<strong>Private Window</strong> on Safari') }}</li>
   </ul>
+  {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -628,4 +628,5 @@
     {% trans %}If you would like to make a complaint about this statement and how it applies to you then please
     contact <abbr title="Civil Legal Advice">CLA</abbr> on <span class="tel">0345 345 4 345</span>.{% endtrans %}
   </p>
+  {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/reasons-for-contacting.html
+++ b/cla_public/templates/reasons-for-contacting.html
@@ -25,6 +25,7 @@
     {{ Form.honeypot(form) }}
     {{ Form.actions(_('Continue to contact CLA')) }}
   </form>
+  {% include "checker/time-out-warning.html" %}
 {% endblock %}
 
 {% block javascripts %}

--- a/cla_public/templates/scope/diagnosis.html
+++ b/cla_public/templates/scope/diagnosis.html
@@ -71,7 +71,7 @@
   </div>
   <p>
     {% trans %}
-    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    Your session will time out after 30 minutes of inactivity. We do this for your security.
     {% endtrans %}
   </p>
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/scope/diagnosis.html
+++ b/cla_public/templates/scope/diagnosis.html
@@ -69,11 +69,7 @@
       {% endfor %}
     </ul>
   </div>
-  <p>
-    {% trans %}
-    Your session will time out after 30 minutes of inactivity. We do this for your security.
-    {% endtrans %}
-  </p>
+  {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}
   
 {% endblock %}

--- a/cla_public/templates/scope/diagnosis.html
+++ b/cla_public/templates/scope/diagnosis.html
@@ -69,6 +69,11 @@
       {% endfor %}
     </ul>
   </div>
-
+  <p>
+    {% trans %}
+    Your session will time out after 5 minutes of inactivity. We do this for your security.
+    {% endtrans %}
+  </p>
   {{ Element.get_in_touch_link() }}
+  
 {% endblock %}

--- a/cla_public/templates/scope/ineligible.html
+++ b/cla_public/templates/scope/ineligible.html
@@ -69,7 +69,7 @@
 
     {% call HelpOrganisations.org_list_container(organisations, category_name, truncate=truncate) %}
       <h2>{% trans category_name=category_name|lower %}Help organisations for problems about {{ category_name }}{% endtrans %}</h2>
-    {% include "checker/time-out-warning.html" %}
     {% endcall %}
   {% endif %}
+  {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/scope/ineligible.html
+++ b/cla_public/templates/scope/ineligible.html
@@ -69,6 +69,7 @@
 
     {% call HelpOrganisations.org_list_container(organisations, category_name, truncate=truncate) %}
       <h2>{% trans category_name=category_name|lower %}Help organisations for problems about {{ category_name }}{% endtrans %}</h2>
+    {% include "checker/time-out-warning.html" %}
     {% endcall %}
   {% endif %}
 {% endblock %}

--- a/cla_public/templates/scope/mediation.html
+++ b/cla_public/templates/scope/mediation.html
@@ -20,6 +20,7 @@
           <a href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">What did you think of this service?</a> (takes 30 seconds)
       {% endtrans %}
     </p>
+    {% include "checker/time-out-warning.html" %}
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
## What does this pull request do?

This adds text at the bottom of key pages in the user flow warning users that their session expires after 30 minutes of inactivity.

## Any other changes that would benefit highlighting?


## Checklist

This is related to ticket LGA-584
https://dsdmoj.atlassian.net/browse/LGA-584
