### PR TITLE
LGA-767 - Add warning message in Edge

### DIFF
--- a/cla_public/templates/checker/about.html
+++ b/cla_public/templates/checker/about.html
@@ -1,7 +1,16 @@
 {% extends "checker/base.html" %}
+{% import "macros/element.html" as Element %}
 
 {% block inner_content %}
   <h1 class="page-title">{{ title }}</h1>
+
+  <div class="edge-warning" style="display:none">
+    {% call Element.alert('error', icon='cross', title='This service does not currently support Microsoft Edge') %}
+      <p>Please use an alternative browser if you are using Microsoft Edge.</p>
+      <p>If you need information about installing a new browser, please visit the <a href="https://www.gov.uk/help/browsers">browser help page</a>.</p>
+    {% endcall %}
+  </div>
+
   <form method="POST">
     {{ form.csrf_token }}
     {{ Form.handle_errors(form) }}
@@ -48,4 +57,14 @@
     };
   </script>
 
+{% endblock %}
+
+
+{% block javascripts %}
+  {{ super() }}
+  <script>
+    if(window.navigator.userAgent.indexOf("Edge") > -1) {
+        $('.edge-warning').show();
+    }
+  </script>
 {% endblock %}

--- a/cla_public/templates/scope/diagnosis.html
+++ b/cla_public/templates/scope/diagnosis.html
@@ -55,6 +55,13 @@
     {{ Element.staying_safe_online_link() }}
   {% endif %}
 
+  <div class="edge-warning" style="display:none">
+    {% call Element.alert('error', icon='cross', title='This service does not currently support Microsoft Edge') %}
+      <p>Please use an alternative browser if you are using Microsoft Edge.</p>
+      <p>If you need information about installing a new browser, please visit the <a href="https://www.gov.uk/help/browsers">browser help page</a>.</p>
+    {% endcall %}
+  </div>
+
   <div class="scope-options">
     <ul class="scope-options-list">
       {% for choice in choices %}
@@ -72,4 +79,14 @@
   {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}
   
+{% endblock %}
+
+
+{% block javascripts %}
+  {{ super() }}
+  <script>
+    if(window.navigator.userAgent.indexOf("Edge") > -1) {
+        $('.edge-warning').show();
+    }
+  </script>
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Adds the following warning to the scope diagnosis and means checker pages when viewed in Edge
![image](https://user-images.githubusercontent.com/1237986/63108392-a5cd7200-bf7e-11e9-8bd3-12638d2dbd6a.png)


## Any other changes that would benefit highlighting?


## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
