### PR TITLE
Use 'key' from nodes, rather than 'label', when calculating category

### DIFF
--- a/cla_public/apps/scope/api.py
+++ b/cla_public/apps/scope/api.py
@@ -86,7 +86,7 @@ class DiagnosisApiClient(object):
     def get_category(self, response_json):
         category = response_json["category"]
         if not category:
-            category_name = Markup(response_json["nodes"][0]["label"]).striptags()
+            category_name = response_json["nodes"][0]["key"]
             with override_locale("en"):
                 category, name, desc = category_option_from_name(category_name)
         return category

--- a/docker/local_deploy.sh
+++ b/docker/local_deploy.sh
@@ -6,5 +6,6 @@ NAMESPACE="development"
 NAMESPACE_DIR="$ROOT/../kubernetes_deploy/$NAMESPACE"
 
 kubectl config use-context docker-for-desktop
+kubectl delete deployments laa-cla-public --ignore-not-found
 
 ECR_DEPLOY_IMAGE=cla_public_local .circleci/deploy_to_kubernetes $NAMESPACE


### PR DESCRIPTION
## What does this pull request do?

Uses the new, untranslated, 'key' key from the API response when determining the category. This prevents the lookup from failing when passed a step name in Welsh.

## Any other changes that would benefit highlighting?
Improves the local k8s script by adding deletion of deployments, so that this doesn't need to be run separately.
Requires https://github.com/ministryofjustice/cla_backend/pull/610

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
