### PR TITLE
LGA-634 - Start using Kubernetes cloud platform hosted LAALAA_API_HOST for production

### DIFF
--- a/kubernetes_deploy/production/deployment.yml
+++ b/kubernetes_deploy/production/deployment.yml
@@ -40,7 +40,7 @@ spec:
         - name: BACKEND_BASE_URI
           value: https://fox.civillegaladvice.service.gov.uk
         - name: LAALAA_API_HOST
-          value: https://prod.laalaa.dsd.io
+          value: https://laa-legal-adviser-api-production.cloud-platform.service.justice.gov.uk
         - name: LOG_LEVEL
           value: INFO
         - name: MOJ_GA_ID


### PR DESCRIPTION
## What does this pull request do?

Start using Kubernetes cloud platform hosted LAALAA_API_HOST for production

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
