### PR TITLE
LGA-701 - production live-1 cutover

### DIFF
--- a/kubernetes_deploy/production/ingress.yml
+++ b/kubernetes_deploy/production/ingress.yml
@@ -7,9 +7,19 @@ spec:
   tls:
   - hosts:
     - laa-cla-public-production.apps.live-1.cloud-platform.service.justice.gov.uk
+  - hosts:
+    - checklegalaid.service.gov.uk
+    secretName: tls-certificate
 
   rules:
   - host: laa-cla-public-production.apps.live-1.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: laa-cla-public
+          servicePort: 80
+  - host: checklegalaid.service.gov.uk
     http:
       paths:
       - path: /

--- a/kubernetes_deploy/production_live_0/ingress.yml
+++ b/kubernetes_deploy/production_live_0/ingress.yml
@@ -7,19 +7,9 @@ spec:
   tls:
   - hosts:
     - laa-cla-public-production.apps.cloud-platform-live-0.k8s.integration.dsd.io
-  - hosts:
-    - checklegalaid.service.gov.uk
-    secretName: laa-cla-public-production-tls-certificate
 
   rules:
   - host: laa-cla-public-production.apps.cloud-platform-live-0.k8s.integration.dsd.io
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: laa-cla-public
-          servicePort: 80
-  - host: checklegalaid.service.gov.uk
     http:
       paths:
       - path: /


### PR DESCRIPTION
## What does this pull request do?

Adds the live production hostname to the live-1 ingress
Removes the live production hostname from the live-0 ingress

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
