### PR TITLE
LGA-797 - Add FALA routes through CLA for Education and Employment categories

### DIFF
--- a/cla_public/apps/checker/tests/test_interstitial.py
+++ b/cla_public/apps/checker/tests/test_interstitial.py
@@ -6,5 +6,6 @@ from cla_public.apps.checker.views import get_show_laalaa_link_categories
 class TestInterstitial(unittest.TestCase):
     def test_should_show_laalaa_categories(self):
         self.assertEqual(
-            ["debt", "discrimination", "family", "housing", "violence"], get_show_laalaa_link_categories()
+            ["debt", "discrimination", "education", "employment", "family", "housing", "violence"],
+            get_show_laalaa_link_categories(),
         )

--- a/cla_public/apps/checker/views.py
+++ b/cla_public/apps/checker/views.py
@@ -408,4 +408,4 @@ def interstitial():
 
 
 def get_show_laalaa_link_categories():
-    return ["debt", "discrimination", "family", "housing", "violence"]
+    return ["debt", "discrimination", "education", "employment", "family", "housing", "violence"]


### PR DESCRIPTION
Adding education and employment to list of categories to show laalaa

## What does this pull request do?

Required.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
