### PR TITLE
LGA-906 Remove superfluous close input tag

### DIFF
--- a/cla_public/libs/honeypot.py
+++ b/cla_public/libs/honeypot.py
@@ -13,7 +13,7 @@ class HoneypotWidget(widgets.Input):
         kwargs.setdefault("id", FIELD_NAME)
 
         return widgets.HTMLString(
-            "<input {params}></input>".format(params=widgets.html_params(name=field.name, **kwargs))
+            "<input {params}>".format(params=widgets.html_params(name=field.name, **kwargs))
         )
 
 


### PR DESCRIPTION
## What does this pull request do?

Deleted the close input tag `</input>` from honeypot.py.  

Input tags are not closed.  Closing them fails HTML validation. 

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
