### PR TITLE
LGA-709 - Add page-title class to h1 that have the page title

### DIFF
--- a/cla_public/templates/checker/about.html
+++ b/cla_public/templates/checker/about.html
@@ -1,7 +1,7 @@
 {% extends "checker/base.html" %}
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
   <form method="POST">
     {{ form.csrf_token }}
     {{ Form.handle_errors(form) }}

--- a/cla_public/templates/checker/additional-benefits.html
+++ b/cla_public/templates/checker/additional-benefits.html
@@ -1,7 +1,7 @@
 {% extends "checker/base.html" %}
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
   <p>{{ _('You’ll need to provide evidence of the financial information you’ve given us through this service.') }}</p>
 
   <form method="POST">

--- a/cla_public/templates/checker/benefits.html
+++ b/cla_public/templates/checker/benefits.html
@@ -7,7 +7,7 @@
 {% endmacro %}
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
 
   <form method="POST">
     {{ form.csrf_token }}

--- a/cla_public/templates/checker/income.html
+++ b/cla_public/templates/checker/income.html
@@ -1,7 +1,7 @@
 {% extends "checker/base.html" %}
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
   <p>{{ _('You’ll need to provide evidence of the financial information you’ve given us through this service.') }}</p>
   <p>
     <strong>{% trans %}We only need to know about any money you received last month, even if this varies from month to month.{% endtrans %}</strong>

--- a/cla_public/templates/checker/outgoings.html
+++ b/cla_public/templates/checker/outgoings.html
@@ -1,7 +1,7 @@
 {% extends "checker/base.html" %}
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
   <p>{{ _('You’ll need to provide evidence of the financial information you’ve given us through this service.') }}</p>
 
   <form method="POST">

--- a/cla_public/templates/checker/property.html
+++ b/cla_public/templates/checker/property.html
@@ -1,7 +1,7 @@
 {% extends "checker/base.html" %}
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
 
   {% if session.checker.has_partner %}
     <p>{{ _('Please tell us about any property owned by you, your partner or both of you.') }}</p>

--- a/cla_public/templates/checker/result/confirmation.html
+++ b/cla_public/templates/checker/result/confirmation.html
@@ -12,7 +12,7 @@
 
 {% block inner_content %}
   <header class="confirmation">
-    <h1>
+    <h1 class="page-title">
       {% if session.stored.callback_requested %}
         {{ _('We will call you back') }}
       {% else %}

--- a/cla_public/templates/checker/result/eligible-f2f.html
+++ b/cla_public/templates/checker/result/eligible-f2f.html
@@ -12,7 +12,7 @@
   {% block sidebar %}{% endblock %}
 
   {% block inner_content %}
-    <h1>{{ title }}</h1>
+    <h1 class="page-title">{{ title }}</h1>
 
     <p>
       {% trans %}Civil Legal Advice does not provide advice about issues

--- a/cla_public/templates/checker/result/eligible.html
+++ b/cla_public/templates/checker/result/eligible.html
@@ -3,7 +3,7 @@
 {% import "macros/element.html" as Element %}
 
 {% block page_text %}
-  <h1>
+  <h1 class="page-title">
     {% trans %}Contact Civil Legal Advice{% endtrans %}
   </h1>
   {% if session.checker.need_more_info %}

--- a/cla_public/templates/checker/result/face-to-face.html
+++ b/cla_public/templates/checker/result/face-to-face.html
@@ -20,7 +20,7 @@
   {% block inner_content %}
 
     {% if category == 'clinneg' %}
-      <h1>{{ _('A legal adviser may be able to help you') }}</h1>
+      <h1 class="page-title">{{ _('A legal adviser may be able to help you') }}</h1>
 
       <p>
         {% trans %}You will usually only get legal aid for advice about
@@ -34,7 +34,7 @@
       </p>
 
     {% elif category == 'pi' %}
-      <h1>{{ _('Legal aid is not usually available for advice about personal injury') }}</h1>
+      <h1 class="page-title">{{ _('Legal aid is not usually available for advice about personal injury') }}</h1>
 
       <p>
         {% trans %}You may be able to get legal aid in exceptional cases. You
