### PR TITLE
LGA-809 - Remove 'Is it safe for us to leave a message on this number?' fields from contact forms

### DIFF
--- a/cla_public/apps/checker/constants.py
+++ b/cla_public/apps/checker/constants.py
@@ -1,6 +1,6 @@
 # coding: utf-8
-from flask.ext.babel import lazy_gettext as _, lazy_pgettext
-
+from flask.ext.babel import lazy_gettext as _
+from extended_choices import Choices
 
 "Categories the user needs help with"
 CATEGORIES = [
@@ -149,15 +149,12 @@ ORGANISATION_CATEGORY_MAPPING = {
     "Trouble with the police": "Action against police",
 }
 
-CONTACT_SAFETY = (
-    ("SAFE", lazy_pgettext(context=u"It is", string=u"Yes")),
-    ("NO_MESSAGE", lazy_pgettext(context=u"It isn’t", string=u"No")),
-)
+SAFE_TO_CONTACT = "SAFE"
 
-CONTACT_PREFERENCE = (
-    ("call", _(u"I’ll call CLA")),
-    ("callback", _(u"Call me back")),
-    ("thirdparty", _(u"Call someone else instead of me")),
+CONTACT_PREFERENCE = Choices(
+    ("CALL", "call", _(u"I’ll call CLA")),
+    ("CALLBACK", "callback", _(u"Call me back")),
+    ("THIRDPARTY", "thirdparty", _(u"Call someone else instead of me")),
 )
 
 LEGAL_ADVISER_SEARCH_PREFERENCE = (("location", _(u"Location")), ("organisation", _(u"Organisation")))

--- a/cla_public/apps/checker/session.py
+++ b/cla_public/apps/checker/session.py
@@ -20,7 +20,6 @@ from cla_public.apps.checker.constants import (
     PASSPORTED_BENEFITS,
     YES,
     END_SERVICE_FLASH_MESSAGE,
-    CONTACT_SAFETY,
     CONTACT_PREFERENCE,
 )
 from cla_public.apps.checker.means_test import MeansTest
@@ -246,9 +245,6 @@ class CheckerSession(SecureCookieSession, SessionMixin):
             "outcome": outcome,
             "adaptations": [k for k, v in self.checker.get("ContactForm", {}).get("adaptations", {}).items() if v],
         }
-        if self.stored["callback_requested"]:
-            form_value = self.checker.get("ContactForm", {}).get(self.checker.contact_type, {}).get("safe_to_contact")
-            self.stored["safe_to_contact"] = form_value == CONTACT_SAFETY[0][0]
 
     def store(self, values_dict):
         self.stored.update(values_dict)

--- a/cla_public/apps/checker/tests/test_payloads.py
+++ b/cla_public/apps/checker/tests/test_payloads.py
@@ -345,7 +345,7 @@ class TestApiPayloads(unittest.TestCase):
             "callback-time-time_today": "1930",
         }
 
-        callback_data = {"contact_number": "000000000", "safe_to_contact": YES}
+        callback_data = {"contact_number": "000000000", "safe_to_contact": "NO_MESSAGE"}
 
         address_data = {"post_code": "POSTCODE", "street_address": "21 Jump Street"}
 
@@ -364,7 +364,7 @@ class TestApiPayloads(unittest.TestCase):
             self.assertEqual(payload["personal_details"]["postcode"], "POSTCODE")
             self.assertEqual(payload["personal_details"]["mobile_phone"], "000000000")
             self.assertEqual(payload["personal_details"]["street"], "21 Jump Street")
-            self.assertEqual(payload["personal_details"]["safe_to_contact"], YES)
+            self.assertEqual(payload["personal_details"]["safe_to_contact"], "NO_MESSAGE")
 
             self.assertEqual(payload["adaptation_details"]["bsl_webcam"], True)
             self.assertEqual(payload["adaptation_details"]["minicom"], True)

--- a/cla_public/apps/checker/tests/test_payloads.py
+++ b/cla_public/apps/checker/tests/test_payloads.py
@@ -3,6 +3,7 @@ import datetime
 import unittest
 
 from cla_common import call_centre_availability
+from cla_common.constants import THIRDPARTY_RELATIONSHIP
 from flask import session
 from mock import patch
 import pytz
