### PR TITLE
LGA-873 - Remove MockServer from manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,7 +2,6 @@
 # coding: utf-8
 import logging
 import datetime
-import mock
 import os
 import subprocess
 import sys
@@ -11,7 +10,6 @@ from flask.ext.script import Manager, Shell, Server
 import requests
 
 from cla_public.app import create_app
-from cla_public.apps.contact.tests.test_availability import override_current_time
 
 
 log = logging.getLogger(__name__)
@@ -59,8 +57,8 @@ def make_messages():
     )
 
     pgettexts = [
-        {"context": "There is\/are", "message": "Yes"},
-        {"context": "There is\/are not", "message": "No"},
+        {"context": r"There is\/are", "message": "Yes"},
+        {"context": r"There is\/are not", "message": "No"},
         {"context": "It is", "message": "Yes"},
         {"context": "It isn’t", "message": "No"},
         {"context": "I am", "message": "Yes"},
@@ -123,14 +121,6 @@ class MockDate(datetime.date):
         return cls(2015, 1, 26)
 
 
-class MockServer(Server):
-    def __call__(self, *args, **kwargs):
-        with override_current_time(datetime.datetime(2015, 1, 26, 9, 0)):
-            with mock.patch("datetime.date", MockDate):
-                super(MockServer, self).__call__(*args, **kwargs)
-
-
-manager.add_command("mockserver", MockServer())
 manager.add_command("server", Server())
 manager.add_command("shell", Shell(make_context=_make_context))
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -35,3 +35,5 @@ django-extended-choices==0.3.0
 # fork of https://github.com/samgiles/slumber
 # with custom parameters for timeouts and additional headers on requests
 git+git://github.com/ministryofjustice/slumber.git@da38360d6d158ee7ed445b43228fefc6f7e430e6#egg=slumber==0.6.3moj
+
+Flask-Script==2.0.5

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,3 @@
-Flask-Script==2.0.5
 mock==1.0.1
 nose==1.3.4
 requests_mock==1.5.2


### PR DESCRIPTION
## What does this pull request do?

* LGA-873 - Remove MockServer from manage.py

The MockServer was a relic from when we used to have nightwatchjs tests run by jenkins
The nightwatchjs end-to-end tests has been moved to https://github.com/ministryofjustice/laa-cla-e2e-tests repo

## Any other changes that would benefit highlighting?

Moved Flask-Script package from test requirements to production requirements because the package is used in manage.py to register additional commands

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