@@ -43,10 +43,10 @@
       </p>
 
     {% elif category == 'debt' or category == 'housing' %}
-      <h1>{{ _('A legal adviser may be able to help you') }}</h1>
+      <h1 class="page-title">{{ _('A legal adviser may be able to help you') }}</h1>
 
     {% else %}
-      <h1>{{ _('A legal adviser may be able to help you') }}</h1>
+      <h1 class="page-title">{{ _('A legal adviser may be able to help you') }}</h1>
     {% endif %}
 
     <p>

--- a/cla_public/templates/checker/result/ineligible.html
+++ b/cla_public/templates/checker/result/ineligible.html
@@ -11,7 +11,7 @@
 {% set _tag = 'li' if multi else 'p' %}
 
 {% block inner_content %}
-  <h1>{{ _('You’re unlikely to get legal aid') }}</h1>
+  <h1 class="page-title">{{ _('You’re unlikely to get legal aid') }}</h1>
 
   <p>
     {% trans fromcla = _('from CLA') if category == 'violence' else '' %}From

--- a/cla_public/templates/checker/review.html
+++ b/cla_public/templates/checker/review.html
@@ -5,7 +5,7 @@
 {% import "macros/review.html" as Review %}
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
 
   <form method="POST" class="answers-summary">
     {% if session.checker.scope_answers %}

--- a/cla_public/templates/checker/savings.html
+++ b/cla_public/templates/checker/savings.html
@@ -1,7 +1,7 @@
 {% extends "checker/base.html" %}
 
 {% block inner_content %}
-  <h1>
+  <h1 class="page-title">
     {{ form.title }}
   </h1>
 

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -18,7 +18,7 @@
         <p>{{ _('The full service is currently unavailable. However, you can still get in touch using the form below.') }}</p>
       {% endcall %}
     {% endif %}