@@ -10,7 +11,7 @@ from werkzeug.datastructures import MultiDict
 
 from cla_public import app
 from cla_public.apps.contact.tests.test_availability import override_current_time
-from cla_public.apps.checker.constants import NO, YES
+from cla_public.apps.checker.constants import NO, YES, CONTACT_SAFETY, CONTACT_PREFERENCE
 from cla_public.apps.contact.forms import ContactForm
 from cla_public.apps.checker.means_test import (
     AboutYouPayload,
@@ -86,7 +87,11 @@ class TestApiPayloads(unittest.TestCase):
     def test_your_benefits_form_no_passported(self):
         form_data = {"benefits": {"other-benefit": True}}
         payload = self.payload(YourBenefitsPayload, form_data)
-        self.assertTrue(all(map(lambda (benefit, selected): not selected, payload["specific_benefits"].items())))
+
+        def get_selected(item):
+            return not item[1]
+
+        self.assertTrue(all(map(get_selected, payload["specific_benefits"].items())))
         self.assertFalse(payload["on_passported_benefits"])
 
     def test_your_benefits_form_child_benefits(self):
@@ -94,7 +99,11 @@ class TestApiPayloads(unittest.TestCase):
         form_data = {"benefits": {"child_benefit": True}}
         form_data = self.merge_money_intervals(form_data, form_mi_data)
         payload = self.payload(YourBenefitsPayload, form_data)
-        self.assertTrue(all(map(lambda (benefit, selected): not selected, payload["specific_benefits"].items())))
+
+        def get_selected(item):
+            return not item[1]
+
+        self.assertTrue(all(map(get_selected, payload["specific_benefits"].items())))
         self.assertFalse(payload["on_passported_benefits"])
         self.assertEqual(payload["you"]["income"]["child_benefits"]["per_interval_value"], 2100)
 
@@ -345,7 +354,7 @@ class TestApiPayloads(unittest.TestCase):
             "callback-time-time_today": "1930",
         }
 
-        callback_data = {"contact_number": "000000000", "safe_to_contact": "NO_MESSAGE"}
+        callback_data = {"contact_number": "000000000"}
 
         address_data = {"post_code": "POSTCODE", "street_address": "21 Jump Street"}
 
@@ -364,7 +373,6 @@ class TestApiPayloads(unittest.TestCase):
             self.assertEqual(payload["personal_details"]["postcode"], "POSTCODE")
             self.assertEqual(payload["personal_details"]["mobile_phone"], "000000000")
             self.assertEqual(payload["personal_details"]["street"], "21 Jump Street")
-            self.assertEqual(payload["personal_details"]["safe_to_contact"], "NO_MESSAGE")
 
             self.assertEqual(payload["adaptation_details"]["bsl_webcam"], True)
             self.assertEqual(payload["adaptation_details"]["minicom"], True)
@@ -375,3 +383,39 @@ class TestApiPayloads(unittest.TestCase):
             time = datetime.datetime.combine(call_centre_availability.current_datetime().date(), datetime.time(19, 30))
 
             self.assertEqual(payload["requires_action_at"], time.replace(tzinfo=pytz.utc).isoformat())
+
+    def test_safe_to_contact_when_contact_type_is_call(self):
+        form_data = self.application_form_data()
+        form_data.pop("callback-contact_number")
+        form_data.pop("callback-time-specific_day")
+        form_data.pop("callback-time-time_today")
+        form_data["contact_type"] = CONTACT_PREFERENCE[0][0]
+
+        with override_current_time(self.now):
+            payload = self.form_payload(ContactForm, form_data)
+            self.assertEqual(payload["personal_details"]["safe_to_contact"], "")
+
+    def test_safe_to_contact_when_contact_type_is_callback(self):
+        form_data = self.application_form_data()
+        form_data["contact_type"] = CONTACT_PREFERENCE[1][0]
+
+        with override_current_time(self.now):
+            payload = self.form_payload(ContactForm, form_data)
+            self.assertEqual(payload["personal_details"]["safe_to_contact"], CONTACT_SAFETY[0][0])
+
+    def test_safe_to_contact_when_contact_type_is_thirdparty(self):
+        form_data = self.application_form_data()
+        form_data["contact_type"] = CONTACT_PREFERENCE[2][0]
+        thirdparty = {
+            "full_name": form_data["full_name"],
+            "contact_number": "00000000000",
+            "relationship": THIRDPARTY_RELATIONSHIP[0][0],
+        }
+        form_data.update(flatten_dict("thirdparty", thirdparty))
+
+        with override_current_time(self.now):
+            payload = self.form_payload(ContactForm, form_data)
+            self.assertEqual(payload["personal_details"]["safe_to_contact"], "")
+            self.assertEqual(
+                payload["thirdparty_details"]["personal_details"]["safe_to_contact"], CONTACT_SAFETY[0][0]
+            )

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -70,12 +70,6 @@ class CallBackForm(BabelTranslationsFormMixin, NoCsrfForm):
             Length(max=20, message=_(u"Your telephone number must be 20 " u"characters or less")),
         ],
     )
