### PR TITLE
LGA 752 remove survey

### DIFF
--- a/cla_public/apps/base/constants.py
+++ b/cla_public/apps/base/constants.py
@@ -16,10 +16,9 @@ FEEL_ABOUT_SERVICE = zip(FEEL_ABOUT_SERVICE_LABELS, FEEL_ABOUT_SERVICE_LABELS)
 # Feedback: help filling in the form
 HELP_FILLING_IN_FORM_LABELS = [
     _(u"No, I filled in this form myself"),
-    _(u"I have difficulty using computers so someone filled in this form for me"),
+    _(u"I had help filling in this form"),
+    _(u"Someone else filled in this form for me"),
     _(u"I used an accessibility tool such as a screen reader"),
-    _(u"I had some other kind of help"),
-]
 
 HELP_FILLING_IN_FORM = zip(HELP_FILLING_IN_FORM_LABELS, HELP_FILLING_IN_FORM_LABELS)
 

--- a/cla_public/apps/base/constants.py
+++ b/cla_public/apps/base/constants.py
@@ -19,6 +19,7 @@ HELP_FILLING_IN_FORM_LABELS = [
     _(u"I had help filling in this form"),
     _(u"Someone else filled in this form for me"),
     _(u"I used an accessibility tool such as a screen reader"),
+]
 
 HELP_FILLING_IN_FORM = zip(HELP_FILLING_IN_FORM_LABELS, HELP_FILLING_IN_FORM_LABELS)
 