-    <h1>{{ title }}</h1>
+    <h1 class="page-title">{{ title }}</h1>
     {#
       'n18' is the index of the node which corresponds to 'yes' in response
       to question 'Are you at immediate risk of harm?'

--- a/cla_public/templates/cookies.html
+++ b/cla_public/templates/cookies.html
@@ -6,7 +6,7 @@
 {% block page_title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
 
   <p>{{ _('GOV.UK puts small files (known as ’cookies’) onto your computer to collect information about how you browse the site.') }}</p>
   <p>{{ _('Cookies are used to:') }}</p>

--- a/cla_public/templates/errors/404.html
+++ b/cla_public/templates/errors/404.html
@@ -3,7 +3,7 @@
 {% block page_title %}404: {{ _('Page not found') }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1>{{ _('Sorry, this page doesn’t exist') }}</h1>
+  <h1 class="page-title">{{ _('Sorry, this page doesn’t exist') }}</h1>
   <p>{{ _('Please return to the <a href="/">Can I get legal aid?</a> page and try again.') }}</p>
 {% endblock %}
 

--- a/cla_public/templates/errors/4xx.html
+++ b/cla_public/templates/errors/4xx.html
@@ -4,7 +4,7 @@
 {% block page_title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
   <p>{{ _('Please return to the <a href="/">Find out if Civil Legal Advice can help you</a> page and try again.') }}</p>
 {% endblock %}
 

--- a/cla_public/templates/feedback-confirmation.html
+++ b/cla_public/templates/feedback-confirmation.html
@@ -7,7 +7,7 @@
 {% block page_title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
   <p>{{ _('We use the feedback to improve the service.')}} </p>
 
   <p>

--- a/cla_public/templates/feedback.html
+++ b/cla_public/templates/feedback.html
@@ -7,7 +7,7 @@
 {% block page_title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
   <p class="subtitle">
     {% trans %}Please don't include any personal or financial details,
     for example, your National Insurance or credit card numbers.{% endtrans %}

--- a/cla_public/templates/index.html
+++ b/cla_public/templates/index.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block inner_content %}
-  <h1>Check if you can get legal aid</h1>
+  <h1 class="page-title">Check if you can get legal aid</h1>
   <p>Legal aid can help pay for legal advice.</p>
   <p>This service will check that your problem is covered by legal aid.</p>
   <ul>

--- a/cla_public/templates/interstitial.html
+++ b/cla_public/templates/interstitial.html
@@ -19,7 +19,7 @@
 
 {% block inner_content %}
 
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
 
   <p class="subtitle">
     {{ _('However, you must also qualify financially.') }}

--- a/cla_public/templates/laalaa.html
+++ b/cla_public/templates/laalaa.html
@@ -16,7 +16,7 @@
   {% block sidebar %}{% endblock %}
 
   {% block inner_content %}
-    <h1>{{ title }}</h1>
+    <h1 class="page-title">{{ title }}</h1>
 
     <p>
       {% if category == 'family' %}

--- a/cla_public/templates/online-safety.html
+++ b/cla_public/templates/online-safety.html
@@ -3,7 +3,7 @@
 {% block page_title %}{{ _('Staying safe online') }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1>{{ _('Staying safe online') }}</h1>
+  <h1 class="page-title">{{ _('Staying safe online') }}</h1>
 
   <p>{{ _('It can be easy for other people to see what you’re doing online, especially if you’re using a home computer.') }}</p>
   <p>{{ _(' You can make it more difficult by following the tips below. But your safest option is to use a different computer - for example, at your local library - or someone else’s mobile.') }}</p>

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -3,7 +3,7 @@
 {% block page_title %}{{ _('Privacy Statement') }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1>{{ _('Terms and conditions and privacy') }}</h1>
+  <h1 class="page-title">{{ _('Terms and conditions and privacy') }}</h1>
 
   <p>
     {% trans %}When using this service you agree to the terms of use for both <a href="http://gov.uk/help/terms-conditions">gov.uk/help/terms-conditions</a> as well as

--- a/cla_public/templates/reasons-for-contacting.html
+++ b/cla_public/templates/reasons-for-contacting.html
@@ -7,7 +7,7 @@
 {% block page_title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
   <p class="subtitle">
     {% trans %}So we can improve this service, we'd like to understand why you want to contact <abbr title="Civil Legal Advice">CLA</abbr>.{% endtrans %}
   </p>

--- a/cla_public/templates/scope/diagnosis.html
+++ b/cla_public/templates/scope/diagnosis.html
@@ -49,7 +49,7 @@
 
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
 
   {% if not nodes|length or nodes and nodes[-1].data_safety %}
     {{ Element.staying_safe_online_link() }}

--- a/cla_public/templates/scope/ineligible.html
+++ b/cla_public/templates/scope/ineligible.html
@@ -40,7 +40,7 @@
 {% endblock %}
 
 {% block inner_content %}
-  <h1>{{ title }}</h1>
+  <h1 class="page-title">{{ title }}</h1>
 
   {% if category != 'other' %}
     <p>

--- a/cla_public/templates/scope/mediation.html
+++ b/cla_public/templates/scope/mediation.html
@@ -6,7 +6,7 @@
 
 {% block inner_content %}
 
-  <h1>{{ _('You may be able to get legal aid for family mediation') }}</h1>
+  <h1 class="page-title">{{ _('You may be able to get legal aid for family mediation') }}</h1>
   <p class="subtitle">
     {{ _('Search for a family mediator in your area to find out if you qualify.') }}
   </p>

--- a/cla_public/templates/session-expired.html
+++ b/cla_public/templates/session-expired.html
@@ -3,7 +3,7 @@
 {% block page_title %}{{ _('You’ve reached the end of this service') }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1>{{ _('You’ve reached the end of this service') }}</h1>
+  <h1 class="page-title">{{ _('You’ve reached the end of this service') }}</h1>
 
   <p>{{ _('For your security, the information you’ve entered has automatically been deleted.') }}</p>
   <p>{{ _('You can start again below.') }}</p>


### PR DESCRIPTION
## What does this pull request do?

The end-to-end tests have been broken for a while due to timeout changes introduced in https://github.com/ministryofjustice/cla_public/pull/851

This PR adds a .page-title class to the `<h1>` tags that contain the page title so the tests can match for those with class selectors

## Any other changes that would benefit highlighting?

https://github.com/ministryofjustice/laa-cla-e2e-tests/pull/62 - PR for end-to-end tests that uses the changes introduced in this PR

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
