### PR TITLE
LGA-813 -  Fetch LAALAA provider categories from LAALAA endpoint

### DIFF
--- a/cla_public/apps/checker/constants.py
+++ b/cla_public/apps/checker/constants.py
@@ -167,6 +167,8 @@ LAALAA_PROVIDER_CATEGORIES_MAP = {
     "clinneg": ["med"],
     "commcare": ["com"],
     "debt": ["deb"],
+    "discrimination": ["disc"],
+    "education": ["edu"],
     "family": ["mat", "fmed"],
     "housing": ["hou"],
     "immigration": ["immas"],

--- a/cla_public/libs/laalaa.py
+++ b/cla_public/libs/laalaa.py
@@ -4,25 +4,7 @@ from flask.ext.babel import lazy_gettext as _
 import requests
 from werkzeug.urls import url_encode
 
-PROVIDER_CATEGORIES = {
-    "aap": _("Actions against the police"),
-    "med": _("Clinical negligence"),
-    "com": _("Community care"),
-    "crm": _("Crime"),
-    "deb": _("Debt"),
-    "mat": _("Family"),
-    "fmed": _("Family mediation"),
-    "hou": _("Housing"),
-    "immas": _("Immigration or asylum"),
-    "mhe": _("Mental health"),
-    "pl": _("Prison law"),
-    "pub": _("Public law"),
-    "wb": _("Welfare benefits"),
-}
-
-
-class LaaLaaError(Exception):
-    pass
+from cla_common.laalaa import LaalaaProviderCategoriesApiClient, LaaLaaError
 
 
 def kwargs_to_urlparams(**kwargs):
@@ -44,9 +26,15 @@ def laalaa_search(**kwargs):
         raise LaaLaaError(e)
 
 
+def get_categories():
+    client = LaalaaProviderCategoriesApiClient.singleton(current_app.config["LAALAA_API_HOST"], category_translator=_)
+    return client.get_categories()
+
+
 def decode_category(category):
     if category and isinstance(category, basestring):
-        return PROVIDER_CATEGORIES.get(category.lower())
+        categories = get_categories()
+        return categories.get(category.lower())
 
 
 def decode_categories(result):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ PyYAML==3.11
 Werkzeug==0.9.6
 argparse==1.2.1
 blinker==1.3
-git+git://github.com/ministryofjustice/cla_common.git@0.3.2#egg=cla_common==0.3.2
+git+git://github.com/ministryofjustice/cla_common.git@0.3.3#egg=cla_common==0.3.3
 itsdangerous==0.24
 jinja-moj-template==0.19.0
 logstash_formatter==0.5.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ PyYAML==3.11
 Werkzeug==0.9.6
 argparse==1.2.1
 blinker==1.3
-git+git://github.com/ministryofjustice/cla_common.git@0.3.0#egg=cla_common==0.3.0
+git+git://github.com/ministryofjustice/cla_common.git@0.3.2#egg=cla_common==0.3.2
 itsdangerous==0.24
 jinja-moj-template==0.19.0
 logstash_formatter==0.5.9


### PR DESCRIPTION
## What does this pull request do?

Fetch LAALAA provider categories from LAALAA endpoint instead of a local constant in this app

## Any other changes that would benefit highlighting?

Requires https://github.com/ministryofjustice/laa-legal-adviser-api/pull/137 to be LAALAA master before merging in this PR

https://dsdmoj.atlassian.net/browse/LGA-848 has been created to capture the relationship between CLA and LAALAA categories of law with the aim of working with business to see if we can also consume CLA categories from LAALAA and to also understand the relationship and difference of CLA and LAALAA categories of law.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