--- a/cla_public/apps/base/forms.py
+++ b/cla_public/apps/base/forms.py
@@ -44,7 +44,8 @@ class FeedbackForm(Honeypot, BabelTranslationsFormMixin, Form):
     referrer = StringField(widget=widgets.HiddenInput())
 
     difficulty = TextAreaField(
-        label=_(u"Did you have difficulty using this service? Tell us about the problem."), validators=[_textarea_length_validator]
+        label=_(u"Did you have difficulty using this service? Tell us about the problem."),
+        validators=[_textarea_length_validator],
     )
 
     ideas = TextAreaField(

--- a/cla_public/apps/base/forms.py
+++ b/cla_public/apps/base/forms.py
@@ -44,7 +44,7 @@ class FeedbackForm(Honeypot, BabelTranslationsFormMixin, Form):
     referrer = StringField(widget=widgets.HiddenInput())
 
     difficulty = TextAreaField(
-        label=_(u"Did you have any difficulty with this service?"), validators=[_textarea_length_validator]
+        label=_(u"Did you have any difficulty using this service? Tell us about the problem."), validators=[_textarea_length_validator]
     )
 
     ideas = TextAreaField(

--- a/cla_public/apps/base/forms.py
+++ b/cla_public/apps/base/forms.py
@@ -44,7 +44,7 @@ class FeedbackForm(Honeypot, BabelTranslationsFormMixin, Form):
     referrer = StringField(widget=widgets.HiddenInput())
 
     difficulty = TextAreaField(
-        label=_(u"Did you have any difficulty using this service? Tell us about the problem."), validators=[_textarea_length_validator]
+        label=_(u"Did you have difficulty using this service? Tell us about the problem."), validators=[_textarea_length_validator]
     )
 
     ideas = TextAreaField(

--- a/cla_public/static-templates/errors/50x.html
+++ b/cla_public/static-templates/errors/50x.html
@@ -111,7 +111,7 @@
       <section id="content" role="main">
         <div class="phase-banner">
           <p>
-            <span id="aria-feedback"><a href="https://checklegalaid.service.gov.uk/reasons-for-contacting">Report a problem</a> if you need help or would like to give feedback to improve this service</span>
+            <span id="aria-feedback"><a href="/reasons-for-contacting">Report a problem</a> if you need help or would like to give feedback to improve this service</span>
           </p>
         </div>
         <div class="inner-block ">

--- a/cla_public/static-templates/errors/50x.html
+++ b/cla_public/static-templates/errors/50x.html
@@ -111,7 +111,7 @@
       <section id="content" role="main">
         <div class="phase-banner">
           <p>
-            <span id="aria-feedback">Your <a href="/feedback" aria-labelledby="aria-feedback">feedback</a> will help us continue to improve this service.</span>
+            <span id="aria-feedback"><a href="https://checklegalaid.service.gov.uk/feedback">Contact us</a> if you need help or would like to give feedback to improve this service</span>
           </p>
         </div>
         <div class="inner-block ">

--- a/cla_public/static-templates/errors/50x.html
+++ b/cla_public/static-templates/errors/50x.html
@@ -111,7 +111,7 @@
       <section id="content" role="main">
         <div class="phase-banner">
           <p>
-            <span id="aria-feedback"><a href="https://checklegalaid.service.gov.uk/feedback">Contact us</a> if you need help or would like to give feedback to improve this service</span>
+            <span id="aria-feedback"><a href="https://checklegalaid.service.gov.uk/reasons-for-contacting">Report a problem</a> if you need help or would like to give feedback to improve this service</span>
           </p>
         </div>
         <div class="inner-block ">
@@ -135,7 +135,7 @@
             <ul>
               <li><a href="/privacy">Privacy Policy</a></li>
               <li><a href="/cookies">Cookies</a></li>
-              <li><a href="/feedback">Feedback</a></li>
+              <li><a href="/reasons-for-contacting">Contact us</a></li>
               <li>
                 Built by
                 <a href="https://mojdigital.blog.gov.uk/"><abbr title="Ministry of Justice">MOJ</abbr> Digital Services</a>

--- a/cla_public/templates/_phase-tag.html
+++ b/cla_public/templates/_phase-tag.html
@@ -13,7 +13,7 @@
 
   <p>
     <span id="aria-feedback">
-      <a href="/reasons-for-contacting">Contact us</a> if you need help or would like to give feedback to improve this service
+      <a href="{{ url_for('base.reasons_for_contacting')}}">Contact us</a> if you need help or would like to give feedback to improve this service
   </p>
 
 </div>

--- a/cla_public/templates/_phase-tag.html
+++ b/cla_public/templates/_phase-tag.html
@@ -13,14 +13,7 @@
 
   <p>
     <span id="aria-feedback">
-      Tell us about your experiences. Your
-      <a
-        rel="noopener noreferrer"
-        target="_blank"
-        href="https://www.surveymonkey.co.uk/r/LegalInfoJourneyMapping_CLA"
-        aria-labelledby="aria-feedback">
-        feedback<span class="visuallyhidden">(Opens in a new window)</span></a>
-        will help us continue to improve this service.</span>
+      <a href="https://checklegalaid.service.gov.uk/feedback">Contact us</a> if you need help or would like to give feedback to improve this service.
   </p>
 
 </div>

--- a/cla_public/templates/_phase-tag.html
+++ b/cla_public/templates/_phase-tag.html
@@ -13,7 +13,7 @@
 
   <p>
     <span id="aria-feedback">
-      <a href="https://checklegalaid.service.gov.uk/feedback">Contact us</a> if you need help or would like to give feedback to improve this service.
+      <a href="https://checklegalaid.service.gov.uk/feedback">Contact us</a> if you need help or would like to give feedback to improve this service
   </p>
 
 </div>

--- a/cla_public/templates/_phase-tag.html
+++ b/cla_public/templates/_phase-tag.html
@@ -13,7 +13,7 @@
 
   <p>
     <span id="aria-feedback">
-      <a href="https://checklegalaid.service.gov.uk/feedback">Contact us</a> if you need help or would like to give feedback to improve this service
+      <a href="https://checklegalaid.service.gov.uk/reasons-for-contacting">Contact us</a> if you need help or would like to give feedback to improve this service
   </p>
 
 </div>

--- a/cla_public/templates/_phase-tag.html
+++ b/cla_public/templates/_phase-tag.html
@@ -13,7 +13,7 @@
 
   <p>
     <span id="aria-feedback">
-      <a href="https://checklegalaid.service.gov.uk/reasons-for-contacting">Contact us</a> if you need help or would like to give feedback to improve this service
+      <a href="/reasons-for-contacting">Contact us</a> if you need help or would like to give feedback to improve this service
   </p>
 
 </div>

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -129,5 +129,5 @@
   <li><a href="{{ url_for('base.online_safety') }}">{{ _('Staying safe online') }}</a></li>
   <li><a href="{{ url_for('base.privacy') }}">{{ _('Privacy Policy') }}</a></li>
   <li><a href="{{ url_for('base.cookies') }}">{{ _('Cookies') }}</a></li>
-  <li><a href="https://checklegalaid.service.gov.uk/reasons-for-contacting">{{ _('Contact us') }}</a></li>
+  <li><a href="https://checklegalaid.service.gov.uk/reasons-for-contacting">{{ _('Contact') }}</a></li>
 {% endblock %}

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -129,5 +129,5 @@
   <li><a href="{{ url_for('base.online_safety') }}">{{ _('Staying safe online') }}</a></li>
   <li><a href="{{ url_for('base.privacy') }}">{{ _('Privacy Policy') }}</a></li>
   <li><a href="{{ url_for('base.cookies') }}">{{ _('Cookies') }}</a></li>
-  <li><a href="{{ url_for('base.feedback') }}">{{ _('Contact us') }}</a></li>
+  <li><a href="https://checklegalaid.service.gov.uk/reasons-for-contacting">{{ _('Contact us') }}</a></li>
 {% endblock %}

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -129,5 +129,5 @@
   <li><a href="{{ url_for('base.online_safety') }}">{{ _('Staying safe online') }}</a></li>
   <li><a href="{{ url_for('base.privacy') }}">{{ _('Privacy Policy') }}</a></li>
   <li><a href="{{ url_for('base.cookies') }}">{{ _('Cookies') }}</a></li>
-  <li><a href="{{ url_for('base.feedback') }}">{{ _('Feedback') }}</a></li>
+  <li><a href="{{ url_for('base.feedback') }}">{{ _('Contact us') }}</a></li>
 {% endblock %}

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -129,5 +129,5 @@
   <li><a href="{{ url_for('base.online_safety') }}">{{ _('Staying safe online') }}</a></li>
   <li><a href="{{ url_for('base.privacy') }}">{{ _('Privacy Policy') }}</a></li>
   <li><a href="{{ url_for('base.cookies') }}">{{ _('Cookies') }}</a></li>
-  <li><a href="https://checklegalaid.service.gov.uk/reasons-for-contacting">{{ _('Contact') }}</a></li>
+  <li><a href="{{ url_for('base.reasons_for_contacting')}}">{{ _('Contact') }}</a></li>
 {% endblock %}

--- a/cla_public/templates/feedback.html
+++ b/cla_public/templates/feedback.html
@@ -25,9 +25,6 @@
       {% endcall %}
     {% endif %}
 
-    {% call Form.fieldset(form.feel_about_service, field_as_label=True) %}
-      {{ Form.option_list(form.feel_about_service) }}
-    {% endcall %}
 
     {% call Form.fieldset(form.help_filling_in_form, field_as_label=True) %}
       {{ Form.option_list(form.help_filling_in_form) }}

--- a/cla_public/templates/feedback.html
+++ b/cla_public/templates/feedback.html
@@ -3,7 +3,7 @@
 {% import "macros/form.html" as Form %}
 {% import "macros/element.html" as Element %}
 
-{% set title = _('Contact us') %}
+{% set title = _('Report a problem') %}
 {% block page_title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
@@ -34,7 +34,7 @@
     {{ Form.group(form.ideas, field_attrs={'class': 'm-full', 'rows': 6}) }}
 
     {{ Form.honeypot(form) }}
-    {{ Form.actions(_('Send')) }}
+    {{ Form.actions(_('Continue to contact CLA')) }}
   </form>
   {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/feedback.html
+++ b/cla_public/templates/feedback.html
@@ -3,7 +3,7 @@
 {% import "macros/form.html" as Form %}
 {% import "macros/element.html" as Element %}
 
-{% set title = _('Your feedback') %}
+{% set title = _('Contact us') %}
 {% block page_title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
@@ -34,7 +34,7 @@
     {{ Form.group(form.ideas, field_attrs={'class': 'm-full', 'rows': 6}) }}
 
     {{ Form.honeypot(form) }}
-    {{ Form.actions(_('Send feedback')) }}
+    {{ Form.actions(_('Send')) }}
   </form>
   {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -92,7 +92,7 @@ msgid "Another reason"
 msgstr "Rheswm arall"
 
 #: cla_public/apps/base/forms.py:46
-msgid "Did you have any difficulty with this service?"
+msgid "Did you have any difficulty using this service? Tell us about the problem."
 msgstr "A gawsoch unrhyw anhawster gyda'r gwasanaeth hwn?"
 
 #: cla_public/apps/base/forms.py:49

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -47,9 +47,8 @@ msgid "No, I filled in this form myself"
 msgstr "Na, llenwais y ffurflen hon fy hun"
 
 #: cla_public/apps/base/constants.py:19
-msgid ""
-"I had help filling in this form"
-msgstr ""
+msgid "I had help filling in this form"
+msgstr "Cefais rhyw fath arall o help"
 
 #: cla_public/apps/base/constants.py:20
 "Someone else filled in this form for me"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -92,7 +92,7 @@ msgid "Another reason"
 msgstr "Rheswm arall"
 
 #: cla_public/apps/base/forms.py:46
-msgid "Did you have any difficulty using this service? Tell us about the problem."
+msgid "Did you have difficulty using this service? Tell us about the problem."
 msgstr "A gawsoch unrhyw anhawster gyda'r gwasanaeth hwn?"
 
 #: cla_public/apps/base/forms.py:49

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -48,16 +48,16 @@ msgstr "Na, llenwais y ffurflen hon fy hun"
 
 #: cla_public/apps/base/constants.py:19
 msgid ""
-"I have difficulty using computers so someone filled in this form for me"
-msgstr "Rwyf yn cael trafferth defnyddio cyfrifiaduron, felly llenwodd rhywun arall y ffurflen hon ar fy rhan"
+"I had help filling in this form"
+msgstr ""
 
 #: cla_public/apps/base/constants.py:20
-msgid "I used an accessibility tool such as a screen reader"
-msgstr "Defnyddiais offer hygyrchedd megis darllenydd sgrîn"
+"Someone else filled in this form for me"
+msgstr "Rwyf yn cael trafferth defnyddio cyfrifiaduron, felly llenwodd rhywun arall y ffurflen hon ar fy rhan"
 
 #: cla_public/apps/base/constants.py:21
-msgid "I had some other kind of help"
-msgstr "Cefais rhyw fath arall o help"
+msgid "I used an accessibility tool such as a screen reader"
+msgstr "Defnyddiais offer hygyrchedd megis darllenydd sgrîn"
 
 #: cla_public/apps/base/constants.py:29
 msgid "I don’t know how to answer a question"

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -86,7 +86,7 @@ msgid "Another reason"
 msgstr ""
 
 #: cla_public/apps/base/forms.py:46
-msgid "Did you have any difficulty with this service?"
+msgid "Did you have any difficulty using this service? Tell us about the problem."
 msgstr ""
 
 #: cla_public/apps/base/forms.py:49

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -42,15 +42,15 @@ msgid "No, I filled in this form myself"
 msgstr ""
 
 #: cla_public/apps/base/constants.py:19
-msgid "I have difficulty using computers so someone filled in this form for me"
+msgid "I had help filling in this form"
 msgstr ""
 
 #: cla_public/apps/base/constants.py:20
-msgid "I used an accessibility tool such as a screen reader"
+msgid "Someone else filled in this form for me"
 msgstr ""
 
 #: cla_public/apps/base/constants.py:21
-msgid "I had some other kind of help"
+msgid "I used an accessibility tool such as a screen reader"
 msgstr ""
 
 #: cla_public/apps/base/constants.py:29

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -86,7 +86,7 @@ msgid "Another reason"
 msgstr ""
 
 #: cla_public/apps/base/forms.py:46
-msgid "Did you have any difficulty using this service? Tell us about the problem."
+msgid "Did you have difficulty using this service? Tell us about the problem."
 msgstr ""
 
 #: cla_public/apps/base/forms.py:49

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -86,7 +86,7 @@ msgid "Another reason"
 msgstr ""
 
 #: cla_public/apps/base/forms.py:46
-msgid "Did you have any difficulty with this service?"
+msgid "Did you have any difficulty using this service? Tell us about the problem."
 msgstr ""
 
 #: cla_public/apps/base/forms.py:49

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -42,15 +42,15 @@ msgid "No, I filled in this form myself"
 msgstr ""
 
 #: cla_public/apps/base/constants.py:19
-msgid "I have difficulty using computers so someone filled in this form for me"
+msgid "I had help filling in this form"
 msgstr ""
 
 #: cla_public/apps/base/constants.py:20
-msgid "I used an accessibility tool such as a screen reader"
+msgid "Someone else filled in this form for me"
 msgstr ""
 
 #: cla_public/apps/base/constants.py:21
-msgid "I had some other kind of help"
+msgid "I used an accessibility tool such as a screen reader"
 msgstr ""
 
 #: cla_public/apps/base/constants.py:29

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -86,7 +86,7 @@ msgid "Another reason"
 msgstr ""
 
 #: cla_public/apps/base/forms.py:46
-msgid "Did you have any difficulty using this service? Tell us about the problem."
+msgid "Did you have difficulty using this service? Tell us about the problem."
 msgstr ""
 
 #: cla_public/apps/base/forms.py:49


### PR DESCRIPTION
## What does this pull request do?

This PR replaces the Survey Monkey feedback link in the header and the Zendesk link in the footer with the Contact CLA feedback route. This gives users a consistent way of getting help if they have a problem using the service.

## Any other changes that would benefit highlighting?

This PR also includes changes to the feedback form (using zendesk) previously linked from the footer. We are proposing future changes to the feedback route and may use the changed form to capture details if users are experiencing technical issues with the service.

## Checklist
 Related ticket is: https://dsdmoj.atlassian.net/browse/LGA-752
