### PR TITLE
Use laa-cla-public-live-0 context for build and deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,7 @@ workflows:
             - lint-with-py2-tools
             - lint-with-py3-tools
             - test
+          context: laa-cla-public-live-0
       - staging_deploy_approval:
           type: approval
           requires:
@@ -190,6 +191,7 @@ workflows:
       - staging_deploy:
           requires:
             - staging_deploy_approval
+          context: laa-cla-public-live-0
       - production_deploy_approval:
           type: approval
           requires:
@@ -201,3 +203,4 @@ workflows:
       - production_deploy:
           requires:
             - production_deploy_approval
+          context: laa-cla-public-live-0


### PR DESCRIPTION
## What does this pull request do?

Uses a new laa-cla-public-live-0 context for the existing build and deploy steps (which currently only get their env vars from the project settings). This will allow us to move live-0-specific env vars out of the project settings, stopping them affecting the live-1 flow when we get to it and meaning we won't have to override or unset those env vars.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