-    safe_to_contact = RadioField(
-        _(u"Is it safe for us to leave a message on this number?"),
-        choices=CONTACT_SAFETY,
-        default="",  # Backend doesn't accept `None` as valid value
-        validators=[InputRequired(message=_(u"Please choose Yes or No"))],
-    )
     time = AvailabilityCheckerField(label=_(u"Select a time for us to call"))
 
 
@@ -100,12 +94,6 @@ class ThirdPartyForm(BabelTranslationsFormMixin, NoCsrfForm):
             InputRequired(),
             Length(max=20, message=_(u"Your telephone number must be 20 " u"characters or less")),
         ],
-    )
-    safe_to_contact = RadioField(
-        _(u"Is it safe for us to leave a message on this number?"),
-        choices=CONTACT_SAFETY,
-        default="",  # Backend doesn't accept `None` as valid value
-        validators=[InputRequired(message=_(u"Please choose Yes or No"))],
     )
     time = AvailabilityCheckerField(label=_(u"Select a time for us to call"))
 
@@ -181,7 +169,7 @@ class ContactForm(Honeypot, BabelTranslationsFormMixin, Form):
                 "postcode": self.address.form.post_code.data,
                 "mobile_phone": self.callback.form.contact_number.data,
                 "street": self.address.form.street_address.data,
