### PR TITLE
LGA-751 Fixing form submitting on Edge browser

### DIFF
--- a/cla_public/apps/base/forms.py
+++ b/cla_public/apps/base/forms.py
@@ -8,12 +8,7 @@ from flask.ext.babel import lazy_gettext as _, get_translations
 from wtforms import TextAreaField, RadioField, SelectMultipleField, StringField, widgets
 from wtforms.validators import InputRequired, Length
 
-from cla_public.apps.base.constants import (
-    FEEL_ABOUT_SERVICE,
-    HELP_FILLING_IN_FORM,
-    REASONS_FOR_CONTACTING_CHOICES,
-    REASONS_FOR_CONTACTING,
-)
+from cla_public.apps.base.constants import HELP_FILLING_IN_FORM, REASONS_FOR_CONTACTING_CHOICES, REASONS_FOR_CONTACTING
 from cla_public.libs.honeypot import Honeypot
 
 
@@ -50,12 +45,6 @@ class FeedbackForm(Honeypot, BabelTranslationsFormMixin, Form):
 
     ideas = TextAreaField(
         label=_(u"Do you have any ideas for how it could be improved?"), validators=[_textarea_length_validator]
-    )
-
-    feel_about_service = RadioField(
-        _(u"Overall, how did you feel about the service you received today?"),
-        choices=FEEL_ABOUT_SERVICE,
-        validators=[InputRequired()],
     )
 
     help_filling_in_form = RadioField(

--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -95,7 +95,7 @@ class Feedback(AbstractFeedbackView):
         return self.render_form(error)
 
 
-base.add_url_rule("/feedback", view_func=Feedback.as_view("feedback"), methods=("GET", "POST", "OPTIONS"))
+base.add_url_rule("/feedback", view_func=Feedback.as_view("feedback"), methods=("GET", "POST"))
 
 
 @base.route("/feedback/confirmation")
@@ -141,7 +141,7 @@ class ReasonsForContacting(AbstractFeedbackView):
 base.add_url_rule(
     "/reasons-for-contacting",
     view_func=ReasonsForContacting.as_view("reasons_for_contacting"),
-    methods=("GET", "POST", "OPTIONS"),
+    methods=("GET", "POST"),
 )
 
 

--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -16,7 +16,7 @@ from cla_public.apps.base import base, healthchecks
 from cla_public.apps.base.forms import FeedbackForm, ReasonsForContactingForm
 from cla_public.apps.checker.api import post_reasons_for_contacting
 from cla_public.libs import zendesk
-from cla_public.libs.views import HasFormMixin, ValidFormOnOptions
+from cla_public.libs.views import HasFormMixin
 
 log = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ def online_safety():
     return render_template("online-safety.html")
 
 
-class AbstractFeedbackView(HasFormMixin, views.MethodView, ValidFormOnOptions):
+class AbstractFeedbackView(HasFormMixin, views.MethodView):
     """
     Abstract view for feedback forms
     """

--- a/cla_public/apps/checker/views.py
+++ b/cla_public/apps/checker/views.py
@@ -229,7 +229,7 @@ class CheckerWizard(AllowSessionOverride, FormWizard):
         return False
 
 
-checker.add_url_rule("/<step>", view_func=CheckerWizard.as_view("wizard"), methods=("GET", "POST", "OPTIONS"))
+checker.add_url_rule("/<step>", view_func=CheckerWizard.as_view("wizard"), methods=("GET", "POST"))
 
 
 class LaaLaaView(views.MethodView):
@@ -316,11 +316,9 @@ class Eligible(HasFormMixin, RequiresSession, views.MethodView, object):
         return render_template("checker/result/eligible.html", current_step=current_step, steps=steps, form=self.form)
 
 
-checker.add_url_rule("/result/eligible", view_func=Eligible.as_view("eligible"), methods=("GET", "POST", "OPTIONS"))
+checker.add_url_rule("/result/eligible", view_func=Eligible.as_view("eligible"), methods=("GET", "POST"))
 
-checker.add_url_rule(
-    "/result/provisional", view_func=Eligible.as_view("provisional"), methods=("GET", "POST", "OPTIONS")
-)
+checker.add_url_rule("/result/provisional", view_func=Eligible.as_view("provisional"), methods=("GET", "POST"))
 
 
 class HelpOrganisations(views.MethodView):

--- a/cla_public/apps/checker/views.py
+++ b/cla_public/apps/checker/views.py
@@ -177,7 +177,7 @@ class CheckerWizard(AllowSessionOverride, FormWizard):
     def complete(self):
         # TODO: Is this still used now that scope diagnosis is taking care of F2F redirects for certain categories?
         if session.checker.needs_face_to_face:
-            return redirect(url_for(".face-to-face", category=session.checker.category))
+            return self.redirect(url_for(".face-to-face", category=session.checker.category))
 
         if session.checker.ineligible:
             session.store(
@@ -186,14 +186,14 @@ class CheckerWizard(AllowSessionOverride, FormWizard):
                     "outcome": "referred/help-organisations/means",
                 }
             )
