### PR TITLE
LGA-788 - Adding FALA routes through CLA for Education and Discrimination categories

### DIFF
--- a/cla_public/apps/checker/tests/test_interstitial.py
+++ b/cla_public/apps/checker/tests/test_interstitial.py
@@ -1,0 +1,10 @@
+import unittest
+
+from cla_public.apps.checker.views import get_show_laalaa_link_categories
+
+
+class TestInterstitial(unittest.TestCase):
+    def test_should_show_laalaa_categories(self):
+        self.assertEqual(
+            ["debt", "discrimination", "family", "housing", "violence"], get_show_laalaa_link_categories()
+        )

--- a/cla_public/apps/checker/views.py
+++ b/cla_public/apps/checker/views.py
@@ -396,7 +396,7 @@ def interstitial():
         category_name_english = unicode(session.checker.category_name)
 
     organisations = get_organisation_list(article_category__name=category_name_english)
-    show_laalaa = category in ["family", "housing"]
+    show_laalaa = category in get_show_laalaa_link_categories()
 
     context = {
         "category": category,
@@ -405,3 +405,7 @@ def interstitial():
         "show_laalaa": show_laalaa,
     }
     return render_template("interstitial.html", **context)
+
+
+def get_show_laalaa_link_categories():
+    return ["debt", "discrimination", "family", "housing", "violence"]


### PR DESCRIPTION
Adding violence, education, debt and discrimination to list of categories to show laalaa link

## What does this pull request do?

Required.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
