### PR TITLE
LGA-753 - fix validation error message for invalid time slot

### DIFF
--- a/cla_public/apps/contact/fields.py
+++ b/cla_public/apps/contact/fields.py
@@ -136,7 +136,7 @@ class AvailableSlot(object):
             date = form.day.data
         time = datetime.datetime.combine(date, field.data) if date else None
         if not (time and OPERATOR_HOURS.can_schedule_callback(time)):
-            raise ValidationError(field.gettext(u"Can't schedule a callback at the requested time"))
+            raise ValidationError([field.gettext(u"Can't schedule a callback at the requested time")])
 
 
 class AvailabilityCheckerForm(NoCsrfForm):


### PR DESCRIPTION
To fix the display issue of the front end splitting the string into
individual letters because it's expecting an iterable of messages.

## What does this pull request do?

Required.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