-            return redirect(url_for(".help_organisations", category_name=session.checker.category_slug))
+            return self.redirect(url_for(".help_organisations", category_name=session.checker.category_slug))
 
         if session.checker.need_more_info:
             session.store({"outcome": "provisional"})
-            return redirect(url_for(".provisional"))
+            return self.redirect(url_for(".provisional"))
 
         session.store({"outcome": "eligible"})
-        return redirect(url_for(".eligible"))
+        return self.redirect(url_for(".eligible"))
 
     def skip(self, step, for_review_page=False):
 

--- a/cla_public/apps/checker/views.py
+++ b/cla_public/apps/checker/views.py
@@ -32,14 +32,7 @@ from cla_public.apps.checker.means_test import MeansTest, MeansTestError
 from cla_public.apps.checker.validators import IgnoreIf
 from cla_public.apps.checker import filters  # noqa: F401
 from cla_public.libs.utils import override_locale, category_id_to_name
-from cla_public.libs.views import (
-    AllowSessionOverride,
-    FormWizard,
-    FormWizardStep,
-    RequiresSession,
-    ValidFormOnOptions,
-    HasFormMixin,
-)
+from cla_public.libs.views import AllowSessionOverride, FormWizard, FormWizardStep, RequiresSession, HasFormMixin
 from cla_public.libs import laalaa, honeypot
 from cla_public.apps.checker.cait_intervention import get_cait_params
 
@@ -90,7 +83,7 @@ def is_null(field):
     return False
 
 
-class CheckerStep(ValidFormOnOptions, UpdatesMeansTest, FormWizardStep):
+class CheckerStep(UpdatesMeansTest, FormWizardStep):
     def completed_fields(self):
         session_data = session.checker.get(self.form_class.__name__, {})
         form = self.form_class(**session_data)
@@ -309,7 +302,7 @@ class EligibleFaceToFace(LaaLaaView):
 checker.add_url_rule("/result/refer/legal-adviser", view_func=EligibleFaceToFace.as_view("find-legal-adviser"))
 
 
-class Eligible(HasFormMixin, RequiresSession, views.MethodView, ValidFormOnOptions, object):
+class Eligible(HasFormMixin, RequiresSession, views.MethodView, object):
     form_class = ContactForm
 
     def get(self):

--- a/cla_public/apps/checker/views.py
+++ b/cla_public/apps/checker/views.py
@@ -59,7 +59,7 @@ class UpdatesMeansTest(object):
             self.form.errors["timeout"] = _(
                 u"There was an error submitting your data. " u"Please check and try again."
             )
-            return self.get(step=self.name)
+            return self.return_form_errors(step=self.name)
         else:
             return super(UpdatesMeansTest, self).on_valid_submit()
 

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -19,7 +19,7 @@ from cla_public.apps.checker.api import (
     get_case_ref_from_api,
 )
 from cla_public.apps.checker.views import UpdatesMeansTest
-from cla_public.libs.views import AllowSessionOverride, SessionBackedFormView, ValidFormOnOptions, HasFormMixin
+from cla_public.libs.views import AllowSessionOverride, SessionBackedFormView, HasFormMixin
 
 
 @contact.after_request
@@ -138,7 +138,7 @@ class Contact(AllowSessionOverride, UpdatesMeansTest, SessionBackedFormView):
 contact.add_url_rule("/contact", view_func=Contact.as_view("get_in_touch"), methods=("GET", "POST", "OPTIONS"))
 
 