-                "safe_to_contact": self.callback.form.safe_to_contact.data,
+                "safe_to_contact": CONTACT_SAFETY[1][0],
             },
             "adaptation_details": {
                 "bsl_webcam": self.adaptations.bsl_webcam.data,
@@ -198,7 +186,7 @@ class ContactForm(Honeypot, BabelTranslationsFormMixin, Form):
             data["thirdparty_details"] = {"personal_details": {}}
             data["thirdparty_details"]["personal_details"]["full_name"] = self.thirdparty.full_name.data
             data["thirdparty_details"]["personal_details"]["mobile_phone"] = self.thirdparty.contact_number.data
-            data["thirdparty_details"]["personal_details"]["safe_to_contact"] = self.thirdparty.safe_to_contact.data
+            data["thirdparty_details"]["personal_details"]["safe_to_contact"] = CONTACT_SAFETY[1][0]
             data["thirdparty_details"]["personal_relationship"] = self.thirdparty.relationship.data
 
             data["requires_action_at"] = process_selected_time(self.thirdparty.form.time)

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -11,7 +11,7 @@ from wtforms.validators import InputRequired, Optional, Required, Length
 
 from cla_common.constants import ADAPTATION_LANGUAGES, THIRDPARTY_RELATIONSHIP
 from cla_public.apps.contact.fields import AvailabilityCheckerField, ValidatedFormField
-from cla_public.apps.checker.constants import CONTACT_SAFETY, CONTACT_PREFERENCE
+from cla_public.apps.checker.constants import SAFE_TO_CONTACT, CONTACT_PREFERENCE
 from cla_public.apps.base.forms import BabelTranslationsFormMixin
 from cla_public.apps.checker.validators import IgnoreIf, FieldValue
 from cla_public.apps.contact.validators import EmailValidator
@@ -162,7 +162,7 @@ class ContactForm(Honeypot, BabelTranslationsFormMixin, Form):
             local = local_tz.localize(naive)
             return local.astimezone(pytz.utc).isoformat()
 
-        safe_to_contact = CONTACT_SAFETY[0][0] if self.contact_type.data == CONTACT_PREFERENCE[1][0] else ""
+        safe_to_contact = SAFE_TO_CONTACT if self.contact_type.data == CONTACT_PREFERENCE.CALLBACK else ""
         data = {
             "personal_details": {
                 "full_name": self.full_name.data,
@@ -187,7 +187,7 @@ class ContactForm(Honeypot, BabelTranslationsFormMixin, Form):
             data["thirdparty_details"] = {"personal_details": {}}
             data["thirdparty_details"]["personal_details"]["full_name"] = self.thirdparty.full_name.data
             data["thirdparty_details"]["personal_details"]["mobile_phone"] = self.thirdparty.contact_number.data
-            data["thirdparty_details"]["personal_details"]["safe_to_contact"] = CONTACT_SAFETY[0][0]
+            data["thirdparty_details"]["personal_details"]["safe_to_contact"] = SAFE_TO_CONTACT
             data["thirdparty_details"]["personal_relationship"] = self.thirdparty.relationship.data
 
             data["requires_action_at"] = process_selected_time(self.thirdparty.form.time)

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -162,6 +162,7 @@ class ContactForm(Honeypot, BabelTranslationsFormMixin, Form):
             local = local_tz.localize(naive)
             return local.astimezone(pytz.utc).isoformat()
 
+        safe_to_contact = CONTACT_SAFETY[0][0] if self.contact_type.data == CONTACT_PREFERENCE[1][0] else ""
         data = {
             "personal_details": {
                 "full_name": self.full_name.data,
@@ -169,7 +170,7 @@ class ContactForm(Honeypot, BabelTranslationsFormMixin, Form):
                 "postcode": self.address.form.post_code.data,
                 "mobile_phone": self.callback.form.contact_number.data,
                 "street": self.address.form.street_address.data,
-                "safe_to_contact": CONTACT_SAFETY[1][0],
+                "safe_to_contact": safe_to_contact,
             },
             "adaptation_details": {
                 "bsl_webcam": self.adaptations.bsl_webcam.data,
@@ -186,7 +187,7 @@ class ContactForm(Honeypot, BabelTranslationsFormMixin, Form):
             data["thirdparty_details"] = {"personal_details": {}}
             data["thirdparty_details"]["personal_details"]["full_name"] = self.thirdparty.full_name.data
             data["thirdparty_details"]["personal_details"]["mobile_phone"] = self.thirdparty.contact_number.data
-            data["thirdparty_details"]["personal_details"]["safe_to_contact"] = CONTACT_SAFETY[1][0]
+            data["thirdparty_details"]["personal_details"]["safe_to_contact"] = CONTACT_SAFETY[0][0]
             data["thirdparty_details"]["personal_relationship"] = self.thirdparty.relationship.data
 
             data["requires_action_at"] = process_selected_time(self.thirdparty.form.time)

--- a/cla_public/apps/contact/tests/test_mail.py
+++ b/cla_public/apps/contact/tests/test_mail.py
@@ -19,7 +19,6 @@ def submit(**kwargs):
         "email": "john.smith@example.com",
         "contact_type": "callback",
         "callback-contact_number": "0123456789",
-        "callback-safe_to_contact": "NO_MESSAGE",
     }
 
     if datetime.datetime.now().time() > datetime.time(hour=17, minute=30):

--- a/cla_public/apps/contact/tests/test_mail.py
+++ b/cla_public/apps/contact/tests/test_mail.py
@@ -19,7 +19,7 @@ def submit(**kwargs):
         "email": "john.smith@example.com",
         "contact_type": "callback",
         "callback-contact_number": "0123456789",
-        "callback-safe_to_contact": "SAFE",
+        "callback-safe_to_contact": "NO_MESSAGE",
     }
 
     if datetime.datetime.now().time() > datetime.time(hour=17, minute=30):
@@ -83,14 +83,6 @@ class TestMail(unittest.TestCase):
                 ),
                 msg.body,
             )
-            assert "We will leave a message" in msg.body
-
-    def test_confirmation_email_not_safe(self):
-        with self.client:
-            form = submit_and_store_in_session(**{"callback-safe_to_contact": "NO_MESSAGE"})
-            msg = create_confirmation_email(form.data)
-            msg = self.receive_email(msg)
-
             assert "We will not leave a message" in msg.body
 
     def test_confirmation_email_no_callback(self):

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -43,10 +43,7 @@ def create_confirmation_email(data):
         callback_time = session.stored.get("callback_time")
         end_time = callback_time + datetime.timedelta(minutes=30)
         data.update(
-            {
-                "safe_to_contact": session.stored.get("safe_to_contact"),
-                "callback_time_string": callback_time.strftime("%A, %d %B at %H:%M - ") + end_time.strftime("%H:%M"),
-            }
+            {"callback_time_string": callback_time.strftime("%A, %d %B at %H:%M - ") + end_time.strftime("%H:%M")}
         )
 
     recipient = (data["full_name"], data["email"]) if data.get("full_name") else data["email"]

--- a/cla_public/templates/emails/confirmation.txt
+++ b/cla_public/templates/emails/confirmation.txt
@@ -36,11 +36,7 @@
   {%- endif -%}
 {%- endif %}
 
-{% if data.safe_to_contact -%}
-  {{ _('We will leave a message when we call.') }}
-{%- else -%}
-  {{ _('We will not leave a message when we call, as you have told us not to.') }}
-{%- endif %}
+{{ _('We will not leave a message when we call.') }}
 
 {{ _('If you miss the call or you need advice urgently, you can call us on 0345 345 4345. Please quote your reference number when you call.') }}
 

--- a/cla_public/templates/macros/subform.html
+++ b/cla_public/templates/macros/subform.html
@@ -21,7 +21,6 @@
       </ul>
     </div>
     {{ Form.group(form.callback.contact_number, field_attrs={'class': 'm-large', 'autocomplete': 'tel', 'type': 'tel'}) }}
-    {{ Form.group(form.callback.safe_to_contact) }}
     {{ time_picker(form.callback.time) }}
   {% endcall %}
 {% endmacro %}
@@ -51,7 +50,6 @@
     {{ Form.group(form.thirdparty.full_name, field_attrs={'class': 'm-large'}) }}
     {{ Form.group(form.thirdparty.relationship) }}
     {{ Form.group(form.thirdparty.contact_number, field_attrs={'class': 'm-large', 'autocomplete': 'tel', 'type': 'tel'}) }}
-    {{ Form.group(form.thirdparty.safe_to_contact) }}
     {{ time_picker(form.thirdparty.time) }}
   {% endcall %}
 {% endmacro %}

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -3354,8 +3354,8 @@ msgid "We will leave a message when we call."
 msgstr "Byddwn yn gadael neges pan fyddwn yn eich ffonio."
 
 #: cla_public/templates/emails/confirmation.txt:42
-msgid "We will not leave a message when we call, as you have told us not to."
-msgstr "Ni fyddwn yn gadael neges pan fyddwn yn eich ffonio, gan eich bod wedi dweud wrthym i beidio."
+msgid "We will not leave a message when we call."
+msgstr "Ni fyddwn yn gadael neges pan fyddwn yn eich ffonio."
 
 #: cla_public/templates/emails/confirmation.txt:45
 msgid ""

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -3161,7 +3161,7 @@ msgid "We will leave a message when we call."
 msgstr ""
 
 #: cla_public/templates/emails/confirmation.txt:42
-msgid "We will not leave a message when we call, as you have told us not to."
+msgid "We will not leave a message when we call."
 msgstr ""
 
 #: cla_public/templates/emails/confirmation.txt:45

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -3161,7 +3161,7 @@ msgid "We will leave a message when we call."
 msgstr ""
 
 #: cla_public/templates/emails/confirmation.txt:42
-msgid "We will not leave a message when we call, as you have told us not to."
+msgid "We will not leave a message when we call."
 msgstr ""
 
 #: cla_public/templates/emails/confirmation.txt:45

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,6 +30,7 @@ ndg-httpsclient==0.4.0
 pyasn1==0.1.7
 wtforms==2.1
 postcodeinfo>=0.0,<0.1
+django-extended-choices==0.3.0
 
 # fork of https://github.com/samgiles/slumber
 # with custom parameters for timeouts and additional headers on requests


### PR DESCRIPTION
## What does this pull request do?

- Remove 'Is it safe for us to leave a message on this number?' fields from 'call me back' and  'Call someone else instead of me' forms
- Remove voice messages text from email templates
- Send SAFE value in safe_to_contact field to the backend when user has requested a callback

## Any other changes that would benefit highlighting?

We have decided to remove this field due to receiving complaints from end user about not getting voice messages and the call centre provider not being allowed to leave voice messages

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