-class ContactConfirmation(HasFormMixin, ValidFormOnOptions, views.MethodView):
+class ContactConfirmation(HasFormMixin, views.MethodView):
 
     form_class = ConfirmationForm
 

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -135,7 +135,7 @@ class Contact(AllowSessionOverride, UpdatesMeansTest, SessionBackedFormView):
             pass
 
 
-contact.add_url_rule("/contact", view_func=Contact.as_view("get_in_touch"), methods=("GET", "POST", "OPTIONS"))
+contact.add_url_rule("/contact", view_func=Contact.as_view("get_in_touch"), methods=("GET", "POST"))
 
 
 class ContactConfirmation(HasFormMixin, views.MethodView):
@@ -173,5 +173,5 @@ class ContactConfirmation(HasFormMixin, views.MethodView):
 
 
 contact.add_url_rule(
-    "/result/confirmation", view_func=ContactConfirmation.as_view("confirmation"), methods=("GET", "POST", "OPTIONS")
+    "/result/confirmation", view_func=ContactConfirmation.as_view("confirmation"), methods=("GET", "POST")
 )

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -71,12 +71,12 @@ class Contact(AllowSessionOverride, UpdatesMeansTest, SessionBackedFormView):
         try:
             get_case_ref_from_api()
             session.store_checker_details()
-            return redirect(url_for("contact.confirmation"))
+            return self.redirect(url_for("contact.confirmation"))
         except ApiError:
             error_text = _(u"There was an error submitting your data. " u"Please check and try again.")
 
             self.form.errors["timeout"] = error_text
-            return self.get()
+            return self.return_form_errors()
 
     def add_errors(self, el, error_list):
         for error in el:
@@ -101,7 +101,7 @@ class Contact(AllowSessionOverride, UpdatesMeansTest, SessionBackedFormView):
             session.store_checker_details()
             if self.form.email.data and current_app.config["MAIL_SERVER"]:
                 current_app.mail.send(create_confirmation_email(self.form.data))
-            return redirect(url_for("contact.confirmation"))
+            return self.redirect(url_for("contact.confirmation"))
         except AlreadySavedApiError:
             return self.already_saved()
         except ApiError as e:
@@ -115,12 +115,12 @@ class Contact(AllowSessionOverride, UpdatesMeansTest, SessionBackedFormView):
 
             self.form.errors["timeout"] = error_text
 
-            return self.get()
+            return self.return_form_errors()
         except SMTPAuthenticationError:
             self.form._fields["email"].errors.append(
                 _(u"There was an error submitting your email. " u"Please check and try again or try without it.")
             )
-            return self.get()
+            return self.return_form_errors()
 
     def dispatch_request(self, *args, **kwargs):
         if not session:

--- a/cla_public/libs/views.py
+++ b/cla_public/libs/views.py
@@ -68,7 +68,13 @@ class AjaxOrNormalMixin(object):
 
     def return_form_errors(self, *args, **kwargs):
         if self.ajax:
-            return jsonify({"errors": {k: v for k, v in self.form.errors.items() if k != "csrf_token"}})
+            data = {"field_errors": self.form.errors}
+            try:
+                del data["field_errors"]["csrf_token"]
+            except KeyError:
+                pass
+            data.update(non_field_errors=kwargs.get("non_field_errors", []))
+            return jsonify(data)
         return self.get(*args, **kwargs)
 
 

--- a/cla_public/libs/views.py
+++ b/cla_public/libs/views.py
@@ -59,7 +59,7 @@ class HasFormMixin(object):
 class AjaxOrNormalMixin(object):
     @property
     def ajax(self):
-        return request.headers.get("Is-Ajax") == "true"
+        return request.headers.get("X-Requested-With") == "XMLHttpRequest"
 
     def redirect(self, url):
         if self.ajax:

--- a/cla_public/libs/views.py
+++ b/cla_public/libs/views.py
@@ -6,7 +6,7 @@ import datetime
 from itertools import dropwhile, ifilter
 import logging
 
-from flask import abort, current_app, redirect, render_template, request, session, url_for, views, jsonify, Response
+from flask import abort, current_app, redirect, render_template, request, session, url_for, views, jsonify
 
 log = logging.getLogger(__name__)
 
@@ -38,20 +38,6 @@ class RequiresSession(object):
         return super(RequiresSession, self).dispatch_request(*args, **kwargs)
 
 
-class ValidFormOnOptions(object):
-    def options(self, *args, **kwargs):
-        """
-        Returns validation errors if a form is submitted to it otherwise
-        returns Response with allowed methods
-        """
-        if "application/x-www-form-urlencoded" in request.content_type:
-            self.form.validate()
-            return jsonify({k: v for k, v in self.form.errors.items() if k != "csrf_token"})
-        rv = Response()
-        rv.allow.update(self.methods)
-        return rv
-
-
 class HasFormMixin(object):
     form_class = None
 
@@ -70,7 +56,7 @@ class HasFormMixin(object):
         return self._form
 
 
-class SessionBackedFormView(HasFormMixin, RequiresSession, views.MethodView, ValidFormOnOptions, object):
+class SessionBackedFormView(HasFormMixin, RequiresSession, views.MethodView, object):
     """
     Saves and loads form data to and from the session
     """
@@ -89,9 +75,12 @@ class SessionBackedFormView(HasFormMixin, RequiresSession, views.MethodView, Val
         Update session with form data if valid, remove from session if not.
         """
         is_submitted = getattr(self.form, "is_submitted", lambda: True)
-        if is_submitted() and self.form.validate():
-            self.save_form_data_in_session()
-            return self.on_valid_submit()
+        if is_submitted():
+            if self.form.validate():
+                self.save_form_data_in_session()
+                return self.on_valid_submit()
+            else:
+                return self.on_invalid_submit(*args, **kwargs)
 
         self.remove_form_data_from_session()
         return self.get(*args, **kwargs)
@@ -115,6 +104,12 @@ class SessionBackedFormView(HasFormMixin, RequiresSession, views.MethodView, Val
         Handle a valid form submission
         """
         raise NotImplementedError
+
+    def on_invalid_submit(self, *args, **kwargs):
+        self.remove_form_data_from_session()
+        if self.ajax:
+            return jsonify({"errors": {k: v for k, v in self.form.errors.items() if k != "csrf_token"}})
+        return self.get(*args, **kwargs)
 
 
 class AllowSessionOverride(object):
@@ -158,6 +153,10 @@ class FormWizard(SessionBackedFormView):
             return step
 
         self.steps = map(add_step, self.steps)
+
+    @property
+    def ajax(self):
+        return request.headers.get("Is-Ajax") == "true"
 
     def dispatch_request(self, *args, **kwargs):
         """
@@ -267,4 +266,6 @@ class FormWizardStep(object):
         return self.wizard.get(**kwargs)
 
     def on_valid_submit(self):
+        if self.wizard.ajax:
+            return jsonify({"redirect": self.wizard.next_url()})
         return redirect(self.wizard.next_url())

--- a/cla_public/libs/views.py
+++ b/cla_public/libs/views.py
@@ -64,6 +64,10 @@ class SessionBackedFormView(HasFormMixin, RequiresSession, views.MethodView, obj
     template = None
     template_context = {}
 
+    @property
+    def ajax(self):
+        return request.headers.get("Is-Ajax") == "true"
+
     def get(self, *args, **kwargs):
         """
         Render template with form
@@ -153,10 +157,6 @@ class FormWizard(SessionBackedFormView):
             return step
 
         self.steps = map(add_step, self.steps)
-
-    @property
-    def ajax(self):
-        return request.headers.get("Is-Ajax") == "true"
 
     def dispatch_request(self, *args, **kwargs):
         """

--- a/cla_public/libs/views.py
+++ b/cla_public/libs/views.py
@@ -283,3 +283,6 @@ class FormWizardStep(object):
 
     def on_valid_submit(self):
         return self.wizard.redirect(self.wizard.next_url())
+
+    def return_form_errors(self, **kwargs):
+        return self.wizard.return_form_errors(**kwargs)

--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -59,7 +59,6 @@
         $.ajax({
           type: 'POST',
           url: '',
-          headers: {'Is-Ajax':true},
           contentType: 'application/x-www-form-urlencoded',
           data: this.$form.serialize()
         })

--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -68,8 +68,11 @@
     },
 
     onAjaxSuccess: function(data) {
-      if (data.errors) {
-        this.loadErrors(data.errors);
+      if (data.redirect) {
+        window.location.href = data.redirect;
+      }
+      if (data.field_errors) {
+        this.loadErrors(data.field_errors);
         var errorBanner = $('.alert-error:visible:first');
 
         if(!errorBanner.length) {
@@ -81,8 +84,13 @@
         }, 300, function() {
           errorBanner.attr({'tabindex': -1}).focus();
         });
-      } else if (data.redirect) {
-        window.location.href = data.redirect;
+      }
+      if (data.non_field_errors.length) {
+        $('#non-field-error-ajax .alert-message').text(data.non_field_errors[0]);
+        $('#non-field-error-ajax').show();
+      }
+      else {
+        $('#non-field-error-ajax').hide()
       }
     },
 
@@ -230,7 +238,7 @@
 
     clearErrors: function() {
       $('.form-row.field-error').remove();
-      $('.alert.alert-error').remove();
+      $('form>.alert.alert-error').remove();
       $('.form-error')
         .removeClass('form-error')
         .removeAttr('aria-invalid');

--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -57,8 +57,9 @@
         e.preventDefault();
         e.stopPropagation();
         $.ajax({
-          type: 'OPTIONS',
+          type: 'POST',
           url: '',
+          headers: {'Is-Ajax':true},
           contentType: 'application/x-www-form-urlencoded',
           data: this.$form.serialize()
         })
@@ -67,9 +68,9 @@
       }
     },
 
-    onAjaxSuccess: function(errors) {
-      if (!$.isEmptyObject(errors)) {
-        this.loadErrors(errors);
+    onAjaxSuccess: function(data) {
+      if (data.errors) {
+        this.loadErrors(data.errors);
         var errorBanner = $('.alert-error:visible:first');
 
         if(!errorBanner.length) {
@@ -81,9 +82,8 @@
         }, 300, function() {
           errorBanner.attr({'tabindex': -1}).focus();
         });
-      } else {
-        this.$form.off('submit');
-        this.$form.submit();
+      } else if (data.redirect) {
+        window.location.href = data.redirect;
       }
     },
 

--- a/cla_public/templates/emails/zendesk-feedback.txt
+++ b/cla_public/templates/emails/zendesk-feedback.txt
@@ -1,6 +1,3 @@
-** {{ form.feel_about_service.label.text }} **
-{{ form.feel_about_service.data }}
-
 ** {{ form.help_filling_in_form.label.text }} **
 {{ form.help_filling_in_form.data }}
 

--- a/cla_public/templates/feedback.html
+++ b/cla_public/templates/feedback.html
@@ -19,12 +19,11 @@
 
     {{ Form.handle_errors(form) }}
 
-    {% if zd_error %}
+    {% if non_field_error %}
       {% call Element.alert('error', icon='cross') %}
-        <p>{{ zd_error }}</p>
+        <p>{{ non_field_error }}</p>
       {% endcall %}
     {% endif %}
-
 
     {% call Form.fieldset(form.help_filling_in_form, field_as_label=True) %}
       {{ Form.option_list(form.help_filling_in_form) }}


### PR DESCRIPTION
## What does this pull request do?

Rewrites ajax form validation to be done on a POST request, rather than an OPTIONS request. Therefore the views have to be able to handle the ajax and non-ajax ways of handling page redirects and displaying errors.

## Any other changes that would benefit highlighting?

In fixing the behaviour in Edge, we've had to completely change the views to use POST for the ajax request (rather than OPTIONS), so this doesn't just affect Edge, where the view were already not working, but all browsers.

Impacts the following paths, with javascript enabled and disabled:
- `/feedback`
- `/reasons-for-contacting`
- `/result/eligible`
- `/result/provisional`
- `/result/confirmation`
- `/contact`
- `/about`
- `/benefits`
- `/additional-benefits`
- `/property`
- `/savings`
- `/income`
- `/outgoings`
- `/review`

Shouldn't need testing in more than one browser on more than one flow, as the different views share the same front-end code but the back-end code varies more.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
