### PR TITLE
LGA-924 HTML and CSS cleanup

### DIFF
--- a/cla_public/static-src/stylesheets/_tables.scss
+++ b/cla_public/static-src/stylesheets/_tables.scss
@@ -1,28 +1,6 @@
 // Tables
 // ==========================================================================
 
-/*
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-  width: 100%;
-}
-
-table th,
-table td {
-  @include core-14;
-  padding: 0.7em 0.5em 0.7em 0;
-  vertical-align: top;
-  text-align: left;
-  color: #0b0c0c;
-  border-bottom: 1px solid $border-colour;
-}
-
-table th {
-  font-weight: 700;
-}
-*/
-
 article table {
   margin-bottom: 30px;
 }

--- a/cla_public/static-src/stylesheets/_tables.scss
+++ b/cla_public/static-src/stylesheets/_tables.scss
@@ -1,6 +1,7 @@
 // Tables
 // ==========================================================================
 
+/*
 table {
   border-collapse: collapse;
   border-spacing: 0;
@@ -20,6 +21,7 @@ table td {
 table th {
   font-weight: 700;
 }
+*/
 
 article table {
   margin-bottom: 30px;

--- a/cla_public/templates/checker/income.html
+++ b/cla_public/templates/checker/income.html
@@ -1,9 +1,9 @@
 {% extends "checker/base.html" %}
 
 {% block inner_content %}
-  <h1 class="page-title">{{ title }}</h1>
-  <p>{{ _('You’ll need to provide evidence of the financial information you’ve given us through this service.') }}</p>
-  <p>
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
+  <p class="govuk-body">{{ _('You’ll need to provide evidence of the financial information you’ve given us through this service.') }}</p>
+  <p class="govuk-body">
     <strong>{% trans %}We only need to know about any money you received last month, even if this varies from month to month.{% endtrans %}</strong>
   </p>
   <form method="POST">
@@ -12,11 +12,9 @@
 
     {% with skip = not (session.checker.is_employed or session.checker.is_self_employed) %}
       {% if session.checker.has_partner %}
-        <fieldset class="fieldset-group">
-          <header>
-            <h3>{{ _('Your money') }}</h3>
-          </header>
-          <p>
+        <fieldset class="govuk-fieldset">
+          <h2 class="govuk-heading-l">{{ _('Your money') }}</h3>
+          <p class="govuk-body">
             {% trans %}Give details of any money that is paid to you
             personally, like your wages. Record money coming in for your
             partner in the next section.{% endtrans %}
@@ -39,11 +37,9 @@
       {% endif %}
     {% endwith %}
     {% if session.checker.has_partner %}
-      <fieldset class="fieldset-group">
+      <fieldset class="govuk-fieldset">
         {% with skip_for_partner = not (session.checker.partner_is_employed or session.checker.partner_is_self_employed) %}
-          <header>
-            <h3>{{ _('Your partner’s money') }}</h3>
-          </header>
+          <h2 class="govuk-heading-l">{{ _('Your partner’s money') }}</h3>
           {% if not skip_for_partner %}
             {{ Form.group(form.partner_income.earnings, skip=skip_for_partner) }}
             {{ Form.group(form.partner_income.income_tax, skip=skip_for_partner) }}

--- a/cla_public/templates/checker/outgoings.html
+++ b/cla_public/templates/checker/outgoings.html
@@ -1,8 +1,8 @@
 {% extends "checker/base.html" %}
 
 {% block inner_content %}
-  <h1 class="page-title">{{ title }}</h1>
-  <p>{{ _('You’ll need to provide evidence of the financial information you’ve given us through this service.') }}</p>
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
+  <p class="govuk-body">{{ _('You’ll need to provide evidence of the financial information you’ve given us through this service.') }}</p>
 
   <form method="POST">
     {{ form.csrf_token }}

--- a/cla_public/templates/checker/result/eligible-f2f.html
+++ b/cla_public/templates/checker/result/eligible-f2f.html
@@ -14,28 +14,28 @@
   {% block sidebar %}{% endblock %}
 
   {% block inner_content %}
-    <h1 class="page-title">{{ title }}</h1>
+    <h1 class="govuk-heading-xl">{{ title }}</h1>
 
-    <p>
+    <p class="govuk-body">
       {% trans %}Civil Legal Advice does not provide advice about issues
         related to welfare benefits but you may be able to get free advice from
         a legal adviser in your area.{% endtrans %}
     </p>
 
-    <p>
+    <p class="govuk-body">
       {% trans %}To get advice about appealing a decision made by the social
         security tribunal about your benefits to the Upper Tribunal, Court of
         Appeal or Supreme Court, you should contact a legal adviser.
       {% endtrans %}
     </p>
 
-    <p>
+    <p class="govuk-body">
       {% trans %}Your adviser will check whether you qualify for legal aid at
       no cost to you. If you qualify for legal aid, you will not have to pay
         for legal advice.{% endtrans %}
     </p>
 
-    <p>
+    <p class="govuk-body">
       {% trans %}If you don't qualify for legal aid, you will have to pay for
         legal advice. You should ask your adviser about the cost of their
         advice.{% endtrans %}

--- a/cla_public/templates/checker/result/eligible.html
+++ b/cla_public/templates/checker/result/eligible.html
@@ -3,34 +3,34 @@
 {% import "macros/element.html" as Element %}
 
 {% block page_text %}
-  <h1 class="page-title">
+  <h1 class="govuk-heading-xl">
     {% trans %}Contact Civil Legal Advice{% endtrans %}
   </h1>
   {% if session.checker.need_more_info %}
-    <p>
+    <p class="govuk-body">
       {% trans %}To decide whether you might qualify for legal aid, we need more information about
       your financial circumstances. Contact Civil Legal Advice (CLA), a national helpline for England and
       Wales to get specialist advice.{% endtrans %}
     </p>
   {% else %}
-    <p>
+    <p class="govuk-body">
       {% trans %}Based on the answers you’ve given today, you might qualify for legal aid.
       Contact Civil Legal Advice (CLA), a national helpline for England and
       Wales, to confirm that you qualify, and get specialist advice if you do.{% endtrans %}
     </p>
-    <p>
+    <p class="govuk-body">
       {% trans %}In some cases, you may need to pay a contribution towards your legal aid.{% endtrans %}
     </p>
   {% endif %}
-  <p>
+  <p class="govuk-body">
     {% trans %}Complete your application by submitting your details
     below.{% endtrans %}
   </p>
-  <p>
+  <p class="govuk-body">
     {% trans call_charges_link=Element.link_new_window('https://www.gov.uk/call-charges', _('call charges'), True) %}
       You can choose to contact CLA yourself and speak to someone immediately (this is an 0345 number -
       {{ call_charges_link }} apply) or ask us to call you back, which is free.
     {% endtrans %}
   </p>
-  <p>{{ _('You’ll need to provide evidence of the financial information you’ve given us through this service.') }}</p>
+  <p class="govuk-body">{{ _('You’ll need to provide evidence of the financial information you’ve given us through this service.') }}</p>
 {% endblock %}

--- a/cla_public/templates/checker/result/ineligible.html
+++ b/cla_public/templates/checker/result/ineligible.html
@@ -11,9 +11,9 @@
 {% set _tag = 'li' if multi else 'p' %}
 
 {% block inner_content %}
-  <h1 class="page-title">{{ _('You’re unlikely to get legal aid') }}</h1>
+  <h1 class="govuk-heading-xl">{{ _('You’re unlikely to get legal aid') }}</h1>
 
-  <p>
+  <p class="govuk-body">
     {% trans fromcla = _('from CLA') if category == 'violence' else '' %}From
     what you have told us today it looks like you won't be able to get
     legal aid {{ fromcla }} as you don’t qualify financially{% endtrans %}.
@@ -21,7 +21,7 @@
 
   {% if ineligible_reasons %}
 
-  <p>{{ _('This is because') }}{% if multi %}:</p><ul>{% endif %}
+  <p class="govuk-body">{{ _('This is because') }}{% if multi %}:</p><ul class="govuk-list govuk-list--bullet">{% endif %}
   {% if ELIGIBILITY_REASONS.DISPOSABLE_CAPITAL in ineligible_reasons %}
     {% if multi %}<{{ _tag }}>{% endif %}{{ partner_text }} {% trans %}have too much disposable
       capital{% endtrans %}{% if not multi %}.{% endif %}</{{ _tag }}>
@@ -40,19 +40,19 @@
   {% if multi %}</ul>{% endif %}
 
   {% if ELIGIBILITY_REASONS.DISPOSABLE_CAPITAL in ineligible_reasons %}
-    <p>{% trans %}Disposable capital includes savings, valuable items and the
+    <p class="govuk-body">{% trans %}Disposable capital includes savings, valuable items and the
       equity in any property you own.{% endtrans %}</p>
   {% endif %}
 
   {% if ELIGIBILITY_REASONS.DISPOSABLE_INCOME in ineligible_reasons %}
-    <p>{% trans %}Disposable income is the money you have left after we’ve accounted
+    <p class="govuk-body">{% trans %}Disposable income is the money you have left after we’ve accounted
       for certain living expenses, like rent or mortgage payments.{% endtrans %}</p>
   {% endif %}
 
   {% endif %}
 
   {% if category == 'family' %}
-    <p>
+    <p class="govuk-body">
       {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'Family Mediation Council') %}
       {% trans family_mediation_link=Element.link_new_window('http://www.familymediationcouncil.org.uk/', _('Family Mediation Council'), True, **{'data-ga': ga_event}) %}
         If you want to make an application to court about a family matter you need to first of all
@@ -62,36 +62,36 @@
     </p>
   {% endif %}
 
-       <p>
+       <p class="govuk-body">
 
-          <a href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">
+          <a class="govuk-link" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">
             {% trans %}What did you think of this service?{% endtrans %}</a> {% trans %}(takes 30 seconds){% endtrans %}
           </a>
     </p>
 
-  <h2>{{ _('A legal adviser may still be able to help') }}</h2>
+  <h2 class="govuk-heading-l">{{ _('A legal adviser may still be able to help') }}</h2>
 
   {% if category == 'violence' %}
-    <p>
+    <p class="govuk-body">
       {% trans %}You may still qualify for legal aid to seek a court order for protection. To find out if you
       might qualify, contact a legal adviser in your area.{% endtrans %}
     </p>
   {% else %}
-    <p>{% trans %}You can still ask a legal adviser for help – you will have to pay for their advice.{% endtrans %}</p>
+    <p class="govuk-body">{% trans %}You can still ask a legal adviser for help – you will have to pay for their advice.{% endtrans %}</p>
 
   {% endif %}
 
   {% if category not in ['debt', 'violence', 'discrimination', 'education', 'family', 'housing', 'benefits'] %}
-    <p>
+    <p class="govuk-body">
       {% trans %}If you have a court hearing date it is important that you get advice
       as soon as possible. You may be able to get last-minute help on the
       day of the hearing from an adviser in the court building.{% endtrans %}
     </p>
   {% endif %}
 
-  <p>
+  <p class="govuk-body">
     {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'Find a solicitor') %}
-    {{ Element.link_new_window('https://www.gov.uk/find-a-legal-adviser', _('Find a solicitor'), **{'class': 'button', 'data-ga': ga_event}) }}
+    {{ Element.link_new_window('https://www.gov.uk/find-a-legal-adviser', _('Find a solicitor'), **{'class': 'govuk-button', 'data-ga': ga_event}) }}
   </p>
 
   {{ HelpOrganisations.org_list_container(organisations, category_name, truncate=5) }}

--- a/cla_public/templates/cookies.html
+++ b/cla_public/templates/cookies.html
@@ -6,22 +6,22 @@
 {% block page_title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1 class="page-title">{{ title }}</h1>
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
 
-  <p>{{ _('The Check if you can get legal aid service puts small files (known as ’cookies’) onto your computer to collect information about how you browse the site.') }}</p>
-  <p>{{ _('Cookies are used to:') }}</p>
+  <p class="govuk-body">{{ _('The Check if you can get legal aid service puts small files (known as ’cookies’) onto your computer to collect information about how you browse the site.') }}</p>
+  <p class="govuk-body">{{ _('Cookies are used to:') }}</p>
 
-  <ul>
+  <ul class="govuk-list govuk-list--bullet">
     <li>{{ _('measure how you use the website so it can be updated and improved based on your needs') }}</li>
     <li>{{ _('remember the notifications you’ve seen so that we don’t show them to you again') }}</li>
   </ul>
 
-  {% call Element.alert() %}
-    <p>{{ _('Check if you can get legal aid cookies aren’t used to identify you personally.') }}</p>
+  {% call Element.inset() %}
+    {{ _('Check if you can get legal aid cookies aren’t used to identify you personally.') }}
   {% endcall %}
 
-  <p>{{ _('You’ll normally see a message on the site before we store a cookie on your computer.') }}</p>
-  <p>
+  <p class="govuk-body">{{ _('You’ll normally see a message on the site before we store a cookie on your computer.') }}</p>
+  <p class="govuk-body">
     {% trans manage_cookies_link=Element.link_new_window('http://www.aboutcookies.org/', _('how to manage cookies'), True) %}
       Find out more about {{ manage_cookies_link }}.
     {% endtrans %}
@@ -29,51 +29,52 @@
   <h2>{{ _('How cookies are used on Check if you can get legal aid') }}</h2>
   <h3>{{ _('Measuring website usage (Google Analytics)') }}</h3>
 
-  <p>{{ _('We use Google Analytics software to collect information about how you use Check if you can get legal aid. We do this to help make sure the service is meeting the needs of its users and to help us make improvements.') }}</p>
-  <p>{{ _('Google Analytics stores information about:') }}</p>
+  <p class="govuk-body">{{ _('We use Google Analytics software to collect information about how you use Check if you can get legal aid. We do this to help make sure the service is meeting the needs of its users and to help us make improvements.') }}</p>
+  <p class="govuk-body">{{ _('Google Analytics stores information about:') }}</p>
 
-  <ul>
+  <ul class="govuk-list govuk-list--bullet">
     <li>{{ _('the pages you visit') }}</li>
     <li>{{ _('how long you spend on each page') }}</li>
     <li>{{ _('how you got to the site') }}</li>
     <li>{{ _('what you click on while you’re visiting the site.') }}</li>
   </ul>
 
-  {% call Element.alert() %}
-    <p>{{ _('We don’t collect or store your personal information so this information can’t be used to identify who you are. For more information visit our <a href="/privacy">Privacy policy</a>.') }}</p>
+  {% call Element.inset() %}
+    {{ _('We don’t collect or store your personal information so this information can’t be used to identify who you are. For more information visit our <a href="/privacy">Privacy policy</a>.') }}
   {% endcall %}
 
-  <p>{{ _('We don’t allow Google to use or share our analytics data.') }}</p>
-  <p>{{ _('Google Analytics sets the following cookies:') }}</p>
+  <p class="govuk-body">{{ _('We don’t allow Google to use or share our analytics data.') }}</p>
+  <p class="govuk-body">{{ _('Google Analytics sets the following cookies:') }}</p>
 
-  <table>
-    <thead>
-      <tr>
-        <th class="u-width-20">{{ _('Name') }}</th>
-        <th>{{ _('Purpose') }}</th>
-        <th class="u-width-10 u-text-right">{{ _('Expires') }}</th>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption">{{ _('Google Analytics cookies') }}</caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header u-width-20">{{ _('Name') }}</th>
+        <th scope="col" class="govuk-table__header">{{ _('Purpose') }}</th>
+        <th scope="col" class="govuk-table__header u-width-10 u-text-right">{{ _('Expires') }}</th>
       </tr>
     </thead>
-    <tbody>
-      <tr>
-        <td>_ga</td>
-        <td>{{ _('This helps us count how many people visit the service. Your data is anonymised.') }}</td>
-        <td class="u-text-right">{{ _('2 years') }}</td>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">_ga</th>
+        <td class="govuk-table__cell">{{ _('This helps us count how many people visit the service. Your data is anonymised.') }}</td>
+        <td class="govuk-table__cell u-text-right">{{ _('2 years') }}</td>
       </tr>
-      <tr>
-        <td>_gat</td>
-        <td>{{ _('Used to manage the rate at which page view requests are made. Your data is anonymised.') }}</td>
-        <td class="u-text-right">{{ _('10 minutes') }}</td>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">_gat</th>
+        <td class="govuk-table__cell">{{ _('Used to manage the rate at which page view requests are made. Your data is anonymised.') }}</td>
+        <td class="govuk-table__cell u-text-right">{{ _('10 minutes') }}</td>
       </tr>
-      <tr>
-        <td>_gid</td>
-        <td>{{ _('This helps us count how many people visit. Your data is anonymised.') }}</td>
-        <td class="u-text-right">{{ _('24 hours') }}</td>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">_gid</th>
+        <td class="govuk-table__cell">{{ _('This helps us count how many people visit. Your data is anonymised.') }}</td>
+        <td class="govuk-table__cell u-text-right">{{ _('24 hours') }}</td>
       </tr>
     </tbody>
   </table>
 
-  <p>
+  <p class="govuk-body">
     {% trans opt_out_link=Element.link_new_window('https://tools.google.com/dlpage/gaoptout', _('opt out of Google Analytics cookies'), True) %}
       You can {{ opt_out_link }}.
     {% endtrans %}
@@ -82,62 +83,65 @@
 
   <h3>{{ _('Our introductory message') }}</h3>
   <p>{{ _('You may see a pop-up welcome message when you first visit GOV.UK. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.') }}</p>
-  <table>
-    <thead>
-      <tr>
-        <th class="u-width-20">{{ _('Name') }}</th>
-        <th>{{ _('Purpose') }}</th>
-        <th class="u-width-10 u-text-right">{{ _('Expires') }}</th>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption">{{ _('Introductory cookies') }}</caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header u-width-20">{{ _('Name') }}</th>
+        <th scope="col" class="govuk-table__header">{{ _('Purpose') }}</th>
+        <th scope="col" class="govuk-table__header u-width-10 u-text-right">{{ _('Expires') }}</th>
       </tr>
     </thead>
-    <tbody>
-      <tr>
-        <td>seen_cookie_message</td>
-        <td>{{ _('Saves a message to let us know that you have seen our cookie message') }}</td>
-        <td class="u-text-right">{{ _('1 month') }}</td>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">seen_cookie_message</th>
+        <td class="govuk-table__cell">{{ _('Saves a message to let us know that you have seen our cookie message') }}</td>
+        <td class="govuk-table__cell u-text-right">{{ _('1 month') }}</td>
       </tr>
     </tbody>
   </table>
 
   <h3>{{ _('Your progress when using the service') }}</h3>
   <p>{{ _('When you use the Check if you can get legal aid service, we’ll set a cookie to remember your progress through the forms. These cookies don’t store your personal data and are deleted once you’ve completed the transaction.') }}</p>
-  <table>
-    <thead>
-      <tr>
-        <th>{{ _('Name') }}</th>
-        <th>{{ _('Purpose') }}</th>
-        <th>{{ _('Expires') }}</th>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption">{{ _('Progress cookies') }}</caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">{{ _('Name') }}</th>
+        <th scope="col" class="govuk-table__header">{{ _('Purpose') }}</th>
+        <th scope="col" class="govuk-table__header">{{ _('Expires') }}</th>
       </tr>
     </thead>
-    <tbody>
-      <tr>
-        <td class="u-width-20">session</td>
-        <td>{{ _('An identifier for your session') }}</td>
-        <td>{{ _('At the end of the session') }}</td>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header u-width-20">session</th>
+        <td class="govuk-table__cell">{{ _('An identifier for your session') }}</td>
+        <td class="govuk-table__cell">{{ _('At the end of the session') }}</td>
       </tr>
     </tbody>
   </table>
 
   <h3>{{ _('Welsh language selection') }}</h3>
-  <p>{{ _('You can choose to view this service in Welsh instead of English. If you choose Welsh, we set a cookie to remember that you have made this selection.') }}</p>
-  <table>
-    <thead>
-      <tr>
-        <th>{{ _('Name') }}</th>
-        <th>{{ _('Purpose') }}</th>
-        <th>{{ _('Expires') }}</th>
+  <p class="govuk-body">{{ _('You can choose to view this service in Welsh instead of English. If you choose Welsh, we set a cookie to remember that you have made this selection.') }}</p>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption">{{ _('Welsh language cookies') }}</caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">{{ _('Name') }}</th>
+        <th scope="col" class="govuk-table__header">{{ _('Purpose') }}</th>
+        <th scope="col" class="govuk-table__header">{{ _('Expires') }}</th>
       </tr>
     </thead>
-    <tbody>
-      <tr>
-        <td class="u-width-20">locale</td>
-        <td>{{ _('To remember your selection of Welsh language') }}</td>
-        <td>{{ _('1 month') }}</td>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell u-width-20">locale</td>
+        <td class="govuk-table__cell">{{ _('To remember your selection of Welsh language') }}</td>
+        <td class="govuk-table__cell">{{ _('1 month') }}</td>
       </tr>
     </tbody>
   </table>
 
-  <p>
+  <p class="govuk-body">
     {% trans govuk_cookies_link=Element.link_new_window('https://www.gov.uk/help/cookies', _('how cookies are used on gov.uk'), True) %}
       You can read more about {{ govuk_cookies_link }}.
     {% endtrans %}

--- a/cla_public/templates/cookies.html
+++ b/cla_public/templates/cookies.html
@@ -134,7 +134,7 @@
     </thead>
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell u-width-20">locale</td>
+        <th scope="row" class="govuk-table__header u-width-20">locale</th>
         <td class="govuk-table__cell">{{ _('To remember your selection of Welsh language') }}</td>
         <td class="govuk-table__cell">{{ _('1 month') }}</td>
       </tr>

--- a/cla_public/templates/feedback-confirmation.html
+++ b/cla_public/templates/feedback-confirmation.html
@@ -3,15 +3,15 @@
 {% import "macros/form.html" as Form %}
 {% import "macros/element.html" as Element %}
 
-{% set title = _('Thanks for your feedback') %}
+{% set title = _('Thank you for your feedback') %}
 {% block page_title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1 class="page-title">{{ title }}</h1>
-  <p>{{ _('We use the feedback to improve the service.')}} </p>
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
+  <p class="govuk-body">{{ _('We use the feedback to improve the service.')}} </p>
 
-  <p>
-    <a href="https://gov.uk/check-if-civil-legal-advice-can-help-you" class="button" role="button">
+  <p class="govuk-body">
+    <a class="govuk-button" href="https://gov.uk/check-if-civil-legal-advice-can-help-you" role="button">
       {{ _('Back to home page') }}
     </a>
   </p>

--- a/cla_public/templates/feedback.html
+++ b/cla_public/templates/feedback.html
@@ -7,10 +7,9 @@
 {% block page_title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1 class="page-title">{{ title }}</h1>
-  <p class="subtitle">
-    {% trans %}Please don't include any personal or financial details,
-    for example, your National Insurance or credit card numbers.{% endtrans %}
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
+  <p class="govuk-body-l">
+    {% trans %}Do not include any personal or financial details, for example, your National Insurance or credit card numbers.{% endtrans %}
   </p>
 
   <form method="POST" action="{{ url_for('.feedback') }}">
@@ -21,7 +20,7 @@
 
     {% if non_field_error %}
       {% call Element.alert('error', icon='cross') %}
-        <p>{{ non_field_error }}</p>
+        <p class="govuk-body">{{ non_field_error }}</p>
       {% endcall %}
     {% endif %}
 

--- a/cla_public/templates/laalaa.html
+++ b/cla_public/templates/laalaa.html
@@ -18,9 +18,9 @@
   {% block sidebar %}{% endblock %}
 
   {% block inner_content %}
-    <h1 class="page-title">{{ title }}</h1>
+    <h1 class="govuk-heading-xl">{{ title }}</h1>
 
-    <p>
+    <p class="govuk-body">
       {% if category == 'family' %}
         {% trans %}Search for a legal adviser or family mediator with a legal aid contract in England and Wales.{% endtrans %}
       {% else %}

--- a/cla_public/templates/macros/element.html
+++ b/cla_public/templates/macros/element.html
@@ -39,6 +39,12 @@
   {% endif %}
 {% endmacro %}
 
+{% macro inset() %}
+  <div class="govuk-inset-text">
+    {{ caller() }}
+  </div>
+{% endmacro %}
+
 
 {#
   'get in touch' link to contact page

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -386,7 +386,7 @@
 #}
 {% macro option_list(field, input_type='checkbox', separated_options=[], callback=None) %}
   <div
-    {% if input_type == 'radio' %}role="radiogroup" class="govuk-radios form-row" {% else %}role="group" class="govuk-radios form-row" {% endif %}
+    {% if input_type == 'radio' %}role="radiogroup" class="govuk-radios form-option-list" {% else %}role="group" class="govuk-radios form-option-list" {% endif %}
     aria-labelledby="field-label-{{ field.id }}"
   >
     {% for option in field %}

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -386,7 +386,7 @@
 #}
 {% macro option_list(field, input_type='checkbox', separated_options=[], callback=None) %}
   <div
-    {% if input_type == 'radio' %}role="radiogroup" class="govuk-radios form-option-list" {% else %}role="group" class="govuk-radios form-option-list" {% endif %}
+    {% if input_type == 'radio' %}role="radiogroup" class="govuk-radios" {% else %}role="group" class="govuk-radios" {% endif %}
     aria-labelledby="field-label-{{ field.id }}"
   >
     {% for option in field %}

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -385,23 +385,24 @@
         Macro to insert inside the each option
 #}
 {% macro option_list(field, input_type='checkbox', separated_options=[], callback=None) %}
-  <ul class="form-option-list form-row"
-    {% if input_type == 'radio' %}role="radiogroup"{% else %}role="group"{% endif %}
+  <div
+    {% if input_type == 'radio' %}role="radiogroup" class="govuk-radios form-row" {% else %}role="group" class="govuk-radios form-row" {% endif %}
     aria-labelledby="field-label-{{ field.id }}"
   >
     {% for option in field %}
-      <li{% if option.data in separated_options %} class="m-separate"{% endif %}>
-        <label class="radio-inline" for="{{option.id}}">
-          {{ option }}
+      {% if option.data in separated_options %}<div class="govuk-radios__divider">{% trans %}or{% endtrans %}</div>{% endif %}
+      <div class="govuk-radios__item">
+        {{ option(**{"class": "govuk-radios__input"}) }}
+        <label class="govuk-label govuk-radios__label" for="{{option.id}}">
           {{ option.label.text }}
         </label>
 
         {% if callback %}
           {{ callback(field, option) }}
         {% endif %}
-      </li>
+      </div>
     {% endfor %}
-  </ul>
+  </div>
 {% endmacro %}
 
 {% macro radio_tick_list(field, input_type='checkbox', separated_options=[], callback=None) %}

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -386,7 +386,7 @@
 #}
 {% macro option_list(field, input_type='checkbox', separated_options=[], callback=None) %}
   <div
-    {% if input_type == 'radio' %}role="radiogroup" class="govuk-radios form-row" {% else %}role="group" class="govuk-radios form-row" {% endif %}
+    {% if input_type == 'radio' %}role="radiogroup" class="govuk-radios" {% else %}role="group" class="govuk-radios" {% endif %}
     aria-labelledby="field-label-{{ field.id }}"
   >
     {% for option in field %}

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -386,7 +386,7 @@
 #}
 {% macro option_list(field, input_type='checkbox', separated_options=[], callback=None) %}
   <div
-    {% if input_type == 'radio' %}role="radiogroup" class="govuk-radios" {% else %}role="group" class="govuk-radios" {% endif %}
+    {% if input_type == 'radio' %}role="radiogroup" class="govuk-radios form-row" {% else %}role="group" class="govuk-radios form-row" {% endif %}
     aria-labelledby="field-label-{{ field.id }}"
   >
     {% for option in field %}

--- a/cla_public/templates/online-safety.html
+++ b/cla_public/templates/online-safety.html
@@ -3,39 +3,39 @@
 {% block page_title %}{{ _('Staying safe online') }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1 class="page-title">{{ _('Staying safe online') }}</h1>
+  <h1 class="govuk-heading-xl">{{ _('Staying safe online') }}</h1>
 
-  <p>{{ _('It can be easy for other people to see what you’re doing online, especially if you’re using a home computer.') }}</p>
-  <p>{{ _(' You can make it more difficult by following the tips below. But your safest option is to use a different computer - for example, at your local library - or someone else’s mobile.') }}</p>
+  <p class="govuk-body">{{ _('It can be easy for other people to see what you’re doing online, especially if you’re using a home computer.') }}</p>
+  <p class="govuk-body">{{ _(' You can make it more difficult by following the tips below. But your safest option is to use a different computer - for example, at your local library - or someone else’s mobile.') }}</p>
 
-  <h2>{{ _('How others can see where you’ve been') }}</h2>
-  <p>{{ _('Every time you use the internet your browser stores a record of what you’ve done with:') }}</p>
-  <ul>
+  <h2 class="govuk-heading-l">{{ _('How others can see where you’ve been') }}</h2>
+  <p class="govuk-body">{{ _('Every time you use the internet your browser stores a record of what you’ve done with:') }}</p>
+  <ul class="govuk-list govuk-list--bullet">
     <li>{{ _('a list of the pages you’ve looked at and the files you’ve downloaded') }}</li>
     <li>{{ _('text files called cookies which remember your settings for different sites') }}</li>
   </ul>
 
-  <h2>{{ _('How to cover your tracks') }}</h2>
-  <p>{{ _('You can improve your safety by deleting your history. But you need to be careful because:') }}</p>
-  <ul>
+  <h2 class="govuk-heading-l">{{ _('How to cover your tracks') }}</h2>
+  <p class="govuk-body">{{ _('You can improve your safety by deleting your history. But you need to be careful because:') }}</p>
+  <ul class="govuk-list govuk-list--bullet">
     <li>{{ _('deleting cookies will also get rid of stored passwords for online accounts') }}</li>
     <li>{{ _('clearing your history could make someone more suspicious') }}</li>
   </ul>
-  <p>{{ _('So just remove information about the websites you want to keep private. You can do that on:') }}</p>
-  <ul>
-    <li><a href="https://support.google.com/chrome/answer/95589?hl=en&rd=1" rel="external">{{ _('Google Chrome') }}</a></li>
-    <li><a href="http://windows.microsoft.com/en-gb/windows-vista/clear-the-history-of-websites-youve-visited" rel="external">{{ _('Internet Explorer') }}</a></li>
-    <li><a href="https://support.mozilla.org/en-US/kb/delete-browsing-search-download-history-firefox" rel="external">{{ _('Mozilla Firefox') }}</a></li>
-    <li><a href="https://support.apple.com/kb/PH19215?locale=en_US&viewlocale=en_US" rel="external">{{ _('Safari') }}</a></li>
-    <li><a href="http://www.opera.com/help/tutorials/security/sharing/" rel="external">{{ _('Opera') }}</a></li>
+  <p class="govuk-body">{{ _('So just remove information about the websites you want to keep private. You can do that on:') }}</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li><a class="govuk-link" href="https://support.google.com/chrome/answer/95589?hl=en&rd=1" rel="external">{{ _('Google Chrome') }}</a></li>
+    <li><a class="govuk-link" href="http://windows.microsoft.com/en-gb/windows-vista/clear-the-history-of-websites-youve-visited" rel="external">{{ _('Internet Explorer') }}</a></li>
+    <li><a class="govuk-link" href="https://support.mozilla.org/en-US/kb/delete-browsing-search-download-history-firefox" rel="external">{{ _('Mozilla Firefox') }}</a></li>
+    <li><a class="govuk-link" href="https://support.apple.com/kb/PH19215?locale=en_US&viewlocale=en_US" rel="external">{{ _('Safari') }}</a></li>
+    <li><a class="govuk-link" href="http://www.opera.com/help/tutorials/security/sharing/" rel="external">{{ _('Opera') }}</a></li>
   </ul>
 
-  <h2>{{ _('Browsing in private') }}</h2>
-  <p>
+  <h2 class="govuk-heading-l">{{ _('Browsing in private') }}</h2>
+  <p class="govuk-body">
     {{ _('You can also look at a website without information like cookies being stored by using the private browsing setting
     in your browser. Go to the menu, click on ‘File’ and choose:') }}
   </p>
-  <ul>
+  <ul class="govuk-list govuk-list--bullet">
     <li>{{ _('<strong>InPrivate</strong> on Internet Explorer') }}</li>
     <li>{{ _('<strong>Private Browsing</strong> on Mozilla Firefox or Opera') }}</li>
     <li>{{ _('<strong>Incognito</strong> on Google Chrome') }}</li>

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -46,13 +46,13 @@
   </p>
 
   <p class="govuk-body">
-    {% trans %}At this point, you will need to tell us your name and phone number and all the information you've entered will
+    {% trans %}At this point, you will need to tell us your name and phone number and all the information you’ve entered will
     be stored when you click 'Submit your application'. We store this information so that the operator can see it
     when they speak to you.{% endtrans %}
   </p>
 
   <p class="govuk-body">
-    {% trans %}If you don't want to speak to an operator, you don't need to enter any personal details and we don't store
+    {% trans %}If you don’t want to speak to an operator, you don’t need to enter any personal details and we don’t store
     any of the information you have entered.{% endtrans %}
   </p>
 
@@ -205,98 +205,102 @@
 
   <table class="govuk-table">
     <caption class="govuk-table__caption">{{ _('How we collect and store your personal data') }}</caption>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header u-width-20">{{ _('Phone') }}</th>
-      <td class="govuk-table__cell">
-        {% trans %}When you call <abbr>CLA</abbr> we will record relevant personal data that you provide within a secure digital system.
-        <br><br>
-        We may also record your calls. But you can choose to opt out of this or choose whether or not
-        to continue with the call.
-        <br><br>
-        If you leave <abbr>CLA</abbr> a voice message we will record the minimum amount of information
-        required in order to contact you back.{% endtrans %}
-      </td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">{{ _('Online') }}</th>
-      <td class="govuk-table__cell">
-        {% trans %}When you contact <abbr>CLA</abbr> online, the personal data that you provide will be recorded within a secure digital system.
-        <br><br>
-        Please note that transmitting information over the internet is generally not completely secure, and
-        <abbr>CLA</abbr> can’t guarantee the security of your data. Any data you transmit is at your own risk.
-        <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it.{% endtrans %}
-      </td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">{{ _('Email') }}</th>
-      <td class="govuk-table__cell">
-        {% trans %}Transmitting information via email is generally not completely secure, and <abbr>CLA</abbr> can’t guarantee the
-        security of your data. Any data you transmit is at your own risk.
-        <br><br>
-        <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it.
-        <br><br>
-        When you email <abbr>CLA</abbr>, relevant personal data that you provide will be recorded within a secure digital system.
-        <br><br>
-        <abbr>CLA</abbr> may monitor and store both your incoming and outgoing emails. We may also use blocking software.{% endtrans %}
-      </td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">{{ _('Post') }}</th>
-      <td class="govuk-table__cell">
-        {% trans %}When <abbr>CLA</abbr> receives post we may record relevant personal data included within a secure digital system.
-        <br><br>
-        <abbr>CLA</abbr> may also retain original hard-copies of information submitted by you. This must be stored in a locked
-        filing cabinet. Digital copies of letters may be scanned and stored.{% endtrans %}
-      </td>
-    </tr>
+    <tbody class="govuk-table__body govuk-!-font-size-16">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header u-width-20">{{ _('Phone') }}</th>
+        <td class="govuk-table__cell">
+          {% trans %}When you call <abbr>CLA</abbr> we will record relevant personal data that you provide within a secure digital system.
+          <br><br>
+          We may also record your calls. But you can choose to opt out of this or choose whether or not
+          to continue with the call.
+          <br><br>
+          If you leave <abbr>CLA</abbr> a voice message we will record the minimum amount of information
+          required in order to contact you back.{% endtrans %}
+        </td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">{{ _('Online') }}</th>
+        <td class="govuk-table__cell">
+          {% trans %}When you contact <abbr>CLA</abbr> online, the personal data that you provide will be recorded within a secure digital system.
+          <br><br>
+          Please note that transmitting information over the internet is generally not completely secure, and
+          <abbr>CLA</abbr> can’t guarantee the security of your data. Any data you transmit is at your own risk.
+          <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it.{% endtrans %}
+        </td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">{{ _('Email') }}</th>
+        <td class="govuk-table__cell">
+          {% trans %}Transmitting information via email is generally not completely secure, and <abbr>CLA</abbr> can’t guarantee the
+          security of your data. Any data you transmit is at your own risk.
+          <br><br>
+          <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it.
+          <br><br>
+          When you email <abbr>CLA</abbr>, relevant personal data that you provide will be recorded within a secure digital system.
+          <br><br>
+          <abbr>CLA</abbr> may monitor and store both your incoming and outgoing emails. We may also use blocking software.{% endtrans %}
+        </td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">{{ _('Post') }}</th>
+        <td class="govuk-table__cell">
+          {% trans %}When <abbr>CLA</abbr> receives post we may record relevant personal data included within a secure digital system.
+          <br><br>
+          <abbr>CLA</abbr> may also retain original hard-copies of information submitted by you. This must be stored in a locked
+          filing cabinet. Digital copies of letters may be scanned and stored.{% endtrans %}
+        </td>
+      </tr>
+    </tbody>
   </table>
 
   <table class="govuk-table">
     <caption class="govuk-table__caption">{{ _('Keeping your personal data safe from others') }}</caption>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header u-width-20">{{ _('Repeat Contacts') }}</th>
-      <td class="govuk-table__cell">
-        {% trans %}<abbr>CLA</abbr> will not disclose any personal information to anyone contacting the <abbr>CLA</abbr> service until
-        they have successfully verified that their identity matches that of an existing record.{% endtrans %}
-      </td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">{{ _('Third-parties') }}</th>
-      <td class="govuk-table__cell">
-        {% trans %}<abbr>CLA</abbr> will accept contact made by a third-party on behalf of another person. The third party has to
-        demonstrate they have appropriate authority to act on your behalf.
-        <br><br>
-        <abbr>CLA</abbr> must record the relationship between the third-party and the individual seeking advice
-        and whether they are authorised to act on their behalf.
-        <br><br>
-        They must also agree a password to verify the identity of the third-party if they contact the service again.{% endtrans %}
-      </td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">{{ _('Outgoing Communications') }}</th>
-      <td class="govuk-table__cell">
-        {{ _('<abbr>CLA</abbr> may need to contact you directly.') }}
-        <br><br>
-        {{ _('In order to protect privacy, <abbr>CLA</abbr> will always check with you what forms of outgoing communication are acceptable and appropriate and whether messages can be left.') }}
-        <br><br>
-        {{ _('When making outgoing calls to you, <abbr>CLA</abbr> will ensure that:') }}
-        <ul class="govuk-list govuk-list--bullet">
-          <li>
-            {% trans %}Call backs are only made where you have agreed to this. Authorised third parties
-            acting on your behalf can give agreement.{% endtrans %}
-          </li>
-          <li>
-            {% trans %}Where a call back is made to you and there is no answer and a message taker is available,
-            no message will be left unless you have previously given specific instructions that this would be acceptable.{% endtrans %}
-          </li>
-          <li>
-            {% trans %}Where the phone is answered and someone other than you answers the phone and says that you are
-            unavailable or asks who is calling, <abbr>CLA</abbr> will state that the call is confidential and will not say
-            that they are calling from <abbr>CLA</abbr>.{% endtrans %}
-          </li>
-        </ul>
-      </td>
-    </tr>
+    <tbody class="govuk-table__body govuk-!-font-size-16">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header u-width-20">{{ _('Repeat Contacts') }}</th>
+        <td class="govuk-table__cell">
+          {% trans %}<abbr>CLA</abbr> will not disclose any personal information to anyone contacting the <abbr>CLA</abbr> service until
+          they have successfully verified that their identity matches that of an existing record.{% endtrans %}
+        </td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">{{ _('Third-parties') }}</th>
+        <td class="govuk-table__cell">
+          {% trans %}<abbr>CLA</abbr> will accept contact made by a third-party on behalf of another person. The third party has to
+          demonstrate they have appropriate authority to act on your behalf.
+          <br><br>
+          <abbr>CLA</abbr> must record the relationship between the third-party and the individual seeking advice
+          and whether they are authorised to act on their behalf.
+          <br><br>
+          They must also agree a password to verify the identity of the third-party if they contact the service again.{% endtrans %}
+        </td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">{{ _('Outgoing Communications') }}</th>
+        <td class="govuk-table__cell">
+          {{ _('<abbr>CLA</abbr> may need to contact you directly.') }}
+          <br><br>
+          {{ _('In order to protect privacy, <abbr>CLA</abbr> will always check with you what forms of outgoing communication are acceptable and appropriate and whether messages can be left.') }}
+          <br><br>
+          {{ _('When making outgoing calls to you, <abbr>CLA</abbr> will ensure that:') }}
+          <ul class="govuk-list govuk-list--bullet govuk-table__body govuk-!-font-size-16">
+            <li>
+              {% trans %}Call backs are only made where you have agreed to this. Authorised third parties
+              acting on your behalf can give agreement.{% endtrans %}
+            </li>
+            <li>
+              {% trans %}Where a call back is made to you and there is no answer and a message taker is available,
+              no message will be left unless you have previously given specific instructions that this would be acceptable.{% endtrans %}
+            </li>
+            <li>
+              {% trans %}Where the phone is answered and someone other than you answers the phone and says that you are
+              unavailable or asks who is calling, <abbr>CLA</abbr> will state that the call is confidential and will not say
+              that they are calling from <abbr>CLA</abbr>.{% endtrans %}
+            </li>
+          </ul>
+        </td>
+      </tr>
+    </tbody>
   </table>
 
 
@@ -348,13 +352,14 @@
     you with the organisations mentioned below. But we will only do this if you have given us permission, when the operator asks for it, or when it is lawful to do so.{% endtrans %}
   </p>
   <table class="govuk-table">
+    <caption class="govuk-table__caption">{{ _('Who we share information with') }}</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header u-width-50">{{ _('Who') }}</th>
         <th scope="col" class="govuk-table__header u-width-50">{{ _('Why') }}</th>
       </tr>
     </thead>
-    <tbody class="govuk-table__body">
+    <tbody class="govuk-table__body govuk-!-font-size-16">
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           {% trans %}External research organisations engaged by <abbr title="Legal Aid Agency">LAA</abbr>
@@ -405,13 +410,14 @@
     <li>{{ _('Only share information on a ‘need to know’ basis.') }}</li>
   </ul>
   <table class="govuk-table">
+    <caption class="govuk-table__caption">{{ _('Who we share information with') }}</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header u-width-50">{{ _('Who') }}</th>
         <th scope="col" class="govuk-table__header u-width-50">{{ _('Why') }}</th>
       </tr>
     </thead>
-    <tbody class="govuk-table__body">
+    <tbody class="govuk-table__body govuk-!-font-size-16">
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           {{ _('Other government organisations') }}

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -107,7 +107,7 @@
 
   <h2 class="govuk-heading-l">{{ _('What types of personal data do we process?') }}</h2>
   <p class="govuk-body">
-    {% trans %}<abbr>CLA</abbr> will only collect the minimum amount of information that is necessary and relevant, in order to deliver the <abbr>CLA</abbr> service to you.{% endtrans %}
+    {% trans %}<abbr title="Civil Legal Advice">CLA</abbr> will only collect the minimum amount of information that is necessary and relevant, in order to deliver the <abbr>CLA</abbr> service to you.{% endtrans %}
   </p>
   <p class="govuk-body">
     {{ _('The kind of information <abbr>CLA</abbr> may collect about you includes:') }}

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -203,8 +203,8 @@
     as outlined in this Privacy Statement.{% endtrans %}
   </p>
 
-  <h3 class="govuk-heading-m">{{ _('How we collect and store your personal data') }}</h3>
   <table class="govuk-table">
+    <caption>{{ _('How we collect and store your personal data') }}</caption>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header u-width-20">{{ _('Phone') }}</th>
       <td class="govuk-table__cell">
@@ -251,9 +251,8 @@
     </tr>
   </table>
 
-
-  <h3 class="govuk-heading-m">{{ _('Keeping your personal data safe from others') }}</h3>
   <table class="govuk-table">
+    <caption>{{ _('Keeping your personal data safe from others') }}</caption>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header u-width-20">{{ _('Repeat Contacts') }}</th>
       <td class="govuk-table__cell">

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -12,7 +12,7 @@
 
   <p class="govuk-body">{{ _('If you do not agree to these terms and privacy policy, do not use this service.') }}</p>
 
-  <h2 class="govuk-heading-m">{{ _('Who manages this digital service and Civil Legal Advice') }}</h3>
+  <h2 class="govuk-heading-m">{{ _('Who manages this digital service and Civil Legal Advice') }}</h2>
   <p class="govuk-body">
     {% trans %}The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for the Civil Legal Advice (<abbr>CLA</abbr>) service. The <abbr title="Legal Aid Agency">LAA</abbr> works with other
     organisations who deliver the <abbr title="Civil Legal Advice">CLA</abbr> service. For example this digital service is managed by the Ministry of

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -204,7 +204,7 @@
   </p>
 
   <table class="govuk-table">
-    <caption>{{ _('How we collect and store your personal data') }}</caption>
+    <caption class="govuk-table__caption">{{ _('How we collect and store your personal data') }}</caption>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header u-width-20">{{ _('Phone') }}</th>
       <td class="govuk-table__cell">
@@ -252,7 +252,7 @@
   </table>
 
   <table class="govuk-table">
-    <caption>{{ _('Keeping your personal data safe from others') }}</caption>
+    <caption class="govuk-table__caption">{{ _('Keeping your personal data safe from others') }}</caption>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header u-width-20">{{ _('Repeat Contacts') }}</th>
       <td class="govuk-table__cell">
@@ -358,7 +358,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           {% trans %}External research organisations engaged by <abbr title="Legal Aid Agency">LAA</abbr>
-          or <abbr title="The Ministry of Justice">MoJ</abbr>{% endtrans %}
+          or the <abbr title="Ministry of Justice">MoJ</abbr>{% endtrans %}
         </td>
         <td class="govuk-table__cell">
           {% trans %}To inform future government policy on legal aid. Such research will not identify

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -81,9 +81,9 @@
   </p>
 
   <p class="govuk-body">
-    {% trans %}The Legal Aid Agency (<abbr title="Legal Aid Agency">LAA</abbr>) is responsible for the <abbr>CLA</abbr>
-    service and the Ministry of Justice (<abbr title="The Ministry of Justice">MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title="Legal Aid Agency">LAA</abbr>) is an
-     Executive Agency of the Ministry of Justice (<abbr title="The Ministry of Justice">MoJ</abbr>).{% endtrans %}
+    {% trans %}The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for <abbr title="Civil Legal Advice">CLA</abbr>
+    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr>LAA</abbr>) is an
+    Executive Agency of the <abbr title="Ministry of Justice">MoJ</abbr>.{% endtrans %}
   </p>
   
   <p class="govuk-body">

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -3,116 +3,116 @@
 {% block page_title %}{{ _('Privacy Statement') }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1 class="page-title">{{ _('Terms and conditions and privacy') }}</h1>
+  <h1 class="govuk-heading-xl">{{ _('Terms and conditions and privacy') }}</h1>
 
-  <p>
-    {% trans %}When using this service you agree to the terms of use for both <a href="http://gov.uk/help/terms-conditions">gov.uk/help/terms-conditions</a> as well as
+  <p class="govuk-body">
+    {% trans %}When using this service you agree to the terms of use for both <a class="govuk-link" href="http://gov.uk/help/terms-conditions">gov.uk/help/terms-conditions</a> as well as
     the terms and conditions specific to this service found below.{% endtrans %}
   </p>
 
-  <p>{{ _('If you do not agree to these terms and privacy policy, do not use this service.') }}</p>
+  <p class="govuk-body">{{ _('If you do not agree to these terms and privacy policy, do not use this service.') }}</p>
 
-  <h3>{{ _('Who manages this digital service and Civil Legal Advice') }}</h3>
-  <p>
-    {% trans %}The Legal Aid Agency (<abbr title="The Legal Aid Agency">LAA</abbr>) is responsible for the Civil Legal Advice (<abbr title="Civil Legal Advice">CLA</abbr>) service. The <abbr title="The Legal Aid Agency">LAA</abbr> works with other
+  <h2 class="govuk-heading-m">{{ _('Who manages this digital service and Civil Legal Advice') }}</h3>
+  <p class="govuk-body">
+    {% trans %}The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for the Civil Legal Advice (<abbr>CLA</abbr>) service. The <abbr title="Legal Aid Agency">LAA</abbr> works with other
     organisations who deliver the <abbr title="Civil Legal Advice">CLA</abbr> service. For example this digital service is managed by the Ministry of
-    Justice.{% endtrans %}
+    Justice (<abbr>MoJ</abbr>).{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}When you first make contact with <abbr title="Civil Legal Advice">CLA</abbr> you will communicate with the <abbr title="Civil Legal Advice">CLA</abbr> Operator Service (CLAOS), which is delivered by
     Hinduja Global Solutions UK Limited.{% endtrans %}
   </p> 
 
-  <p>
-    {% trans %}Hinduja Global Solutions UK Limited is a contractor employed by the <abbr title="The Legal Aid Agency">LAA</abbr>
+  <p class="govuk-body">
+    {% trans %}Hinduja Global Solutions UK Limited is a contractor employed by the <abbr title="Legal Aid Agency">LAA</abbr>
     to deliver the <abbr title="Civil Legal Advice">CLA</abbr> Operator Service.{% endtrans %}
   </p>
 
-  <h3>{{ _('Complaints') }}</h3>
-  <p>
+  <h3 class="govuk-heading-m">{{ _('Complaints') }}</h3>
+  <p class="govuk-body">
     {{ _('If you would like to make a complaint about this service or Civil Legal Advice please contact <abbr title="Civil Legal Advice">CLA</abbr> on 0345 345 4 345.') }}
   </p>
 
-  <h2>{{ _('How is my privacy protected?') }}</h2>
-  <p>
+  <h2 class="govuk-heading-l">{{ _('How is my privacy protected?') }}</h2>
+  <p class="govuk-body">
     {% trans %}Protecting your privacy is important to us. You can use this service to find out if you might qualify for
     legal aid without providing any personal information that could identify you.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}We only save the information you enter if you decide to contact a Civil Legal Advice
     operator.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}At this point, you will need to tell us your name and phone number and all the information you've entered will
     be stored when you click 'Submit your application'. We store this information so that the operator can see it
     when they speak to you.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}If you don't want to speak to an operator, you don't need to enter any personal details and we don't store
     any of the information you have entered.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}To provide you with the best service that we can, Civil Legal Advice may share some information about you
     with other organisations. But we will only do this, if you have given us permission or when we have a lawful basis for doing so.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}In exceptional circumstances, we may share limited information about you without your consent. This would
     only be to prevent fraud, to help detect crime, if it is required by law or by a court order or if we are
     very worried about your safety or the safety of others.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}In order to provide a service to you, Civil Legal Advice (<abbr title="Civil Legal Advice">CLA</abbr>)
     may need to view, collect, record and hold (‘process’) personal data about you.{% endtrans %}
   </p>
-  <p>
+  <p class="govuk-body">
     {% trans %}Personal data is information about you as an individual. It can be your name, address or telephone number. It can also include the information that you have provided in this form, such as your financial circumstances.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}This statement explains how <abbr>CLA</abbr> will process any personal data that we collect
     from you or that you provide to us.{% endtrans %}
   </p>
 
-  <p>
-    {% trans %}The Legal Aid Agency (<abbr title="The Legal Aid Agency">LAA</abbr>) is responsible for the <abbr>CLA</abbr>
-    service and the Ministry of Justice (<abbr title="The Ministry of Justice">MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title="The Legal Aid Agency">LAA</abbr>) is an
+  <p class="govuk-body">
+    {% trans %}The Legal Aid Agency (<abbr title="Legal Aid Agency">LAA</abbr>) is responsible for the <abbr>CLA</abbr>
+    service and the Ministry of Justice (<abbr title="The Ministry of Justice">MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title="Legal Aid Agency">LAA</abbr>) is an
      Executive Agency of the Ministry of Justice (<abbr title="The Ministry of Justice">MoJ</abbr>).{% endtrans %}
   </p>
   
-  <p>
-    {% trans %}The <abbr title="The Legal Aid Agency">LAA</abbr> works with other organisations who deliver the <abbr>CLA</abbr> service.
+  <p class="govuk-body">
+    {% trans %}The <abbr title="Legal Aid Agency">LAA</abbr> works with other organisations who deliver the <abbr>CLA</abbr> service.
     For example, when you first make contact with <abbr>CLA</abbr>, you will communicate with
     the <abbr>CLA</abbr> Operator Service, which is delivered by Hinduja Global Solutions UK Limited
-    (a contractor employed by the <abbr title="The Legal Aid Agency">LAA</abbr>).{% endtrans %}
+    (a contractor employed by the <abbr title="Legal Aid Agency">LAA</abbr>).{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}Once you have contacted the <abbr>CLA</abbr> Operator Service, if you are likely to qualify for Legal Aid, the operator will transfer you to
      a <abbr>CLA</abbr> Specialist Provider. If you do not qualify to receive
     <abbr>CLA</abbr> Specialist advice, the operator will inform you accordingly and direct you to alternative sources of help.{% endtrans %}
   </p>
   
-  <p>
+  <p class="govuk-body">
     {% trans %}The <abbr>CLA</abbr> service is committed to following this Privacy Statement.
     <abbr>CLA</abbr> Specialists must also adhere to their own internal privacy policy.{% endtrans %}
   </p>
 
 
-  <h2>{{ _('What types of personal data do we process?') }}</h2>
-  <p>
+  <h2 class="govuk-heading-l">{{ _('What types of personal data do we process?') }}</h2>
+  <p class="govuk-body">
     {% trans %}<abbr>CLA</abbr> will only collect the minimum amount of information that is necessary and relevant, in order to deliver the <abbr>CLA</abbr> service to you.{% endtrans %}
   </p>
-  <p>
+  <p class="govuk-body">
     {{ _('The kind of information <abbr>CLA</abbr> may collect about you includes:') }}
   </p>
-  <ul>
+  <ul class="govuk-list govuk-list--bullet">
     <li>
       {% trans %}Personal details including your name, address, date of birth, contact details, diversity
       monitoring information and national insurance number;{% endtrans %}
@@ -131,16 +131,16 @@
       for a review of our decision about whether you qualify for legal aid.{% endtrans %}
     </li>
   </ul>
-  <p>
+  <p class="govuk-body">
     {% trans %}The amount of information <abbr>CLA</abbr> will collect will depend on whether you qualify for the <abbr>CLA</abbr>
     service and/or your specific needs. For example, you will be asked to provide more information
     before we can transfer you through to a <abbr>CLA</abbr> Specialist.{% endtrans %}
   </p>
 
 
-  <h2>{{ _('How does <abbr>CLA</abbr> use your data and why?') }}</h2>
-  <p><abbr>CLA</abbr> {{ _('collects and records information about you to:') }}</p>
-  <ul>
+  <h2 class="govuk-heading-l">{{ _('How does <abbr>CLA</abbr> use your data and why?') }}</h2>
+  <p class="govuk-body"><abbr>CLA</abbr> {{ _('collects and records information about you to:') }}</p>
+  <ul class="govuk-list govuk-list--bullet">
     <li>{{ _('Work out whether you qualify for legal aid;') }}</li>
     <li>{{ _('Provide information and/or advice services to you;') }}</li>
     <li>{{ _('Save you from repeating information every time you contact us;') }}</li>
@@ -157,57 +157,57 @@
     <li>{{ _('Conduct occasional assurance audits to ensure that the decisions we make are correct and accurate.') }}</li>
   </ul>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}Without this information, <abbr>CLA</abbr> would not be able to conduct the activities above which are essential to the delivery of legal aid.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}The lawful basis for <abbr>CLA</abbr> collecting and processing your personal data is the result of the powers contained in legislation, specifically the Legal Aid, Sentencing
      and Punishment of Offenders Act 2012.{% endtrans %}
   </p>
 
- <p>
+ <p class="govuk-body">
     {% trans %}<abbr>CLA</abbr> also collects ‘special categories of personal data’ for the purposes of monitoring equality. This is a legal requirement for public authorities, under the Equality Act 2010.
      Special categories of personal data obtained for equality monitoring will be treated with the strictest confidence and any information published will not identify you or anyone else associated with your legal aid application.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}Given the purposes for which your personal data may be used (as referred to above)
     it is essential that the information you provide is accurate and complete.{% endtrans %}
   </p>
 
-  <h2>{{ _('How does <abbr>CLA</abbr> collect your personal data and keep it safe?') }}</h2>
-  <p>
+  <h2 class="govuk-heading-l">{{ _('How does <abbr>CLA</abbr> collect your personal data and keep it safe?') }}</h2>
+  <p class="govuk-body">
     {% trans %}<abbr>CLA</abbr> may collect personal data about you by phone, online, email or post (see table below).
     Any personal data will be recorded and stored within a secure system that meets required Government standards.{% endtrans %}
   </p>
-  <p>
+  <p class="govuk-body">
     {% trans %}<abbr>CLA</abbr> will be able to view and verify the information that you provide and, where
     necessary, will amend it to maintain its accuracy.{% endtrans %}
   </p>
-  <p>
+  <p class="govuk-body">
     {% trans %}The minimum amount of personal data that <abbr>CLA</abbr> will ask to collect is your name and two other pieces
     of personal information that could be used to identify you, e.g. postcode, date of birth or telephone number.{% endtrans %}
   </p>
-  <p>
+  <p class="govuk-body">
     {% trans %}As your personal data is stored on our IT infrastructure, and shared with our data processors, it may be transferred
      and stored securely outside the European Economic Area (EEA). Where that is the case, it will be subject to equivalent legal protection through the use of Model Contract Clauses.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}Any transfers made will be in full compliance with all aspects of the data protection law.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}By submitting your personal data, you agree to information being recorded, used and stored
     as outlined in this Privacy Statement.{% endtrans %}
   </p>
 
-  <h3>{{ _('How we collect and store your personal data') }}</h3>
-  <table>
-    <tr>
-      <th class="u-width-20">{{ _('Phone') }}</th>
-      <td>
+  <h3 class="govuk-heading-m">{{ _('How we collect and store your personal data') }}</h3>
+  <table class="govuk-table">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header u-width-20">{{ _('Phone') }}</th>
+      <td class="govuk-table__cell">
         {% trans %}When you call <abbr>CLA</abbr> we will record relevant personal data that you provide within a secure digital system.
         <br><br>
         We may also record your calls. But you can choose to opt out of this or choose whether or not
@@ -217,9 +217,9 @@
         required in order to contact you back.{% endtrans %}
       </td>
     </tr>
-    <tr>
-      <th>{{ _('Online') }}</th>
-      <td>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">{{ _('Online') }}</th>
+      <td class="govuk-table__cell">
         {% trans %}When you contact <abbr>CLA</abbr> online, the personal data that you provide will be recorded within a secure digital system.
         <br><br>
         Please note that transmitting information over the internet is generally not completely secure, and
@@ -227,9 +227,9 @@
         <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it.{% endtrans %}
       </td>
     </tr>
-    <tr>
-      <th>{{ _('Email') }}</th>
-      <td>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">{{ _('Email') }}</th>
+      <td class="govuk-table__cell">
         {% trans %}Transmitting information via email is generally not completely secure, and <abbr>CLA</abbr> can’t guarantee the
         security of your data. Any data you transmit is at your own risk.
         <br><br>
@@ -240,9 +240,9 @@
         <abbr>CLA</abbr> may monitor and store both your incoming and outgoing emails. We may also use blocking software.{% endtrans %}
       </td>
     </tr>
-    <tr>
-      <th>{{ _('Post') }}</th>
-      <td>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">{{ _('Post') }}</th>
+      <td class="govuk-table__cell">
         {% trans %}When <abbr>CLA</abbr> receives post we may record relevant personal data included within a secure digital system.
         <br><br>
         <abbr>CLA</abbr> may also retain original hard-copies of information submitted by you. This must be stored in a locked
@@ -252,18 +252,18 @@
   </table>
 
 
-  <h3>{{ _('Keeping your personal data safe from others') }}</h3>
-  <table>
-    <tr>
-      <th class="u-width-20">{{ _('Repeat Contacts') }}</th>
-      <td>
+  <h3 class="govuk-heading-m">{{ _('Keeping your personal data safe from others') }}</h3>
+  <table class="govuk-table">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header u-width-20">{{ _('Repeat Contacts') }}</th>
+      <td class="govuk-table__cell">
         {% trans %}<abbr>CLA</abbr> will not disclose any personal information to anyone contacting the <abbr>CLA</abbr> service until
         they have successfully verified that their identity matches that of an existing record.{% endtrans %}
       </td>
     </tr>
-    <tr>
-      <th>{{ _('Third-parties') }}</th>
-      <td>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">{{ _('Third-parties') }}</th>
+      <td class="govuk-table__cell">
         {% trans %}<abbr>CLA</abbr> will accept contact made by a third-party on behalf of another person. The third party has to
         demonstrate they have appropriate authority to act on your behalf.
         <br><br>
@@ -273,15 +273,15 @@
         They must also agree a password to verify the identity of the third-party if they contact the service again.{% endtrans %}
       </td>
     </tr>
-    <tr>
-      <th>{{ _('Outgoing Communications') }}</th>
-      <td>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">{{ _('Outgoing Communications') }}</th>
+      <td class="govuk-table__cell">
         {{ _('<abbr>CLA</abbr> may need to contact you directly.') }}
         <br><br>
         {{ _('In order to protect privacy, <abbr>CLA</abbr> will always check with you what forms of outgoing communication are acceptable and appropriate and whether messages can be left.') }}
         <br><br>
         {{ _('When making outgoing calls to you, <abbr>CLA</abbr> will ensure that:') }}
-        <ul>
+        <ul class="govuk-list govuk-list--bullet">
           <li>
             {% trans %}Call backs are only made where you have agreed to this. Authorised third parties
             acting on your behalf can give agreement.{% endtrans %}
@@ -301,15 +301,15 @@
   </table>
 
 
-  <h2>{{ _('How we use cookies') }}</h2>
-  <p>
+  <h2 class="govuk-heading-l">{{ _('How we use cookies') }}</h2>
+  <p class="govuk-body">
     {% trans %}When you use our online services we may store a small file, known as a cookie, on your
     <abbr title="Personal Computer">PC</abbr> or digital device.{% endtrans %}
   </p>
-  <p>{{ _('You may see a message before we store a cookie on your computer.') }}</p>
-  <p>{{ _('The cookies are not used to identify you personally.') }}</p>
-  <p>{{ _('We use these cookies to:') }}</p>
-  <ul>
+  <p class="govuk-body">{{ _('You may see a message before we store a cookie on your computer.') }}</p>
+  <p class="govuk-body">{{ _('The cookies are not used to identify you personally.') }}</p>
+  <p class="govuk-body">{{ _('We use these cookies to:') }}</p>
+  <ul class="govuk-list govuk-list--bullet">
     <li>{{ _('Help your <abbr>PC</abbr> or digital device to interact with us more quickly') }}</li>
     <li>{{ _('Measure how you use our service so it can be updated and improved based on your needs') }}</li>
     <li>{{ _('Remember the notifications you’ve seen so that we don’t show them to you again') }}</li>
@@ -322,112 +322,112 @@
       a gov.uk service in an attempt to gather your information{% endtrans %}
     </li>
   </ul>
-  <p>
+  <p class="govuk-body">
     {% trans %}The online service also uses cookies from the Government Digital Service (GDS). These cookies collect information to help improve the user experience across government digital services.{% endtrans %}
-    <p>
-    {% trans cookie_settings_url = url_for('.cookie_settings') %}You can change <a href="{{ cookie_settings_url }}">your cookie settings</a> to opt in or out of how different cookies are used.{% endtrans %}
   </p>
-  <p>
-    {% trans cookie_url = url_for('.cookies') %}You can read more about <a href="{{ cookie_url }}">cookies used on 
+  <p class="govuk-body">
+    {% trans cookie_settings_url = url_for('.cookie_settings') %}You can change <a class="govuk-link" href="{{ cookie_settings_url }}">your cookie settings</a> to opt in or out of how different cookies are used.{% endtrans %}
+  </p>
+  <p class="govuk-body">
+    {% trans cookie_url = url_for('.cookies') %}You can read more about <a class="govuk-link" href="{{ cookie_url }}">cookies used on 
     check you can get legal aid</a>.{% endtrans %}
   </p>
-  <p>
+  <p class="govuk-body">
     {% trans %}You can read about
-    <a href="http://www.aboutcookies.org/" rel="external">how to manage cookies</a>.{% endtrans %}
+    <a class="govuk-link" href="http://www.aboutcookies.org/" rel="external">how to manage cookies</a>.{% endtrans %}
   </p>
 
 
-  <h2>{{ _('When will we share information about you outside <abbr>CLA</abbr>?') }}</h2>
-  <p>{{ _('Confidentiality means ensuring information is only accessible by those allowed to have access to it.') }}</p>
-  <p>
+  <h2 class="govuk-heading-l">{{ _('When will we share information about you outside <abbr>CLA</abbr>?') }}</h2>
+  <p class="govuk-body">{{ _('Confidentiality means ensuring information is only accessible by those allowed to have access to it.') }}</p>
+  <p class="govuk-body">
     {% trans %}We want to keep your contact with <abbr>CLA</abbr> confidential, which means you can feel safe talking to us.
     But we sometimes need to share some information outside <abbr>CLA</abbr> which we explain below.{% endtrans %}
   </p>
-  <p>
+  <p class="govuk-body">
     {% trans %}In order to provide you with the best service that we can we may share some information about
     you with the organisations mentioned below. But we will only do this if you have given us permission, when the operator asks for it, or when it is lawful to do so.{% endtrans %}
   </p>
-  <table>
-    <thead>
-      <tr>
-        <th class="u-width-50">{{ _('Who') }}</th>
-        <th class="u-width-50">{{ _('Why') }}</th>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header u-width-50">{{ _('Who') }}</th>
+        <th scope="col" class="govuk-table__header u-width-50">{{ _('Why') }}</th>
       </tr>
     </thead>
-    <tbody>
-      <tr>
-        <td>
-          {% trans %}External research organisations engaged by <abbr title="The Legal Aid Agency">LAA</abbr>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          {% trans %}External research organisations engaged by <abbr title="Legal Aid Agency">LAA</abbr>
           or <abbr title="The Ministry of Justice">MoJ</abbr>{% endtrans %}
         </td>
-        <td>
+        <td class="govuk-table__cell">
           {% trans %}To inform future government policy on legal aid. Such research will not identify
           individuals whose data has been used for research purposes.{% endtrans %}
         </td>
       </tr>
-      <tr>
-        <td>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
           {{ _('Other government organisations') }}
           <br><br>
           {{ _('These organisations may include the Department of Work and Pensions (DWP), HM Courts and Tribunals Service (HMCTS), HM Revenue and Customs (HMRC).') }}
         </td>
-        <td>
+        <td class="govuk-table__cell">
           {{ _('To verify information provided by you and check whether you qualify for legal aid.') }}
         </td>
       </tr>
-      <tr>
-        <td>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
           {{ _('Other advice organisations and non-governmental organisations') }}
           <br><br>
           {{ _('These organisations may include credit reference agencies.') }}
         </td>
-        <td>
+        <td class="govuk-table__cell">
           {{ _('To help you get further help and advice from appropriate organisations.') }}
           <br><br>
-          {{ _('To verify information provided by you, when conducting audits on our decisions and eligibility assessments.
-') }}
+          {{ _('To verify information provided by you, when conducting audits on our decisions and eligibility assessments.') }}
         </td>
       </tr>
     </tbody>
   </table>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}When this is necessary, we will comply with all aspects of the relevant data protection laws.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}In exceptional circumstances we may share limited information without your consent,
     for example if it is a legal requirement or a court compels us to do so.{% endtrans %}
   </p>
-  <p>{{ _('If we do this, we will wherever possible:') }}</p>
-  <ul>
+  <p class="govuk-body">{{ _('If we do this, we will wherever possible:') }}</p>
+  <ul class="govuk-list govuk-list--bullet">
     <li>{{ _('Talk to you first') }}</li>
     <li>{{ _('Give you as much control as possible over how we do this') }}</li>
     <li>{{ _('Only share information on a ‘need to know’ basis.') }}</li>
   </ul>
-  <table>
-    <thead>
-      <tr>
-        <th class="u-width-50">{{ _('Who') }}</th>
-        <th class="u-width-50">{{ _('Why') }}</th>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header u-width-50">{{ _('Who') }}</th>
+        <th scope="col" class="govuk-table__header u-width-50">{{ _('Why') }}</th>
       </tr>
     </thead>
-    <tbody>
-      <tr>
-        <td>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
           {{ _('Other government organisations') }}
         </td>
-        <td>
+        <td class="govuk-table__cell">
           {{ _('To prevent fraud and to help detect crime.') }}
           <br><br>
           {{ _('Or where it is required by law or by a court order') }}
         </td>
       </tr>
-      <tr>
-        <td>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
           {{ _('External protection organisations') }}
         </td>
-        <td>
+        <td class="govuk-table__cell">
           {% trans %}If we are very worried about your safety or the safety of other people we may need to let others know.
           <br><br>
           For example if we think it necessary in order to protect a child, young person or vulnerable adult
@@ -438,33 +438,28 @@
   </table>
 
 
-  <h2>{{ _('Access to personal information') }}</h2>
-  <p>{{ _('You can find out if we hold any personal data about you and request a copy of this information by writing to the Legal Aid Agency to make a ‘subject access request’.
+  <h2 class="govuk-heading-l">{{ _('Access to personal information') }}</h2>
+  <p class="govuk-body">{{ _('You can find out if we hold any personal data about you and request a copy of this information by writing to the Legal Aid Agency to make a ‘subject access request’.
    If you wish to make a subject access request, you will need to contact:') }}</p>
   
 
-  <p class="vcard">
-    
-    <address class="adr">
-      <span class="extended-address">
-        <span>Disclosure Team</span>
-        <span>Post Point 10.38</span>
-        <span class="street-address">102 Petty France</span>
-        <span class="locality">London</span>
-        <span class="postal-code">SW1H 9AJ</span>       
-      </span>
-
-    </address>
-
+  <p class="govuk-body">
+    Disclosure Team<br />
+    Legal Aid Agency<br />
+    <!--Post Point 10.38<br />-->
+    102 Petty France<br />
+    London<br />
+    SW1H 9AJ       
   </p>
 
-    <p>
-      {{ _('You can also email at <a class="email" href="mailto:data.access@justice.gov.uk">data.access@justice.gov.uk</a>.') }}
-      </p>
 
-<p>{{ _('When making a subject access request for a copy of your personal information, please provide the following information:') }}</p>
+  <p class="govuk-body">
+    {{ _('You can also email at <a class="govuk-link email" href="mailto:data.access@justice.gov.uk">data.access@justice.gov.uk</a>.') }}
+  </p>
 
-  <ul>
+  <p class="govuk-body">{{ _('When making a subject access request for a copy of your personal information, please provide the following information:') }}</p>
+
+  <ul class="govuk-list govuk-list--bullet">
     <li>{{ _('Full name') }}</li>
     <li>{{ _('Address') }}</li>
     <li>{{ _('Date of birth') }}</li>
@@ -478,46 +473,46 @@
     </li>
   </ul>
 
-<p>{{ _('You will also be required to provide proof of your identity. Acceptable forms of ID include:') }}</p>
+  <p class="govuk-body">{{ _('You will also be required to provide proof of your identity. Acceptable forms of ID include:') }}</p>
 
-  <ul>
-    <li>{{ _('a photocopy of your passport or driving licence') }}</li>
-    <li>{{ _('an electricity bill (the original bill, not a copy)') }}</li>
-    <li>{{ _('a gas bill (the original bill, not a copy)') }}</li>
-    <li>{{ _('a council tax bill (the original bill, not a copy)') }}</li>
-    <li>{{ _('any other bill in your full name (the original bill, not a copy)') }}</li>
-  </ul>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>{{ _('a photocopy of your passport or driving licence') }}</li>
+      <li>{{ _('an electricity bill (the original bill, not a copy)') }}</li>
+      <li>{{ _('a gas bill (the original bill, not a copy)') }}</li>
+      <li>{{ _('a council tax bill (the original bill, not a copy)') }}</li>
+      <li>{{ _('any other bill in your full name (the original bill, not a copy)') }}</li>
+    </ul>
 
-<p>{{ _('Any bill you send us must be less than 6 months old.') }}</p>
+  <p class="govuk-body">{{ _('Any bill you send us must be less than 6 months old.') }}</p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}Please note that we cannot give out any information unless the details that you provide match our records.
     If you used an alias or pseudonym when you contacted <abbr>CLA</abbr>, you will need to prove your identity.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}Once we receive the subject access request, we will deal with the request without any undue delay within one calendar month.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}There is no charge for providing this information, however, if processing the subject access request is deemed to be excessive, we may charge a fee.{% endtrans %}
   </p>
 
-  <p>
-    {% trans %}You can also review our <a href="https://www.gov.uk/government/organisations/legal-aid-agency/about/personal-information-charter" rel="external">Personal Information Charter</a>
+  <p class="govuk-body">
+    {% trans %}You can also review our <a class="govuk-link" href="https://www.gov.uk/government/organisations/legal-aid-agency/about/personal-information-charter" rel="external">Personal Information Charter</a>
      which contains important information on your rights to access your personal information.{% endtrans %}
   </p>
 
-  <h2>{{ _('How you can request to have your personal data amended or deleted?') }}</h2>
+  <h2 class="govuk-heading-l">{{ _('How you can request to have your personal data amended or deleted?') }}</h2>
   
-  <p>
+  <p class="govuk-body">
     {{ _('Under data protection legislation, we are only allowed to keep your personal information when we have a lawful basis for processing it and only for as long as it is necessary for the purposes
      for which it was collected.') }}
   </p>
-  <p>
+  <p class="govuk-body">
     {{ _('We will consider requests to delete some or all of your personal data but please note that, as a minimum, <abbr>CLA</abbr> will usually retain:') }}
   </p>
-  <ul>
+  <ul class="govuk-list govuk-list--bullet">
     <li>
       {% trans %}For everyone that uses our service, a name and two other pieces of personal data, e.g. date of birth and postcode {% endtrans %}
     </li>
@@ -526,26 +521,26 @@
       <abbr>CLA</abbr> Specialist, details of any financial information and case details used to prove that you qualify for legal aid{% endtrans %}
     </li>
   </ul>
-  <p>
+  <p class="govuk-body">
     {% trans %}Please note that, if you qualify to receive advice from a <abbr>CLA</abbr> Specialist, they will also need to retain
     additional personal data about you within their own Case Handling System. Such data shall be sufficient
     to justify the provision of legal aid advice and meet professional requirements.{% endtrans %}
   </p>
-  <p>
+  <p class="govuk-body">
     {{ _('If the information we hold about you is inaccurate for whatever reason, you can contact CLA to have your personal information amended.') }}
   </p>
 
-  <h2>{{ _('When we ask you for personal data') }}</h2>
-  <p>
+  <h2 class="govuk-heading-l">{{ _('When we ask you for personal data') }}</h2>
+  <p class="govuk-body">
     {% trans %}We promise to inform you why we need your personal data and ask only for the personal data we need. We will not collect information that
      is irrelevant or unnecessary.{% endtrans %}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {% trans %}When we collect your personal data, we have responsibilities, and you have rights. These include:{% endtrans %}
   </p>
 
-  <ul>
+  <ul class="govuk-list govuk-list--bullet">
     <li>
       {% trans %}That you can withdraw consent at any time, where relevant;{% endtrans %}
     </li>
@@ -569,9 +564,9 @@
     </li>
   </ul>
 
-  <h2>{{ _('You can get more details on:') }}</h2>
+  <h2 class="govuk-heading-l">{{ _('You can get more details on:') }}</h2>
 
-  <ul>
+  <ul class="govuk-list govuk-list--bullet">
     <li>
       {% trans %}Agreements we have with other organisations for sharing information;{% endtrans %}
     </li>
@@ -590,52 +585,57 @@
     </li>
   </ul>
 
-  <p>
-      {% trans %}For more information about the above issues, please contact the MoJ Data Protection Officer;{% endtrans %}
+  <p class="govuk-body">
+      {% trans %}For more information about the above issues, please contact the <abbr>MoJ</abbr> Data Protection Officer:{% endtrans %}
   </p>
-    <address class="adr">
-      <span class="extended-address">
-        <span>Post Point 10.38</span>
-        <span class="street-address">102 Petty France</span>
-        <span class="locality">London</span>
-        <span class="postal-code">SW1H 9AJ</span>  
-        <span class="email"><a href="mailto:data.compliance@justice.gov.uk">data.compliance@justice.gov.uk</a>
-      </span>
-    </address>
-  </p>
+  <ul class="govuk-list">
+    <li>
+      <abbr>MoJ</abbr> Data Protection Officer<br />
+      Post Point 10.38<br />
+      102 Petty France<br />
+      London<br />
+      SW1H 9AJ
+    </li>
+    <li>
+      <a class="govuk-link email" href="mailto:data.compliance@justice.gov.uk">data.compliance@justice.gov.uk</a>
+    </li>
+  </ul>
 
 
-  <p>
-      {% trans %}For more information on how and why your information is processed, please see the information provided when you accessed our services or were contacted by us.{% endtrans %}
+  <p class="govuk-body">
+    {% trans %}For more information on how and why your information is processed, please see the information provided when you accessed our services or were contacted by us.{% endtrans %}
   </p>
 
-  <h2>{{ _('Complaints') }}</h2>
-  <p>
+  <h2 class="govuk-heading-l">{{ _('Complaints') }}</h2>
+  <p class="govuk-body">
       {% trans %}When we ask you for information, we will comply with the law. If you consider that your information has been handled incorrectly, 
       you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:{% endtrans %}
   </p>
-    <address class="adr">
-      <span class="extended-address">
-        <span>Information Commissioner's Office</span>
-        <span>Wycliffe House</span>
-        <span class="street-address">Water Lane</span>
-        <span class="locality">Wilmslow</span>
-        <span class="locality">Cheshire</span>
-        <span class="postal-code">SK9 5AF</span>  
-        <span class="tel">{% trans %}Tel:{% endtrans %} 0303 123 1113</span>
-        <span><a href="https://www.ico.org.uk" rel="external">www.ico.org.uk</a>
-      </span>
-    </address>
-  </p>
+  <ul class="govuk-list">
+    <li>
+      Information Commissioner’s Office<br />
+      Wycliffe House<br />
+      Water Lane<br />
+      Wilmslow<br />
+      Cheshire<br />
+      SK9 5AF  
+    </li>
+    <li>
+      {% trans %}Telephone:{% endtrans %} 0303 123 1113</span>
+    </li>
+    <li>
+      <a class="govuk-link" href="https://www.ico.org.uk" rel="external">www.ico.org.uk</a>
+    </li>
+  </ul>
 
-  <h2>{{ _('Changes to the statement') }}</h2>
-  <p>
+  <h2 class="govuk-heading-l">{{ _('Changes to the statement') }}</h2>
+  <p class="govuk-body">
     {% trans %}This policy is under regular review. Any changes made to the privacy policy will be posted here and,
     where appropriate, <abbr>CLA</abbr> staff will be notified by email.{% endtrans %}
   </p>
 
-  <h2>{{ _('Complaints about this statement') }}</h2>
-  <p class="vcard">
+  <h2 class="govuk-heading-l">{{ _('Complaints about this statement') }}</h2>
+  <p class="govuk-body">
     {% trans %}If you would like to make a complaint about this statement and how it applies to you then please
     contact <abbr title="Civil Legal Advice">CLA</abbr> on <span class="tel">0345 345 4 345</span>.{% endtrans %}
   </p>

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -285,12 +285,10 @@
           {{ _('When making outgoing calls to you, <abbr>CLA</abbr> will ensure that:') }}
           <ul class="govuk-list govuk-list--bullet govuk-table__body govuk-!-font-size-16">
             <li>
-              {% trans %}Call backs are only made where you have agreed to this. Authorised third parties
-              acting on your behalf can give agreement.{% endtrans %}
+              {% trans %}Call backs are only made where you have agreed to this. Authorised third parties acting on your behalf can give agreement.{% endtrans %}
             </li>
             <li>
-              {% trans %}Where a call back is made to you and there is no answer and a message taker is available,
-              no message will be left unless you have previously given specific instructions that this would be acceptable.{% endtrans %}
+              {% trans %}Where a call back is made to you and there is no answer and a message taker is available, no message will be left unless you have previously given specific instructions that this would be acceptable.{% endtrans %}
             </li>
             <li>
               {% trans %}Where the phone is answered and someone other than you answers the phone and says that you are

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -1975,13 +1975,13 @@ msgstr "Yr Asiantaeth Cymorth Cyfreithiol (LAA) sy’n gyfrifol am y gwasanaeth 
 msgid ""
 "When you first make contact with <abbr title=\"Civil Legal Advice\">CLA</abbr> you will communicate with the <abbr title=\"Civil Legal Advice\">CLA</abbr> Operator Service (CLAOS), which is delivered by\n"
 "    Hinduja Global Solutions UK Limited."
-msgstr "Y tro cyntaf y byddwch yn dod i gysylltiad â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> byddwch yn cyfathrebu â Gwasanaeth Gweithredwr y CLA (CLAOS), sy’n cael ei ddarparu gan Hinduja Global Solutions UK Limited."
+msgstr "Y tro cyntaf y byddwch yn dod i gysylltiad â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> byddwch yn cyfathrebu â Gwasanaeth Gweithredwr y CLA (CLAOS), sy’n cael ei ddarparu gan Hinduja Global Solutions UK Limited."
 
 #: cla_public/templates/privacy.html:28
 msgid ""
 "Hinduja Global Solutions UK Limited is a contractor employed by the <abbr title=\"Legal Aid Agency\">LAA</abbr>\n"
 "    to deliver the <abbr title=\"Civil Legal Advice\">CLA</abbr> Operator Service."
-msgstr "Contractwr sy’n cael ei gyflogi gan yr Asiantaeth Cymorth Cyfreithiol i ddarparu Gwasanaeth Gweithredwr y <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yw Hinduja Global Solutions UK Limited."
+msgstr "Contractwr sy’n cael ei gyflogi gan yr Asiantaeth Cymorth Cyfreithiol i ddarparu Gwasanaeth Gweithredwr y <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yw Hinduja Global Solutions UK Limited."
 
 #: cla_public/templates/privacy.html:32 cla_public/templates/privacy.html:612
 msgid "Complaints"
@@ -1989,7 +1989,7 @@ msgstr "Cwynion"
 
 #: cla_public/templates/privacy.html:34
 msgid "If you would like to make a complaint about this service or Civil Legal Advice please contact <abbr title=\"Civil Legal Advice\">CLA</abbr> on 0345 345 4 345."
-msgstr "Os ydych chi’n dymuno gwneud cwyn am y gwasanaeth hwn neu Gyngor Cyfreithiol Sifil, cysylltwch â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> ar 0345 345 4 345"
+msgstr "Os ydych chi’n dymuno gwneud cwyn am y gwasanaeth hwn neu Gyngor Cyfreithiol Sifil, cysylltwch â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> ar 0345 345 4 345"
 
 #: cla_public/templates/privacy.html:37
 msgid "How is my privacy protected?"
@@ -2054,7 +2054,7 @@ msgid ""
 "The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for <abbr title=\"Civil Legal Advice\">CLA</abbr>\n"
 "    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr>LAA</abbr>) is an\n"
 "    Executive Agency of the (<abbr title=\"Ministry of Justice\">MoJ</abbr>)."
-msgstr "Yr Asiantaeth Cymorth Cyfreithiol (<abbr>LAA</abbr>) sy’n gyfrifol am y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, a’r Weinyddiaeth Gyfiawnder yw Rheolwr y Data. Mae’r Asiantaeth Cymorth Cyfreithiol  yn Asiantaeth Weithredol i’r Weinyddiaeth Gyfiawnder."
+msgstr "Yr Asiantaeth Cymorth Cyfreithiol (<abbr>LAA</abbr>) sy’n gyfrifol am y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, a’r Weinyddiaeth Gyfiawnder yw Rheolwr y Data. Mae’r Asiantaeth Cymorth Cyfreithiol  yn Asiantaeth Weithredol i’r Weinyddiaeth Gyfiawnder."
 
 #: cla_public/templates/privacy.html:90
 msgid ""
@@ -2062,20 +2062,20 @@ msgid ""
 "    For example, when you first make contact with <abbr>CLA</abbr>, you will communicate with\n"
 "    the <abbr>CLA</abbr> Operator Service, which is delivered by Hinduja Global Solutions UK Limited\n"
 "    (a contractor employed by the <abbr title=\"Legal Aid Agency\">LAA</abbr>)."
-msgstr "Mae’r Asiantaeth Cymorth Cyfreithiol yn gweithio gyda sefydliadau eraill sy’n darparu’r gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>. Er enghraifft, y tro cyntaf y byddwch yn dod i gysylltiad â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, byddwch yn cyfathrebu â Gwasanaeth Gweithredwr y <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, sy’n cael ei ddarparu gan Hinduja Global Solutions UK Limited (contractwr sy’n cael ei gyflogi gan yr Asiantaeth Cymorth Cyfreithiol)."
+msgstr "Mae’r Asiantaeth Cymorth Cyfreithiol yn gweithio gyda sefydliadau eraill sy’n darparu’r gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>. Er enghraifft, y tro cyntaf y byddwch yn dod i gysylltiad â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, byddwch yn cyfathrebu â Gwasanaeth Gweithredwr y <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, sy’n cael ei ddarparu gan Hinduja Global Solutions UK Limited (contractwr sy’n cael ei gyflogi gan yr Asiantaeth Cymorth Cyfreithiol)."
 
 #: cla_public/templates/privacy.html:97
 msgid ""
 "Once you have contacted the <abbr>CLA</abbr> Operator Service, if you are likely to qualify for Legal Aid, the operator will transfer you to\n"
 "     a <abbr>CLA</abbr> Specialist Provider. If you do not qualify to receive\n"
 "    <abbr>CLA</abbr> Specialist advice, the operator will inform you accordingly and direct you to alternative sources of help."
-msgstr "Ar ôl i chi gysylltu â Gwasanaeth Gweithredwr y <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, os ydych yn debygol o fod yn gymwys i gael Cymorth Cyfreithiol bydd y gweithredwr yn eich trosglwyddo i Ddarparwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> Arbenigol. Os nad ydych yn gymwys i dderbyn cyngor Arbenigwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, bydd y gweithredwr yn dweud wrthych ac yn eich cyfeirio at ffynonellau cymorth eraill."
+msgstr "Ar ôl i chi gysylltu â Gwasanaeth Gweithredwr y <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, os ydych yn debygol o fod yn gymwys i gael Cymorth Cyfreithiol bydd y gweithredwr yn eich trosglwyddo i Ddarparwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> Arbenigol. Os nad ydych yn gymwys i dderbyn cyngor Arbenigwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, bydd y gweithredwr yn dweud wrthych ac yn eich cyfeirio at ffynonellau cymorth eraill."
 
 #: cla_public/templates/privacy.html:103
 msgid ""
 "The <abbr>CLA</abbr> service is committed to following this Privacy Statement.\n"
 "    <abbr>CLA</abbr> Specialists must also adhere to their own internal privacy policy."
-msgstr "Mae gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> wedi ymrwymo i gydymffurfio â’r Datganiad Preifatrwydd hwn. Hefyd rhaid i Arbenigwyr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gydymffurfio â’u polisi preifatrwydd mewnol eu hunain."
+msgstr "Mae gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> wedi ymrwymo i gydymffurfio â’r Datganiad Preifatrwydd hwn. Hefyd rhaid i Arbenigwyr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> gydymffurfio â’u polisi preifatrwydd mewnol eu hunain."
 
 #: cla_public/templates/privacy.html:108
 msgid "What types of personal data do we process?"
@@ -2083,11 +2083,11 @@ msgstr "Pa fathau o ddata personol rydym yn eu prosesu? "
 
 #: cla_public/templates/privacy.html:110
 msgid "<abbr>CLA</abbr> will only collect the minimum amount of information that is necessary and relevant, in order to deliver the <abbr>CLA</abbr> service to you."
-msgstr "Ni fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn casglu mwy o wybodaeth nag sy’n angenrheidiol ac yn berthnasol er mwyn darparu’r gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> i chi."
+msgstr "Ni fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn casglu mwy o wybodaeth nag sy’n angenrheidiol ac yn berthnasol er mwyn darparu’r gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> i chi."
 
 #: cla_public/templates/privacy.html:113
 msgid "The kind of information <abbr>CLA</abbr> may collect about you includes:"
-msgstr "Y math o wybodaeth y gall <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> ei chasglu amdanoch chi yw:"
+msgstr "Y math o wybodaeth y gall <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> ei chasglu amdanoch chi yw:"
 
 #: cla_public/templates/privacy.html:117
 msgid ""
@@ -2101,11 +2101,11 @@ msgstr "Gwybodaeth ariannol sydd ei hangen i bennu a ydych chi’n gymwys i gael
 
 #: cla_public/templates/privacy.html:124
 msgid "Reason for contacting <abbr>CLA</abbr>, such as the nature of your problem or specific details about your situation;"
-msgstr "Y rheswm dros gysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, er enghraifft, natur eich problem neu fanylion penodol am eich sefyllfa;"
+msgstr "Y rheswm dros gysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, er enghraifft, natur eich problem neu fanylion penodol am eich sefyllfa;"
 
 #: cla_public/templates/privacy.html:127
 msgid "Details of any specific needs that you may have in order to access the <abbr>CLA</abbr> service; and"
-msgstr "Manylion unrhyw anghenion penodol sydd gennych er mwyn cael mynediad at wasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>; a"
+msgstr "Manylion unrhyw anghenion penodol sydd gennych er mwyn cael mynediad at wasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>; a"
 
 #: cla_public/templates/privacy.html:130
 msgid ""
@@ -2118,15 +2118,15 @@ msgid ""
 "The amount of information <abbr>CLA</abbr> will collect will depend on whether you qualify for the <abbr>CLA</abbr>\n"
 "    service and/or your specific needs. For example, you will be asked to provide more information\n"
 "    before we can transfer you through to a <abbr>CLA</abbr> Specialist."
-msgstr "Bydd faint o wybodaeth y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn ei gasglu amdanoch yn amrywio gan ddibynnu a ydych yn gymwys ar gyfer y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, a/neu a oes gennych anghenion penodol. Er enghraifft, gofynnir i chi roi mwy o wybodaeth cyn y gallwn eich trosglwyddo at Arbenigwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>."
+msgstr "Bydd faint o wybodaeth y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn ei gasglu amdanoch yn amrywio gan ddibynnu a ydych yn gymwys ar gyfer y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, a/neu a oes gennych anghenion penodol. Er enghraifft, gofynnir i chi roi mwy o wybodaeth cyn y gallwn eich trosglwyddo at Arbenigwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>."
 
 #: cla_public/templates/privacy.html:141
 msgid "How does <abbr>CLA</abbr> use your data and why?"
-msgstr "Sut mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn defnyddio eich data a pham?"
+msgstr "Sut mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn defnyddio eich data a pham?"
 
 #: cla_public/templates/privacy.html:142
 msgid "collects and records information about you to:"
-msgstr "Mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn casglu ac yn cofnodi gwybodaeth amdanoch chi er mwyn:"
+msgstr "Mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn casglu ac yn cofnodi gwybodaeth amdanoch chi er mwyn:"
 
 #: cla_public/templates/privacy.html:144
 msgid "Work out whether you qualify for legal aid;"
@@ -2148,13 +2148,13 @@ msgstr "Ein helpu i fonitro a gwella ein gwasanaeth;"
 msgid ""
 "Build statistics about the <abbr>CLA</abbr> service, monitor fraud and justify public expenditure.\n"
 "      This information is collated in an anonymous format;"
-msgstr "Adeiladu ystadegau am y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, monitro twyll a chyfiawnhau gwariant cyhoeddus. Mae’r wybodaeth hon yn cael ei choladu mewn fformat dienw;"
+msgstr "Adeiladu ystadegau am y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, monitro twyll a chyfiawnhau gwariant cyhoeddus. Mae’r wybodaeth hon yn cael ei choladu mewn fformat dienw;"
 
 #: cla_public/templates/privacy.html:153
 msgid ""
 "Collect views on the <abbr>CLA</abbr> service and any improvements considered necessary.\n"
 "      Where consent is provided, <abbr>CLA</abbr> User contact details may be passed onto an independent research agency;"
-msgstr "Casglu barn am y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> ac unrhyw welliannau y credir bod eu hangen. Lle rhoddir cydsyniad, mae’n bosibl y bydd manylion cysylltu defnyddiwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn cael eu pasio ymlaen i asiantaeth ymchwil annibynnol;"
+msgstr "Casglu barn am y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> ac unrhyw welliannau y credir bod eu hangen. Lle rhoddir cydsyniad, mae’n bosibl y bydd manylion cysylltu defnyddiwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn cael eu pasio ymlaen i asiantaeth ymchwil annibynnol;"
 
 #: cla_public/templates/privacy.html:156
 msgid "Prevent or detect crime or fraud; and"
@@ -2166,19 +2166,19 @@ msgstr "Cynnal archwiliadau sicrwydd achlysurol er mwyn sicrhau bod y penderfyni
 
 #: cla_public/templates/privacy.html:161
 msgid "Without this information, <abbr>CLA</abbr> would not be able to conduct the activities above which are essential to the delivery of legal aid."
-msgstr "Heb yr wybodaeth hon, ni fyddai <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn gallu cynnal y gweithgareddau uchod sy’n hanfodol er mwyn darparu cymorth cyfreithiol."
+msgstr "Heb yr wybodaeth hon, ni fyddai <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn gallu cynnal y gweithgareddau uchod sy’n hanfodol er mwyn darparu cymorth cyfreithiol."
 
 #: cla_public/templates/privacy.html:165
 msgid ""
 "The lawful basis for <abbr>CLA</abbr> collecting and processing your personal data is the result of the powers contained in legislation, specifically the Legal Aid, Sentencing\n"
 "     and Punishment of Offenders Act 2012."
-msgstr "Mae’r sail gyfreithlon sy’n caniatáu i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gasglu a phrosesu eich data personol yn deillio o’r pwerau sydd wedi’u cynnwys mewn deddfwriaeth, yn fwyaf penodol, Deddf Cymorth Cyfreithiol Dedfrydu a Chosbi Troseddwyr 2012."
+msgstr "Mae’r sail gyfreithlon sy’n caniatáu i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> gasglu a phrosesu eich data personol yn deillio o’r pwerau sydd wedi’u cynnwys mewn deddfwriaeth, yn fwyaf penodol, Deddf Cymorth Cyfreithiol Dedfrydu a Chosbi Troseddwyr 2012."
 
 #: cla_public/templates/privacy.html:170
 msgid ""
 "<abbr>CLA</abbr> also collects ‘special categories of personal data’ for the purposes of monitoring equality. This is a legal requirement for public authorities, under the Equality Act 2010.\n"
 "     Special categories of personal data obtained for equality monitoring will be treated with the strictest confidence and any information published will not identify you or anyone else associated with your legal aid application."
-msgstr "Mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> hefyd yn casglu ‘categorïau arbennig o ddata personol’ at ddibenion monitro cydraddoldeb. Mae Deddf Cydraddoldeb 2010 yn nodi ei bod yn ofynnol i awdurdodau cyhoeddus wneud hyn. Byddwn yn trin categorïau arbennig o ddata personol a gesglir er mwyn monitro cydraddoldeb yn gwbl gyfrinachol ac ni fydd unrhyw wybodaeth a gyhoeddir yn nodi pwy ydych chi na neb arall sy’n gysylltiedig â’ch cais am gymorth cyfreithiol."
+msgstr "Mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> hefyd yn casglu ‘categorïau arbennig o ddata personol’ at ddibenion monitro cydraddoldeb. Mae Deddf Cydraddoldeb 2010 yn nodi ei bod yn ofynnol i awdurdodau cyhoeddus wneud hyn. Byddwn yn trin categorïau arbennig o ddata personol a gesglir er mwyn monitro cydraddoldeb yn gwbl gyfrinachol ac ni fydd unrhyw wybodaeth a gyhoeddir yn nodi pwy ydych chi na neb arall sy’n gysylltiedig â’ch cais am gymorth cyfreithiol."
 
 #: cla_public/templates/privacy.html:175
 msgid ""
@@ -2188,25 +2188,25 @@ msgstr "Oherwydd y dibenion y gellir defnyddio eich data personol ar eu cyfer (s
 
 #: cla_public/templates/privacy.html:179
 msgid "How does <abbr>CLA</abbr> collect your personal data and keep it safe?"
-msgstr "Sut y mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn casglu’ch data personol ac yn eu cadw’n ddiogel?"
+msgstr "Sut y mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn casglu’ch data personol ac yn eu cadw’n ddiogel?"
 
 #: cla_public/templates/privacy.html:181
 msgid ""
 "<abbr>CLA</abbr> may collect personal data about you by phone, online, email or post (see table below).\n"
 "    Any personal data will be recorded and stored within a secure system that meets required Government standards."
-msgstr "Gall <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gasglu data personol amdanoch chi dros y ffôn, ar-lein, drwy’r post a’r e-bost (gweler y tabl isod). Bydd unrhyw ddata personol yn cael eu cofnodi a’u storio mewn system ddiogel sy’n cyrraedd safonau sydd wedi’u gosod gan y Llywodraeth."
+msgstr "Gall <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> gasglu data personol amdanoch chi dros y ffôn, ar-lein, drwy’r post a’r e-bost (gweler y tabl isod). Bydd unrhyw ddata personol yn cael eu cofnodi a’u storio mewn system ddiogel sy’n cyrraedd safonau sydd wedi’u gosod gan y Llywodraeth."
 
 #: cla_public/templates/privacy.html:185
 msgid ""
 "<abbr>CLA</abbr> will be able to view and verify the information that you provide and, where\n"
 "    necessary, will amend it to maintain its accuracy."
-msgstr "Bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn gallu gweld a gwirio’r wybodaeth y byddwch yn ei rhoi a, lle bo angen, bydd yn diwygio’r wybodaeth er mwyn sicrhau ei bod yn gywir."
+msgstr "Bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn gallu gweld a gwirio’r wybodaeth y byddwch yn ei rhoi a, lle bo angen, bydd yn diwygio’r wybodaeth er mwyn sicrhau ei bod yn gywir."
 
 #: cla_public/templates/privacy.html:189
 msgid ""
 "The minimum amount of personal data that <abbr>CLA</abbr> will ask to collect is your name and two other pieces\n"
 "    of personal information that could be used to identify you, e.g. postcode, date of birth or telephone number."
-msgstr "Y data personol sylfaenol y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn gofyn amdanynt yw eich enw a dau ddarn arall o wybodaeth bersonol a allai gael eu defnyddio i’ch adnabod, e.e. côd post, dyddiad geni neu rif ffôn."
+msgstr "Y data personol sylfaenol y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn gofyn amdanynt yw eich enw a dau ddarn arall o wybodaeth bersonol a allai gael eu defnyddio i’ch adnabod, e.e. côd post, dyddiad geni neu rif ffôn."
 
 #: cla_public/templates/privacy.html:193
 msgid ""
@@ -2241,7 +2241,7 @@ msgid ""
 "        <br><br>\n"
 "        If you leave <abbr>CLA</abbr> a voice message we will record the minimum amount of information\n"
 "        required in order to contact you back."
-msgstr "Pan fyddwch chi’n ffonio <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, byddwn ni’n cofnodi data personol perthnasol yr ydych chi’n eu rhoi mewn system ddigidol ddiogel. Gallwn recordio’ch galwadau hefyd. Ond cewch chi ddewis peidio ag ymuno â hyn neu ddewis a ydych chi am barhau â’r alwad neu beidio. Os byddwch chi’n gadael neges llais i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, byddwn ni’n cofnodi’r lleiaf o wybodaeth sydd ei hangen i gysylltu â chi wedyn."
+msgstr "Pan fyddwch chi’n ffonio <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, byddwn ni’n cofnodi data personol perthnasol yr ydych chi’n eu rhoi mewn system ddigidol ddiogel. Gallwn recordio’ch galwadau hefyd. Ond cewch chi ddewis peidio ag ymuno â hyn neu ddewis a ydych chi am barhau â’r alwad neu beidio. Os byddwch chi’n gadael neges llais i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, byddwn ni’n cofnodi’r lleiaf o wybodaeth sydd ei hangen i gysylltu â chi wedyn."
 
 #: cla_public/templates/privacy.html:221
 msgid "Online"
@@ -2254,7 +2254,7 @@ msgid ""
 "        Please note that transmitting information over the internet is generally not completely secure, and\n"
 "        <abbr>CLA</abbr> can’t guarantee the security of your data. Any data you transmit is at your own risk.\n"
 "        <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it."
-msgstr "Pan fyddwch yn cysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> ar-lein, bydd y data personol y byddwch yn eu rhoi yn cael eu cofnodi mewn system ddigidol ddiogel. Sylwer nad yw trawsyrru gwybodaeth dros y rhyngrwyd yn gwbl ddiogel bob amser, ac ni all <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> warantu diogelwch eich data. Ni allwn fod yn gyfrifol am unrhyw ddata y byddwch yn eu trawsyrru. Mae gan <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> weithdrefnau a nodweddion diogelwch er mwyn cadw eich data’n ddiogel ar ôl i ni eu derbyn."
+msgstr "Pan fyddwch yn cysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> ar-lein, bydd y data personol y byddwch yn eu rhoi yn cael eu cofnodi mewn system ddigidol ddiogel. Sylwer nad yw trawsyrru gwybodaeth dros y rhyngrwyd yn gwbl ddiogel bob amser, ac ni all <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> warantu diogelwch eich data. Ni allwn fod yn gyfrifol am unrhyw ddata y byddwch yn eu trawsyrru. Mae gan <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> weithdrefnau a nodweddion diogelwch er mwyn cadw eich data’n ddiogel ar ôl i ni eu derbyn."
 
 #: cla_public/templates/privacy.html:233
 msgid ""
@@ -2266,7 +2266,7 @@ msgid ""
 "        When you email <abbr>CLA</abbr>, relevant personal data that you provide will be recorded within a secure digital system.\n"
 "        <br><br>\n"
 "        <abbr>CLA</abbr> may monitor and store both your incoming and outgoing emails. We may also use blocking software."
-msgstr "Nid yw trawsyrru gwybodaeth drwy e-bost yn gwbl ddiogel bob amser, ac ni all <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> warantu diogelwch eich data. Ni allwn fod yn gyfrifol am unrhyw ddata y byddwch yn eu trawsyrru"
+msgstr "Nid yw trawsyrru gwybodaeth drwy e-bost yn gwbl ddiogel bob amser, ac ni all <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> warantu diogelwch eich data. Ni allwn fod yn gyfrifol am unrhyw ddata y byddwch yn eu trawsyrru"
 
 #: cla_public/templates/privacy.html:244
 msgid "Post"
@@ -2278,7 +2278,7 @@ msgid ""
 "        <br><br>\n"
 "        <abbr>CLA</abbr> may also retain original hard-copies of information submitted by you. This must be stored in a locked\n"
 "        filing cabinet. Digital copies of letters may be scanned and stored."
-msgstr "Pan fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn derbyn llythyrau, gallwn ni gofnodi data personol perthnasol sydd ynddynt mewn system ddigidol ddiogel. Hefyd gall <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gadw llythyrau gwreiddiol sy’n cynnwys gwybodaeth a gyflwynwyd gennych chi. Rhaid storio’r rhain mewn cwpwrdd ffeiliau sydd wedi’i gloi. Gellir sganio copïau digidol o lythyrau a’u storio."
+msgstr "Pan fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn derbyn llythyrau, gallwn ni gofnodi data personol perthnasol sydd ynddynt mewn system ddigidol ddiogel. Hefyd gall <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> gadw llythyrau gwreiddiol sy’n cynnwys gwybodaeth a gyflwynwyd gennych chi. Rhaid storio’r rhain mewn cwpwrdd ffeiliau sydd wedi’i gloi. Gellir sganio copïau digidol o lythyrau a’u storio."
 
 #: cla_public/templates/privacy.html:255
 msgid "Keeping your personal data safe from others"
@@ -2292,7 +2292,7 @@ msgstr "Ailgysylltu"
 msgid ""
 "<abbr>CLA</abbr> will not disclose any personal information to anyone contacting the <abbr>CLA</abbr> service until\n"
 "        they have successfully verified that their identity matches that of an existing record."
-msgstr "Ni fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn datgelu unrhyw wybodaeth bersonol i rywun sy’n cysylltu â gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> nes ei fod wedi cadarnhau bod ei hunaniaeth yn cyfateb i gofnod sy’n bodoli."
+msgstr "Ni fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn datgelu unrhyw wybodaeth bersonol i rywun sy’n cysylltu â gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> nes ei fod wedi cadarnhau bod ei hunaniaeth yn cyfateb i gofnod sy’n bodoli."
 
 #: cla_public/templates/privacy.html:265
 msgid "Third-parties"
@@ -2307,7 +2307,7 @@ msgid ""
 "        and whether they are authorised to act on their behalf.\n"
 "        <br><br>\n"
 "        They must also agree a password to verify the identity of the third-party if they contact the service again."
-msgstr "Bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn cydnabod trydydd parti sy’n cysylltu ar ran person arall. Mae’n rhaid i’r trydydd parti ddangos bod ganddynt yr awdurdod priodol i weithredu ar eich rhan. Rhaid i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gofnodi’r berthynas rhwng y trydydd parti a’r unigolyn sy’n gofyn am gyngor ac a yw’r trydydd parti wedi’i awdurdodi i weithredu ar ei ran. Hefyd rhaid i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gytuno ar gyfrinair er mwyn gwirio hunaniaeth y trydydd parti os bydd yn cysylltu â’r gwasanaeth eto."
+msgstr "Bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn cydnabod trydydd parti sy’n cysylltu ar ran person arall. Mae’n rhaid i’r trydydd parti ddangos bod ganddynt yr awdurdod priodol i weithredu ar eich rhan. Rhaid i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> gofnodi’r berthynas rhwng y trydydd parti a’r unigolyn sy’n gofyn am gyngor ac a yw’r trydydd parti wedi’i awdurdodi i weithredu ar ei ran. Hefyd rhaid i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> gytuno ar gyfrinair er mwyn gwirio hunaniaeth y trydydd parti os bydd yn cysylltu â’r gwasanaeth eto."
 
 #: cla_public/templates/privacy.html:277
 msgid "Outgoing Communications"
@@ -2315,15 +2315,15 @@ msgstr "Anfon negeseuon allan"
 
 #: cla_public/templates/privacy.html:279
 msgid "<abbr>CLA</abbr> may need to contact you directly."
-msgstr "Mae’n bosibl y bydd angen i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gysylltu â chi’n uniongyrchol."
+msgstr "Mae’n bosibl y bydd angen i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> gysylltu â chi’n uniongyrchol."
 
 #: cla_public/templates/privacy.html:281
 msgid "In order to protect privacy, <abbr>CLA</abbr> will always check with you what forms of outgoing communication are acceptable and appropriate and whether messages can be left."
-msgstr "Er mwyn sicrhau preifatrwydd, bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> bob amser yn gofyn pa ddulliau cyfathrebu sy’n dderbyniol ac yn briodol i chi ac a oes modd gadael negeseuon."
+msgstr "Er mwyn sicrhau preifatrwydd, bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> bob amser yn gofyn pa ddulliau cyfathrebu sy’n dderbyniol ac yn briodol i chi ac a oes modd gadael negeseuon."
 
 #: cla_public/templates/privacy.html:283
 msgid "When making outgoing calls to you, <abbr>CLA</abbr> will ensure that:"
-msgstr "Pan fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn eich ffonio chi, bydd yn:"
+msgstr "Pan fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn eich ffonio chi, bydd yn:"
 
 #: cla_public/templates/privacy.html:286
 msgid ""
@@ -2342,7 +2342,7 @@ msgid ""
 "Where the phone is answered and someone other than you answers the phone and says that you are\n"
 "            unavailable or asks who is calling, <abbr>CLA</abbr> will state that the call is confidential and will not say\n"
 "            that they are calling from <abbr>CLA</abbr>."
-msgstr "Os bydd rhywun heblaw chi’n ateb y ffôn ac yn dweud nad ydych chi ar gael neu’n gofyn pwy sy’n galw, y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn dweud bod yr alwad yn gyfrinachol ac na fydd yn dweud ei fod yn ffonio o <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>."
+msgstr "Os bydd rhywun heblaw chi’n ateb y ffôn ac yn dweud nad ydych chi ar gael neu’n gofyn pwy sy’n galw, y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn dweud bod yr alwad yn gyfrinachol ac na fydd yn dweud ei fod yn ffonio o <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>."
 
 #: cla_public/templates/privacy.html:304
 msgid "How we use cookies"
@@ -2414,7 +2414,7 @@ msgstr "<a class=\"govuk-link\" href=\"http://www.aboutcookies.org/\" rel=\"exte
 
 #: cla_public/templates/privacy.html:340
 msgid "When will we share information about you outside <abbr>CLA</abbr>?"
-msgstr "Pryd y byddwn ni’n rhannu gwybodaeth amdanoch chi y tu allan i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>?"
+msgstr "Pryd y byddwn ni’n rhannu gwybodaeth amdanoch chi y tu allan i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>?"
 
 #: cla_public/templates/privacy.html:341
 msgid "Confidentiality means ensuring information is only accessible by those allowed to have access to it."
@@ -2424,7 +2424,7 @@ msgstr "Mae cyfrinachedd yn golygu sicrhau mai dim ond y rheini sydd â hawl i w
 msgid ""
 "We want to keep your contact with <abbr>CLA</abbr> confidential, which means you can feel safe talking to us.\n"
 "    But we sometimes need to share some information outside <abbr>CLA</abbr> which we explain below."
-msgstr "Rydyn ni am gadw’ch cysylltiad â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn gyfrinachol: mae hyn yn golygu y byddwch chi’n gallu teimlo’n ddiogel wrth siarad â ni. Ond weithiau bydd angen i ni rannu rhywfaint o wybodaeth y tu allan i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>. Rydyn ni’n egluro hyn isod."
+msgstr "Rydyn ni am gadw’ch cysylltiad â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn gyfrinachol: mae hyn yn golygu y byddwch chi’n gallu teimlo’n ddiogel wrth siarad â ni. Ond weithiau bydd angen i ni rannu rhywfaint o wybodaeth y tu allan i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>. Rydyn ni’n egluro hyn isod."
 
 #: cla_public/templates/privacy.html:347
 msgid ""
@@ -2559,11 +2559,11 @@ msgstr "Dyddiad geni"
 
 #: cla_public/templates/privacy.html:471
 msgid "What you contacted <abbr>CLA</abbr> about"
-msgstr "Y mater yr oeddech chi wedi cysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn ei gylch"
+msgstr "Y mater yr oeddech chi wedi cysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn ei gylch"
 
 #: cla_public/templates/privacy.html:472
 msgid "When you contacted <abbr>CLA</abbr>"
-msgstr "Pryd yr oeddech chi wedi cysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>"
+msgstr "Pryd yr oeddech chi wedi cysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>"
 
 #: cla_public/templates/privacy.html:473
 msgid "What information you want to see"
@@ -2574,7 +2574,7 @@ msgid ""
 "Any additional information that might help us to check your identity e.g. <abbr>CLA</abbr> case reference number.\n"
 "      This is to help us protect your privacy by ensuring that we only give data out to the person it relates to\n"
 "      (or their appropriately authorised representative)."
-msgstr "Unrhyw wybodaeth ychwanegol i’n helpu i wirio pwy ydych chi e.e. rhif cyfeirio achos <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>. Bydd hyn yn ein helpu i ddiogelu’ch preifatrwydd drwy sicrhau mai dim ond i’r person y mae’r data’n ymwneud ag ef (neu gynrychiolydd sydd wedi’i awdurdodi’n briodol) y byddwn ni’n rhoi’r data."
+msgstr "Unrhyw wybodaeth ychwanegol i’n helpu i wirio pwy ydych chi e.e. rhif cyfeirio achos <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>. Bydd hyn yn ein helpu i ddiogelu’ch preifatrwydd drwy sicrhau mai dim ond i’r person y mae’r data’n ymwneud ag ef (neu gynrychiolydd sydd wedi’i awdurdodi’n briodol) y byddwn ni’n rhoi’r data."
 
 #: cla_public/templates/privacy.html:481
 msgid "You will also be required to provide proof of your identity. Acceptable forms of ID include:"
@@ -2608,7 +2608,7 @@ msgstr "Rhaid i unrhyw fil y byddwch yn ei anfon atom fod yn llai na 6 mis oed."
 msgid ""
 "Please note that we cannot give out any information unless the details that you provide match our records.\n"
 "    If you used an alias or pseudonym when you contacted <abbr>CLA</abbr>, you will need to prove your identity."
-msgstr "Sylwer na allwn roi unrhyw wybodaeth oni bai fod y manylion rydych chi’n eu rhoi yn cyfateb i’n cofnodion ni. Os gwnaethoch roi enw arall neu ffugenw pan wnaethoch chi gysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, bydd angen i chi brofi pwy ydych chi."
+msgstr "Sylwer na allwn roi unrhyw wybodaeth oni bai fod y manylion rydych chi’n eu rhoi yn cyfateb i’n cofnodion ni. Os gwnaethoch roi enw arall neu ffugenw pan wnaethoch chi gysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, bydd angen i chi brofi pwy ydych chi."
 
 #: cla_public/templates/privacy.html:499
 msgid "Once we receive the subject access request, we will deal with the request without any undue delay within one calendar month."
@@ -2636,7 +2636,7 @@ msgstr "Dan y ddeddfwriaeth diogelu data, nid oes gennym hawl i gadw eich gwybod
 
 #: cla_public/templates/privacy.html:518
 msgid "We will consider requests to delete some or all of your personal data but please note that, as a minimum, <abbr>CLA</abbr> will usually retain:"
-msgstr "Byddwn yn ystyried ceisiadau i ddileu eich holl ddata personol, neu rai data, ond dylech fod yn ymwybodol y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> fel arfer yn cadw’r canlynol o leiaf:"
+msgstr "Byddwn yn ystyried ceisiadau i ddileu eich holl ddata personol, neu rai data, ond dylech fod yn ymwybodol y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> fel arfer yn cadw’r canlynol o leiaf:"
 
 #: cla_public/templates/privacy.html:522
 msgid "For everyone that uses our service, a name and two other pieces of personal data, e.g. date of birth and postcode "
@@ -2646,18 +2646,18 @@ msgstr "Ar gyfer pawb sy’n defnyddio’n gwasanaeth, enw a dau ddarn arall o d
 msgid ""
 "For everyone that asks <abbr>CLA</abbr> to check whether they qualify for legal aid in order to seek advice from a\n"
 "      <abbr>CLA</abbr> Specialist, details of any financial information and case details used to prove that you qualify for legal aid"
-msgstr "Ar gyfer pawb sy’n gofyn i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> wirio a ydynt yn gymwys i gael cymorth cyfreithiol er mwyn gofyn am gyngor gan un o Arbenigwyr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, manylion unrhyw wybodaeth ariannol a manylion yr achos a ddefnyddir i brofi eich bod yn gymwys i gael cymorth cyfreithiol"
+msgstr "Ar gyfer pawb sy’n gofyn i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> wirio a ydynt yn gymwys i gael cymorth cyfreithiol er mwyn gofyn am gyngor gan un o Arbenigwyr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, manylion unrhyw wybodaeth ariannol a manylion yr achos a ddefnyddir i brofi eich bod yn gymwys i gael cymorth cyfreithiol"
 
 #: cla_public/templates/privacy.html:530
 msgid ""
 "Please note that, if you qualify to receive advice from a <abbr>CLA</abbr> Specialist, they will also need to retain\n"
 "    additional personal data about you within their own Case Handling System. Such data shall be sufficient\n"
 "    to justify the provision of legal aid advice and meet professional requirements."
-msgstr "Sylwer, os byddwch yn gymwys i gael cyngor gan un o Arbenigwyr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, bydd angen iddynt hefyd gadw data personol ychwanegol amdanoch yn eu System Ymdrin ag Achosion. Bydd data o’r fath yn ddigon i gyfiawnhau darparu cyngor am gymorth cyfreithiol a bodloni gofynion proffesiynol."
+msgstr "Sylwer, os byddwch yn gymwys i gael cyngor gan un o Arbenigwyr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, bydd angen iddynt hefyd gadw data personol ychwanegol amdanoch yn eu System Ymdrin ag Achosion. Bydd data o’r fath yn ddigon i gyfiawnhau darparu cyngor am gymorth cyfreithiol a bodloni gofynion proffesiynol."
 
 #: cla_public/templates/privacy.html:535
 msgid "If the information we hold about you is inaccurate for whatever reason, you can contact CLA to have your personal information amended."
-msgstr "Os yw’r wybodaeth rydym yn ei chadw amdanoch yn anghywir am unrhyw reswm, gallwch gysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> i ofyn i ni newid eich gwybodaeth bersonol."
+msgstr "Os yw’r wybodaeth rydym yn ei chadw amdanoch yn anghywir am unrhyw reswm, gallwch gysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> i ofyn i ni newid eich gwybodaeth bersonol."
 
 #: cla_public/templates/privacy.html:538
 msgid "When we ask you for personal data"
@@ -2749,7 +2749,7 @@ msgstr "Newidiadau yn y datganiad"
 msgid ""
 "This policy is under regular review. Any changes made to the privacy policy will be posted here and,\n"
 "    where appropriate, <abbr>CLA</abbr> staff will be notified by email."
-msgstr "Mae’r polisi hwn yn cael ei adolygu’n rheolaidd. Bydd unrhyw newidiadau yn y polisi preifatrwydd yn cael eu dangos yma ac, os yw’n briodol, bydd staff <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn cael eu hysbysu drwy’r e-bost"
+msgstr "Mae’r polisi hwn yn cael ei adolygu’n rheolaidd. Bydd unrhyw newidiadau yn y polisi preifatrwydd yn cael eu dangos yma ac, os yw’n briodol, bydd staff <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn cael eu hysbysu drwy’r e-bost"
 
 #: cla_public/templates/privacy.html:637
 msgid "Complaints about this statement"
@@ -2759,7 +2759,7 @@ msgstr "Cwynion am y datganiad hwn"
 msgid ""
 "If you would like to make a complaint about this statement and how it applies to you then please\n"
 "    contact <abbr title=\"Civil Legal Advice\">CLA</abbr> on <span class=\"tel\">0345 345 4 345</span>."
-msgstr "Os ydych chi’n dymuno gwneud cwyn am y datganiad hwn a’r ffordd y mae’n cael ei gymhwyso i chi, cysylltwch â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> ar 0345 345 4 345."
+msgstr "Os ydych chi’n dymuno gwneud cwyn am y datganiad hwn a’r ffordd y mae’n cael ei gymhwyso i chi, cysylltwch â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> ar 0345 345 4 345."
 
 #: cla_public/templates/reasons-for-contacting.html:6
 msgid "Why do you want to contact Civil Legal Advice?"
@@ -3007,7 +3007,7 @@ msgstr "Eich cyfeirnod yw"
 
 #: cla_public/templates/checker/result/confirmation.html:30
 msgid "You can now call CLA on"
-msgstr "Gallwch ffonio <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn awr ar"
+msgstr "Gallwch ffonio <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn awr ar"
 
 #: cla_public/templates/checker/result/confirmation.html:31
 msgid ""
@@ -3054,7 +3054,7 @@ msgstr ""
 #: cla_public/templates/macros/subform.html:19
 #: cla_public/templates/macros/subform.html:46
 msgid "When a CLA operator calls, the call will come from an anonymous number."
-msgstr "Pan fydd gweithredwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn eich ffonio, bydd rhif anhysbys yn ymddangos ar yr alwad."
+msgstr "Pan fydd gweithredwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn eich ffonio, bydd rhif anhysbys yn ymddangos ar yr alwad."
 
 #: cla_public/templates/checker/result/confirmation.html:80
 msgid ""
@@ -3152,7 +3152,7 @@ msgstr ""
 
 #: cla_public/templates/checker/result/confirmation.html:146
 msgid "If CLA can’t help you, we’ll always suggest where else you might get help."
-msgstr "Os nad yw <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn gallu eich helpu, byddwn ni bob amser yn awgrymu rhywle arall allai’ch helpu."
+msgstr "Os nad yw <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn gallu eich helpu, byddwn ni bob amser yn awgrymu rhywle arall allai’ch helpu."
 
 #: cla_public/templates/checker/result/confirmation.html:149
 msgid "If we can do anything to make it easier for you to communicate with us, please tell the operator."
@@ -3273,7 +3273,7 @@ msgid ""
 "    "
 msgstr ""
 "\n"
-"Gallwch ddewis cysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> eich hun a siarad â rhywun ar unwaith (mae hwn yn rhif 0345 - %(call_charges_link)s) neu gallwch ofyn i ni eich ffonio yn ôl, sydd yn rhad ac am ddim."
+"Gallwch ddewis cysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> eich hun a siarad â rhywun ar unwaith (mae hwn yn rhif 0345 - %(call_charges_link)s) neu gallwch ofyn i ni eich ffonio yn ôl, sydd yn rhad ac am ddim."
 
 #: cla_public/templates/checker/result/face-to-face.html:14
 msgid "Results for "
@@ -3412,7 +3412,7 @@ msgstr "Eich cyfeirnod yw %(case_ref)s."
 
 #: cla_public/templates/emails/confirmation.txt:51
 msgid "You can now call CLA on 0345 345 4 345. Please quote your reference number when you call."
-msgstr "Gallwch ffonio <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> nawr ar 0345 345 4 345. Dyfynnwch eich cyfeirnod pan fyddwch yn ffonio."
+msgstr "Gallwch ffonio <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> nawr ar 0345 345 4 345. Dyfynnwch eich cyfeirnod pan fyddwch yn ffonio."
 
 #: cla_public/templates/emails/confirmation.txt:55
 msgid "Take a short survey. Help improve the service."

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -2053,7 +2053,7 @@ msgstr "Mae’r datganiad hwn yn egluro sut y bydd CLA yn prosesu unrhyw ddata p
 msgid ""
 "The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for <abbr title=\"Civil Legal Advice\">CLA</abbr>\n"
 "    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr>LAA</abbr>) is an\n"
-"    Executive Agency of the (<abbr title=\"Ministry of Justice\">MoJ</abbr>)."
+"    Executive Agency of the <abbr title=\"Ministry of Justice\">MoJ</abbr>."
 msgstr "Yr Asiantaeth Cymorth Cyfreithiol (<abbr>LAA</abbr>) sy’n gyfrifol am y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, a’r Weinyddiaeth Gyfiawnder yw Rheolwr y Data. Mae’r Asiantaeth Cymorth Cyfreithiol  yn Asiantaeth Weithredol i’r Weinyddiaeth Gyfiawnder."
 
 #: cla_public/templates/privacy.html:90
@@ -2186,9 +2186,10 @@ msgid ""
 "    it is essential that the information you provide is accurate and complete."
 msgstr "Oherwydd y dibenion y gellir defnyddio eich data personol ar eu cyfer (sydd wedi’u nodi uchod), mae’n hanfodol eich bod yn darparu gwybodaeth sy’n gywir a chyflawn."
 
+#heading - do not add title attribute to abbr tag
 #: cla_public/templates/privacy.html:179
 msgid "How does <abbr>CLA</abbr> collect your personal data and keep it safe?"
-msgstr "Sut y mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn casglu’ch data personol ac yn eu cadw’n ddiogel?"
+msgstr "Sut y mae <abbr>CLA</abbr> yn casglu’ch data personol ac yn eu cadw’n ddiogel?"
 
 #: cla_public/templates/privacy.html:181
 msgid ""
@@ -2412,9 +2413,10 @@ msgid ""
 "    <a class=\"govuk-link\" href=\"http://www.aboutcookies.org/\" rel=\"external\">how to manage cookies</a>."
 msgstr "<a class=\"govuk-link\" href=\"http://www.aboutcookies.org/\" rel=\"external\">Mae gwybodaeth am ffyrdd o reoli cwcis yma</a>."
 
+#heading - do not add title attribute to abbr tag
 #: cla_public/templates/privacy.html:340
 msgid "When will we share information about you outside <abbr>CLA</abbr>?"
-msgstr "Pryd y byddwn ni’n rhannu gwybodaeth amdanoch chi y tu allan i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>?"
+msgstr "Pryd y byddwn ni’n rhannu gwybodaeth amdanoch chi y tu allan i <abbr>CLA</abbr>?"
 
 #: cla_public/templates/privacy.html:341
 msgid "Confidentiality means ensuring information is only accessible by those allowed to have access to it."

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -1969,19 +1969,19 @@ msgid ""
 "The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for the Civil Legal Advice (<abbr>CLA</abbr>) service. The <abbr title=\"Legal Aid Agency\">LAA</abbr> works with other\n"
 "    organisations who deliver the <abbr title=\"Civil Legal Advice\">CLA</abbr> service. For example this digital service is managed by the Ministry of\n"
 "    Justice (<abbr>MoJ</abbr>)."
-msgstr "Yr Asiantaeth Cymorth Cyfreithiol (LAA) sy’n gyfrifol am y gwasanaeth Cyngor Cyfreithiol Sifil (CLA). Mae’r Asiantaeth Cymorth Cyfreithiol yn gweithio gyda sefydliadau eraill sy’n darparu’r gwasanaeth CLA. Er enghraifft, mae’r gwasanaeth digidol hwn yn cael ei reoli gan y Weinyddiaeth Gyfiawnder."
+msgstr "Yr Asiantaeth Cymorth Cyfreithiol (LAA) sy’n gyfrifol am y gwasanaeth Cyngor Cyfreithiol Sifil (<abbr>CLA</abbr>). Mae’r Asiantaeth Cymorth Cyfreithiol yn gweithio gyda sefydliadau eraill sy’n darparu’r gwasanaeth CLA. Er enghraifft, mae’r gwasanaeth digidol hwn yn cael ei reoli gan y Weinyddiaeth Gyfiawnder."
 
 #: cla_public/templates/privacy.html:23
 msgid ""
 "When you first make contact with <abbr title=\"Civil Legal Advice\">CLA</abbr> you will communicate with the <abbr title=\"Civil Legal Advice\">CLA</abbr> Operator Service (CLAOS), which is delivered by\n"
 "    Hinduja Global Solutions UK Limited."
-msgstr "Y tro cyntaf y byddwch yn dod i gysylltiad â CLA byddwch yn cyfathrebu â Gwasanaeth Gweithredwr y CLA (CLAOS), sy’n cael ei ddarparu gan Hinduja Global Solutions UK Limited."
+msgstr "Y tro cyntaf y byddwch yn dod i gysylltiad â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> byddwch yn cyfathrebu â Gwasanaeth Gweithredwr y CLA (CLAOS), sy’n cael ei ddarparu gan Hinduja Global Solutions UK Limited."
 
 #: cla_public/templates/privacy.html:28
 msgid ""
 "Hinduja Global Solutions UK Limited is a contractor employed by the <abbr title=\"Legal Aid Agency\">LAA</abbr>\n"
 "    to deliver the <abbr title=\"Civil Legal Advice\">CLA</abbr> Operator Service."
-msgstr "Contractwr sy’n cael ei gyflogi gan yr Asiantaeth Cymorth Cyfreithiol i ddarparu Gwasanaeth Gweithredwr y CLA yw Hinduja Global Solutions UK Limited."
+msgstr "Contractwr sy’n cael ei gyflogi gan yr Asiantaeth Cymorth Cyfreithiol i ddarparu Gwasanaeth Gweithredwr y <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yw Hinduja Global Solutions UK Limited."
 
 #: cla_public/templates/privacy.html:32 cla_public/templates/privacy.html:612
 msgid "Complaints"
@@ -1989,7 +1989,7 @@ msgstr "Cwynion"
 
 #: cla_public/templates/privacy.html:34
 msgid "If you would like to make a complaint about this service or Civil Legal Advice please contact <abbr title=\"Civil Legal Advice\">CLA</abbr> on 0345 345 4 345."
-msgstr "Os ydych chi’n dymuno gwneud cwyn am y gwasanaeth hwn neu Gyngor Cyfreithiol Sifil, cysylltwch â CLA ar 0345 345 4 345"
+msgstr "Os ydych chi’n dymuno gwneud cwyn am y gwasanaeth hwn neu Gyngor Cyfreithiol Sifil, cysylltwch â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> ar 0345 345 4 345"
 
 #: cla_public/templates/privacy.html:37
 msgid "How is my privacy protected?"
@@ -2009,14 +2009,14 @@ msgstr "Dim ond os byddwch chi’n penderfynu cysylltu â gweithredwr Cyngor Cyf
 
 #: cla_public/templates/privacy.html:49
 msgid ""
-"At this point, you will need to tell us your name and phone number and all the information you've entered will\n"
+"At this point, you will need to tell us your name and phone number and all the information you’ve entered will\n"
 "    be stored when you click 'Submit your application'. We store this information so that the operator can see it\n"
 "    when they speak to you."
 msgstr ""
 
 #: cla_public/templates/privacy.html:55
 msgid ""
-"If you don't want to speak to an operator, you don't need to enter any personal details and we don't store\n"
+"If you don’t want to speak to an operator, you don’t need to enter any personal details and we don’t store\n"
 "    any of the information you have entered."
 msgstr ""
 
@@ -2037,7 +2037,7 @@ msgstr "Mewn amgylchiadau eithriadol, mae’n bosibl y byddwn yn rhannu ychydig 
 msgid ""
 "In order to provide a service to you, Civil Legal Advice (<abbr title=\"Civil Legal Advice\">CLA</abbr>)\n"
 "    may need to view, collect, record and hold (‘process’) personal data about you."
-msgstr "Er mwyn darparu gwasanaeth i chi, mae’n bosibl y bydd angen i Gyngor Cyfreithiol Sifil (CLA) weld, casglu, cofnodi a dal (‘prosesu’) data personol amdanoch chi."
+msgstr "Er mwyn darparu gwasanaeth i chi, mae’n bosibl y bydd angen i Gyngor Cyfreithiol Sifil (<abbr>CLA</abbr>) weld, casglu, cofnodi a dal (‘prosesu’) data personol amdanoch chi."
 
 #: cla_public/templates/privacy.html:75
 msgid "Personal data is information about you as an individual. It can be your name, address or telephone number. It can also include the information that you have provided in this form, such as your financial circumstances."
@@ -2052,9 +2052,9 @@ msgstr "Mae’r datganiad hwn yn egluro sut y bydd CLA yn prosesu unrhyw ddata p
 #: cla_public/templates/privacy.html:84
 msgid ""
 "The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for <abbr title=\"Civil Legal Advice\">CLA</abbr>\n"
-"    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is an\n"
+"    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr>LAA</abbr>) is an\n"
 "    Executive Agency of the (<abbr title=\"Ministry of Justice\">MoJ</abbr>)."
-msgstr "Yr Asiantaeth Cymorth Cyfreithiol (<abbr>LAA</abbr>) sy’n gyfrifol am y gwasanaeth <abbr>CLA</abbr>, a’r Weinyddiaeth Gyfiawnder yw Rheolwr y Data. Mae’r Asiantaeth Cymorth Cyfreithiol  yn Asiantaeth Weithredol i’r Weinyddiaeth Gyfiawnder."
+msgstr "Yr Asiantaeth Cymorth Cyfreithiol (<abbr>LAA</abbr>) sy’n gyfrifol am y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, a’r Weinyddiaeth Gyfiawnder yw Rheolwr y Data. Mae’r Asiantaeth Cymorth Cyfreithiol  yn Asiantaeth Weithredol i’r Weinyddiaeth Gyfiawnder."
 
 #: cla_public/templates/privacy.html:90
 msgid ""
@@ -2062,20 +2062,20 @@ msgid ""
 "    For example, when you first make contact with <abbr>CLA</abbr>, you will communicate with\n"
 "    the <abbr>CLA</abbr> Operator Service, which is delivered by Hinduja Global Solutions UK Limited\n"
 "    (a contractor employed by the <abbr title=\"Legal Aid Agency\">LAA</abbr>)."
-msgstr "Mae’r Asiantaeth Cymorth Cyfreithiol yn gweithio gyda sefydliadau eraill sy’n darparu’r gwasanaeth CLA. Er enghraifft, y tro cyntaf y byddwch yn dod i gysylltiad â CLA, byddwch yn cyfathrebu â Gwasanaeth Gweithredwr y CLA, sy’n cael ei ddarparu gan Hinduja Global Solutions UK Limited (contractwr sy’n cael ei gyflogi gan yr Asiantaeth Cymorth Cyfreithiol)."
+msgstr "Mae’r Asiantaeth Cymorth Cyfreithiol yn gweithio gyda sefydliadau eraill sy’n darparu’r gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>. Er enghraifft, y tro cyntaf y byddwch yn dod i gysylltiad â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, byddwch yn cyfathrebu â Gwasanaeth Gweithredwr y <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, sy’n cael ei ddarparu gan Hinduja Global Solutions UK Limited (contractwr sy’n cael ei gyflogi gan yr Asiantaeth Cymorth Cyfreithiol)."
 
 #: cla_public/templates/privacy.html:97
 msgid ""
 "Once you have contacted the <abbr>CLA</abbr> Operator Service, if you are likely to qualify for Legal Aid, the operator will transfer you to\n"
 "     a <abbr>CLA</abbr> Specialist Provider. If you do not qualify to receive\n"
 "    <abbr>CLA</abbr> Specialist advice, the operator will inform you accordingly and direct you to alternative sources of help."
-msgstr "Ar ôl i chi gysylltu â Gwasanaeth Gweithredwr y CLA, os ydych yn debygol o fod yn gymwys i gael Cymorth Cyfreithiol bydd y gweithredwr yn eich trosglwyddo i Ddarparwr CLA Arbenigol. Os nad ydych yn gymwys i dderbyn cyngor Arbenigwr CLA, bydd y gweithredwr yn dweud wrthych ac yn eich cyfeirio at ffynonellau cymorth eraill."
+msgstr "Ar ôl i chi gysylltu â Gwasanaeth Gweithredwr y <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, os ydych yn debygol o fod yn gymwys i gael Cymorth Cyfreithiol bydd y gweithredwr yn eich trosglwyddo i Ddarparwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> Arbenigol. Os nad ydych yn gymwys i dderbyn cyngor Arbenigwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, bydd y gweithredwr yn dweud wrthych ac yn eich cyfeirio at ffynonellau cymorth eraill."
 
 #: cla_public/templates/privacy.html:103
 msgid ""
 "The <abbr>CLA</abbr> service is committed to following this Privacy Statement.\n"
 "    <abbr>CLA</abbr> Specialists must also adhere to their own internal privacy policy."
-msgstr "Mae gwasanaeth CLA wedi ymrwymo i gydymffurfio â’r Datganiad Preifatrwydd hwn. Hefyd rhaid i Arbenigwyr CLA gydymffurfio â’u polisi preifatrwydd mewnol eu hunain."
+msgstr "Mae gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> wedi ymrwymo i gydymffurfio â’r Datganiad Preifatrwydd hwn. Hefyd rhaid i Arbenigwyr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gydymffurfio â’u polisi preifatrwydd mewnol eu hunain."
 
 #: cla_public/templates/privacy.html:108
 msgid "What types of personal data do we process?"
@@ -2083,11 +2083,11 @@ msgstr "Pa fathau o ddata personol rydym yn eu prosesu? "
 
 #: cla_public/templates/privacy.html:110
 msgid "<abbr>CLA</abbr> will only collect the minimum amount of information that is necessary and relevant, in order to deliver the <abbr>CLA</abbr> service to you."
-msgstr "Ni fydd CLA yn casglu mwy o wybodaeth nag sy’n angenrheidiol ac yn berthnasol er mwyn darparu’r gwasanaeth CLA i chi."
+msgstr "Ni fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn casglu mwy o wybodaeth nag sy’n angenrheidiol ac yn berthnasol er mwyn darparu’r gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> i chi."
 
 #: cla_public/templates/privacy.html:113
 msgid "The kind of information <abbr>CLA</abbr> may collect about you includes:"
-msgstr "Y math o wybodaeth y gall CLA ei chasglu amdanoch chi yw:"
+msgstr "Y math o wybodaeth y gall <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> ei chasglu amdanoch chi yw:"
 
 #: cla_public/templates/privacy.html:117
 msgid ""
@@ -2101,11 +2101,11 @@ msgstr "Gwybodaeth ariannol sydd ei hangen i bennu a ydych chi’n gymwys i gael
 
 #: cla_public/templates/privacy.html:124
 msgid "Reason for contacting <abbr>CLA</abbr>, such as the nature of your problem or specific details about your situation;"
-msgstr "Y rheswm dros gysylltu â CLA, er enghraifft, natur eich problem neu fanylion penodol am eich sefyllfa;"
+msgstr "Y rheswm dros gysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, er enghraifft, natur eich problem neu fanylion penodol am eich sefyllfa;"
 
 #: cla_public/templates/privacy.html:127
 msgid "Details of any specific needs that you may have in order to access the <abbr>CLA</abbr> service; and"
-msgstr "Manylion unrhyw anghenion penodol sydd gennych er mwyn cael mynediad at wasanaeth CLA; a"
+msgstr "Manylion unrhyw anghenion penodol sydd gennych er mwyn cael mynediad at wasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>; a"
 
 #: cla_public/templates/privacy.html:130
 msgid ""
@@ -2118,15 +2118,15 @@ msgid ""
 "The amount of information <abbr>CLA</abbr> will collect will depend on whether you qualify for the <abbr>CLA</abbr>\n"
 "    service and/or your specific needs. For example, you will be asked to provide more information\n"
 "    before we can transfer you through to a <abbr>CLA</abbr> Specialist."
-msgstr "Bydd faint o wybodaeth y bydd CLA yn ei gasglu amdanoch yn amrywio gan ddibynnu a ydych yn gymwys ar gyfer y gwasanaeth CLA, a/neu a oes gennych anghenion penodol. Er enghraifft, gofynnir i chi roi mwy o wybodaeth cyn y gallwn eich trosglwyddo at Arbenigwr CLA."
+msgstr "Bydd faint o wybodaeth y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn ei gasglu amdanoch yn amrywio gan ddibynnu a ydych yn gymwys ar gyfer y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, a/neu a oes gennych anghenion penodol. Er enghraifft, gofynnir i chi roi mwy o wybodaeth cyn y gallwn eich trosglwyddo at Arbenigwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>."
 
 #: cla_public/templates/privacy.html:141
 msgid "How does <abbr>CLA</abbr> use your data and why?"
-msgstr "Sut mae CLA yn defnyddio eich data a pham?"
+msgstr "Sut mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn defnyddio eich data a pham?"
 
 #: cla_public/templates/privacy.html:142
 msgid "collects and records information about you to:"
-msgstr "Mae CLA yn casglu ac yn cofnodi gwybodaeth amdanoch chi er mwyn:"
+msgstr "Mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn casglu ac yn cofnodi gwybodaeth amdanoch chi er mwyn:"
 
 #: cla_public/templates/privacy.html:144
 msgid "Work out whether you qualify for legal aid;"
@@ -2148,13 +2148,13 @@ msgstr "Ein helpu i fonitro a gwella ein gwasanaeth;"
 msgid ""
 "Build statistics about the <abbr>CLA</abbr> service, monitor fraud and justify public expenditure.\n"
 "      This information is collated in an anonymous format;"
-msgstr "Adeiladu ystadegau am y gwasanaeth CLA, monitro twyll a chyfiawnhau gwariant cyhoeddus. Mae’r wybodaeth hon yn cael ei choladu mewn fformat dienw;"
+msgstr "Adeiladu ystadegau am y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, monitro twyll a chyfiawnhau gwariant cyhoeddus. Mae’r wybodaeth hon yn cael ei choladu mewn fformat dienw;"
 
 #: cla_public/templates/privacy.html:153
 msgid ""
 "Collect views on the <abbr>CLA</abbr> service and any improvements considered necessary.\n"
 "      Where consent is provided, <abbr>CLA</abbr> User contact details may be passed onto an independent research agency;"
-msgstr "Casglu barn am y gwasanaeth CLA ac unrhyw welliannau y credir bod eu hangen. Lle rhoddir cydsyniad, mae’n bosibl y bydd manylion cysylltu defnyddiwr CLA yn cael eu pasio ymlaen i asiantaeth ymchwil annibynnol;"
+msgstr "Casglu barn am y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> ac unrhyw welliannau y credir bod eu hangen. Lle rhoddir cydsyniad, mae’n bosibl y bydd manylion cysylltu defnyddiwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn cael eu pasio ymlaen i asiantaeth ymchwil annibynnol;"
 
 #: cla_public/templates/privacy.html:156
 msgid "Prevent or detect crime or fraud; and"
@@ -2166,19 +2166,19 @@ msgstr "Cynnal archwiliadau sicrwydd achlysurol er mwyn sicrhau bod y penderfyni
 
 #: cla_public/templates/privacy.html:161
 msgid "Without this information, <abbr>CLA</abbr> would not be able to conduct the activities above which are essential to the delivery of legal aid."
-msgstr "Heb yr wybodaeth hon, ni fyddai CLA yn gallu cynnal y gweithgareddau uchod sy’n hanfodol er mwyn darparu cymorth cyfreithiol."
+msgstr "Heb yr wybodaeth hon, ni fyddai <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn gallu cynnal y gweithgareddau uchod sy’n hanfodol er mwyn darparu cymorth cyfreithiol."
 
 #: cla_public/templates/privacy.html:165
 msgid ""
 "The lawful basis for <abbr>CLA</abbr> collecting and processing your personal data is the result of the powers contained in legislation, specifically the Legal Aid, Sentencing\n"
 "     and Punishment of Offenders Act 2012."
-msgstr "Mae’r sail gyfreithlon sy’n caniatáu i CLA gasglu a phrosesu eich data personol yn deillio o’r pwerau sydd wedi’u cynnwys mewn deddfwriaeth, yn fwyaf penodol, Deddf Cymorth Cyfreithiol Dedfrydu a Chosbi Troseddwyr 2012."
+msgstr "Mae’r sail gyfreithlon sy’n caniatáu i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gasglu a phrosesu eich data personol yn deillio o’r pwerau sydd wedi’u cynnwys mewn deddfwriaeth, yn fwyaf penodol, Deddf Cymorth Cyfreithiol Dedfrydu a Chosbi Troseddwyr 2012."
 
 #: cla_public/templates/privacy.html:170
 msgid ""
 "<abbr>CLA</abbr> also collects ‘special categories of personal data’ for the purposes of monitoring equality. This is a legal requirement for public authorities, under the Equality Act 2010.\n"
 "     Special categories of personal data obtained for equality monitoring will be treated with the strictest confidence and any information published will not identify you or anyone else associated with your legal aid application."
-msgstr "Mae CLA hefyd yn casglu ‘categorïau arbennig o ddata personol’ at ddibenion monitro cydraddoldeb. Mae Deddf Cydraddoldeb 2010 yn nodi ei bod yn ofynnol i awdurdodau cyhoeddus wneud hyn. Byddwn yn trin categorïau arbennig o ddata personol a gesglir er mwyn monitro cydraddoldeb yn gwbl gyfrinachol ac ni fydd unrhyw wybodaeth a gyhoeddir yn nodi pwy ydych chi na neb arall sy’n gysylltiedig â’ch cais am gymorth cyfreithiol."
+msgstr "Mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> hefyd yn casglu ‘categorïau arbennig o ddata personol’ at ddibenion monitro cydraddoldeb. Mae Deddf Cydraddoldeb 2010 yn nodi ei bod yn ofynnol i awdurdodau cyhoeddus wneud hyn. Byddwn yn trin categorïau arbennig o ddata personol a gesglir er mwyn monitro cydraddoldeb yn gwbl gyfrinachol ac ni fydd unrhyw wybodaeth a gyhoeddir yn nodi pwy ydych chi na neb arall sy’n gysylltiedig â’ch cais am gymorth cyfreithiol."
 
 #: cla_public/templates/privacy.html:175
 msgid ""
@@ -2188,25 +2188,25 @@ msgstr "Oherwydd y dibenion y gellir defnyddio eich data personol ar eu cyfer (s
 
 #: cla_public/templates/privacy.html:179
 msgid "How does <abbr>CLA</abbr> collect your personal data and keep it safe?"
-msgstr "Sut y mae CLA yn casglu’ch data personol ac yn eu cadw’n ddiogel?"
+msgstr "Sut y mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn casglu’ch data personol ac yn eu cadw’n ddiogel?"
 
 #: cla_public/templates/privacy.html:181
 msgid ""
 "<abbr>CLA</abbr> may collect personal data about you by phone, online, email or post (see table below).\n"
 "    Any personal data will be recorded and stored within a secure system that meets required Government standards."
-msgstr "Gall CLA gasglu data personol amdanoch chi dros y ffôn, ar-lein, drwy’r post a’r e-bost (gweler y tabl isod). Bydd unrhyw ddata personol yn cael eu cofnodi a’u storio mewn system ddiogel sy’n cyrraedd safonau sydd wedi’u gosod gan y Llywodraeth."
+msgstr "Gall <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gasglu data personol amdanoch chi dros y ffôn, ar-lein, drwy’r post a’r e-bost (gweler y tabl isod). Bydd unrhyw ddata personol yn cael eu cofnodi a’u storio mewn system ddiogel sy’n cyrraedd safonau sydd wedi’u gosod gan y Llywodraeth."
 
 #: cla_public/templates/privacy.html:185
 msgid ""
 "<abbr>CLA</abbr> will be able to view and verify the information that you provide and, where\n"
 "    necessary, will amend it to maintain its accuracy."
-msgstr "Bydd CLA yn gallu gweld a gwirio’r wybodaeth y byddwch yn ei rhoi a, lle bo angen, bydd yn diwygio’r wybodaeth er mwyn sicrhau ei bod yn gywir."
+msgstr "Bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn gallu gweld a gwirio’r wybodaeth y byddwch yn ei rhoi a, lle bo angen, bydd yn diwygio’r wybodaeth er mwyn sicrhau ei bod yn gywir."
 
 #: cla_public/templates/privacy.html:189
 msgid ""
 "The minimum amount of personal data that <abbr>CLA</abbr> will ask to collect is your name and two other pieces\n"
 "    of personal information that could be used to identify you, e.g. postcode, date of birth or telephone number."
-msgstr "Y data personol sylfaenol y bydd CLA yn gofyn amdanynt yw eich enw a dau ddarn arall o wybodaeth bersonol a allai gael eu defnyddio i’ch adnabod, e.e. côd post, dyddiad geni neu rif ffôn."
+msgstr "Y data personol sylfaenol y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn gofyn amdanynt yw eich enw a dau ddarn arall o wybodaeth bersonol a allai gael eu defnyddio i’ch adnabod, e.e. côd post, dyddiad geni neu rif ffôn."
 
 #: cla_public/templates/privacy.html:193
 msgid ""
@@ -2241,7 +2241,7 @@ msgid ""
 "        <br><br>\n"
 "        If you leave <abbr>CLA</abbr> a voice message we will record the minimum amount of information\n"
 "        required in order to contact you back."
-msgstr "Pan fyddwch chi’n ffonio CLA, byddwn ni’n cofnodi data personol perthnasol yr ydych chi’n eu rhoi mewn system ddigidol ddiogel. Gallwn recordio’ch galwadau hefyd. Ond cewch chi ddewis peidio ag ymuno â hyn neu ddewis a ydych chi am barhau â’r alwad neu beidio. Os byddwch chi’n gadael neges llais i CLA, byddwn ni’n cofnodi’r lleiaf o wybodaeth sydd ei hangen i gysylltu â chi wedyn."
+msgstr "Pan fyddwch chi’n ffonio <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, byddwn ni’n cofnodi data personol perthnasol yr ydych chi’n eu rhoi mewn system ddigidol ddiogel. Gallwn recordio’ch galwadau hefyd. Ond cewch chi ddewis peidio ag ymuno â hyn neu ddewis a ydych chi am barhau â’r alwad neu beidio. Os byddwch chi’n gadael neges llais i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, byddwn ni’n cofnodi’r lleiaf o wybodaeth sydd ei hangen i gysylltu â chi wedyn."
 
 #: cla_public/templates/privacy.html:221
 msgid "Online"
@@ -2254,7 +2254,7 @@ msgid ""
 "        Please note that transmitting information over the internet is generally not completely secure, and\n"
 "        <abbr>CLA</abbr> can’t guarantee the security of your data. Any data you transmit is at your own risk.\n"
 "        <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it."
-msgstr "Pan fyddwch yn cysylltu â CLA ar-lein, bydd y data personol y byddwch yn eu rhoi yn cael eu cofnodi mewn system ddigidol ddiogel. Sylwer nad yw trawsyrru gwybodaeth dros y rhyngrwyd yn gwbl ddiogel bob amser, ac ni all CLA warantu diogelwch eich data. Ni allwn fod yn gyfrifol am unrhyw ddata y byddwch yn eu trawsyrru. Mae gan CLA weithdrefnau a nodweddion diogelwch er mwyn cadw eich data’n ddiogel ar ôl i ni eu derbyn."
+msgstr "Pan fyddwch yn cysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> ar-lein, bydd y data personol y byddwch yn eu rhoi yn cael eu cofnodi mewn system ddigidol ddiogel. Sylwer nad yw trawsyrru gwybodaeth dros y rhyngrwyd yn gwbl ddiogel bob amser, ac ni all <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> warantu diogelwch eich data. Ni allwn fod yn gyfrifol am unrhyw ddata y byddwch yn eu trawsyrru. Mae gan <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> weithdrefnau a nodweddion diogelwch er mwyn cadw eich data’n ddiogel ar ôl i ni eu derbyn."
 
 #: cla_public/templates/privacy.html:233
 msgid ""
@@ -2266,7 +2266,7 @@ msgid ""
 "        When you email <abbr>CLA</abbr>, relevant personal data that you provide will be recorded within a secure digital system.\n"
 "        <br><br>\n"
 "        <abbr>CLA</abbr> may monitor and store both your incoming and outgoing emails. We may also use blocking software."
-msgstr "Nid yw trawsyrru gwybodaeth drwy e-bost yn gwbl ddiogel bob amser, ac ni all CLA warantu diogelwch eich data. Ni allwn fod yn gyfrifol am unrhyw ddata y byddwch yn eu trawsyrru"
+msgstr "Nid yw trawsyrru gwybodaeth drwy e-bost yn gwbl ddiogel bob amser, ac ni all <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> warantu diogelwch eich data. Ni allwn fod yn gyfrifol am unrhyw ddata y byddwch yn eu trawsyrru"
 
 #: cla_public/templates/privacy.html:244
 msgid "Post"
@@ -2278,7 +2278,7 @@ msgid ""
 "        <br><br>\n"
 "        <abbr>CLA</abbr> may also retain original hard-copies of information submitted by you. This must be stored in a locked\n"
 "        filing cabinet. Digital copies of letters may be scanned and stored."
-msgstr "Pan fydd CLA yn derbyn llythyrau, gallwn ni gofnodi data personol perthnasol sydd ynddynt mewn system ddigidol ddiogel. Hefyd gall CLA gadw llythyrau gwreiddiol sy’n cynnwys gwybodaeth a gyflwynwyd gennych chi. Rhaid storio’r rhain mewn cwpwrdd ffeiliau sydd wedi’i gloi. Gellir sganio copïau digidol o lythyrau a’u storio."
+msgstr "Pan fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn derbyn llythyrau, gallwn ni gofnodi data personol perthnasol sydd ynddynt mewn system ddigidol ddiogel. Hefyd gall <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gadw llythyrau gwreiddiol sy’n cynnwys gwybodaeth a gyflwynwyd gennych chi. Rhaid storio’r rhain mewn cwpwrdd ffeiliau sydd wedi’i gloi. Gellir sganio copïau digidol o lythyrau a’u storio."
 
 #: cla_public/templates/privacy.html:255
 msgid "Keeping your personal data safe from others"
@@ -2292,7 +2292,7 @@ msgstr "Ailgysylltu"
 msgid ""
 "<abbr>CLA</abbr> will not disclose any personal information to anyone contacting the <abbr>CLA</abbr> service until\n"
 "        they have successfully verified that their identity matches that of an existing record."
-msgstr "Ni fydd CLA yn datgelu unrhyw wybodaeth bersonol i rywun sy’n cysylltu â gwasanaeth CLA nes ei fod wedi cadarnhau bod ei hunaniaeth yn cyfateb i gofnod sy’n bodoli."
+msgstr "Ni fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn datgelu unrhyw wybodaeth bersonol i rywun sy’n cysylltu â gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> nes ei fod wedi cadarnhau bod ei hunaniaeth yn cyfateb i gofnod sy’n bodoli."
 
 #: cla_public/templates/privacy.html:265
 msgid "Third-parties"
@@ -2307,7 +2307,7 @@ msgid ""
 "        and whether they are authorised to act on their behalf.\n"
 "        <br><br>\n"
 "        They must also agree a password to verify the identity of the third-party if they contact the service again."
-msgstr "Bydd CLA yn cydnabod trydydd parti sy’n cysylltu ar ran person arall. Mae’n rhaid i’r trydydd parti ddangos bod ganddynt yr awdurdod priodol i weithredu ar eich rhan. Rhaid i CLA gofnodi’r berthynas rhwng y trydydd parti a’r unigolyn sy’n gofyn am gyngor ac a yw’r trydydd parti wedi’i awdurdodi i weithredu ar ei ran. Hefyd rhaid i CLA gytuno ar gyfrinair er mwyn gwirio hunaniaeth y trydydd parti os bydd yn cysylltu â’r gwasanaeth eto."
+msgstr "Bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn cydnabod trydydd parti sy’n cysylltu ar ran person arall. Mae’n rhaid i’r trydydd parti ddangos bod ganddynt yr awdurdod priodol i weithredu ar eich rhan. Rhaid i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gofnodi’r berthynas rhwng y trydydd parti a’r unigolyn sy’n gofyn am gyngor ac a yw’r trydydd parti wedi’i awdurdodi i weithredu ar ei ran. Hefyd rhaid i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gytuno ar gyfrinair er mwyn gwirio hunaniaeth y trydydd parti os bydd yn cysylltu â’r gwasanaeth eto."
 
 #: cla_public/templates/privacy.html:277
 msgid "Outgoing Communications"
@@ -2315,15 +2315,15 @@ msgstr "Anfon negeseuon allan"
 
 #: cla_public/templates/privacy.html:279
 msgid "<abbr>CLA</abbr> may need to contact you directly."
-msgstr "Mae’n bosibl y bydd angen i CLA gysylltu â chi’n uniongyrchol."
+msgstr "Mae’n bosibl y bydd angen i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> gysylltu â chi’n uniongyrchol."
 
 #: cla_public/templates/privacy.html:281
 msgid "In order to protect privacy, <abbr>CLA</abbr> will always check with you what forms of outgoing communication are acceptable and appropriate and whether messages can be left."
-msgstr "Er mwyn sicrhau preifatrwydd, bydd CLA bob amser yn gofyn pa ddulliau cyfathrebu sy’n dderbyniol ac yn briodol i chi ac a oes modd gadael negeseuon."
+msgstr "Er mwyn sicrhau preifatrwydd, bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> bob amser yn gofyn pa ddulliau cyfathrebu sy’n dderbyniol ac yn briodol i chi ac a oes modd gadael negeseuon."
 
 #: cla_public/templates/privacy.html:283
 msgid "When making outgoing calls to you, <abbr>CLA</abbr> will ensure that:"
-msgstr "Pan fydd CLA yn eich ffonio chi, bydd yn:"
+msgstr "Pan fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn eich ffonio chi, bydd yn:"
 
 #: cla_public/templates/privacy.html:286
 msgid ""
@@ -2342,7 +2342,7 @@ msgid ""
 "Where the phone is answered and someone other than you answers the phone and says that you are\n"
 "            unavailable or asks who is calling, <abbr>CLA</abbr> will state that the call is confidential and will not say\n"
 "            that they are calling from <abbr>CLA</abbr>."
-msgstr "Os bydd rhywun heblaw chi’n ateb y ffôn ac yn dweud nad ydych chi ar gael neu’n gofyn pwy sy’n galw, y bydd CLA yn dweud bod yr alwad yn gyfrinachol ac na fydd yn dweud ei fod yn ffonio o CLA."
+msgstr "Os bydd rhywun heblaw chi’n ateb y ffôn ac yn dweud nad ydych chi ar gael neu’n gofyn pwy sy’n galw, y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn dweud bod yr alwad yn gyfrinachol ac na fydd yn dweud ei fod yn ffonio o <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>."
 
 #: cla_public/templates/privacy.html:304
 msgid "How we use cookies"
@@ -2396,25 +2396,25 @@ msgstr "Mae’r gwasanaeth ar-lein hefyd yn defnyddio cwcis o Wasanaeth Digidol 
 
 #: cla_public/templates/privacy.html:328
 #, python-format
-msgid "You can change <a href=\"%(cookie_settings_url)s\">your cookie settings</a> to opt in or out of how different cookies are used."
-msgstr "<a href=\"%(cookie_settings_url)s\">Gallwch newid eich gosodiadau cwcis er mwyn optio i mewn neu allan o’r ffordd y defnyddir gwahanol gwcis.</a>"
+msgid "You can change <a class=\"govuk-link\" href=\"%(cookie_settings_url)s\">your cookie settings</a> to opt in or out of how different cookies are used."
+msgstr "<a class=\"govuk-link\" href=\"%(cookie_settings_url)s\">Gallwch newid eich gosodiadau cwcis er mwyn optio i mewn neu allan o’r ffordd y defnyddir gwahanol gwcis.</a>"
 
 #: cla_public/templates/privacy.html:331
 #, python-format
 msgid ""
-"You can read more about <a href=\"%(cookie_url)s\">cookies used on \n"
+"You can read more about <a class=\"govuk-link\" href=\"%(cookie_url)s\">cookies used on \n"
 "    check you can get legal aid</a>."
-msgstr "<a href=\"%(cookie_url)s\">Gallwch ddarllen mwy am y cwcis sy’n cael eu defnyddio ar ‘Gwirio os ydych yn gymwys i gael cymorth cyfreithiol’</a>"
+msgstr "<a class=\"govuk-link\" href=\"%(cookie_url)s\">Gallwch ddarllen mwy am y cwcis sy’n cael eu defnyddio ar ‘Gwirio os ydych yn gymwys i gael cymorth cyfreithiol’</a>"
 
 #: cla_public/templates/privacy.html:335
 msgid ""
 "You can read about\n"
-"    <a href=\"http://www.aboutcookies.org/\" rel=\"external\">how to manage cookies</a>."
-msgstr "<a href=\"http://www.aboutcookies.org/\" rel=\"external\">Mae gwybodaeth am ffyrdd o reoli cwcis yma</a>."
+"    <a class=\"govuk-link\" href=\"http://www.aboutcookies.org/\" rel=\"external\">how to manage cookies</a>."
+msgstr "<a class=\"govuk-link\" href=\"http://www.aboutcookies.org/\" rel=\"external\">Mae gwybodaeth am ffyrdd o reoli cwcis yma</a>."
 
 #: cla_public/templates/privacy.html:340
 msgid "When will we share information about you outside <abbr>CLA</abbr>?"
-msgstr "Pryd y byddwn ni’n rhannu gwybodaeth amdanoch chi y tu allan i CLA?"
+msgstr "Pryd y byddwn ni’n rhannu gwybodaeth amdanoch chi y tu allan i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>?"
 
 #: cla_public/templates/privacy.html:341
 msgid "Confidentiality means ensuring information is only accessible by those allowed to have access to it."
@@ -2424,7 +2424,7 @@ msgstr "Mae cyfrinachedd yn golygu sicrhau mai dim ond y rheini sydd â hawl i w
 msgid ""
 "We want to keep your contact with <abbr>CLA</abbr> confidential, which means you can feel safe talking to us.\n"
 "    But we sometimes need to share some information outside <abbr>CLA</abbr> which we explain below."
-msgstr "Rydyn ni am gadw’ch cysylltiad â CLA yn gyfrinachol: mae hyn yn golygu y byddwch chi’n gallu teimlo’n ddiogel wrth siarad â ni. Ond weithiau bydd angen i ni rannu rhywfaint o wybodaeth y tu allan i CLA. Rydyn ni’n egluro hyn isod."
+msgstr "Rydyn ni am gadw’ch cysylltiad â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn gyfrinachol: mae hyn yn golygu y byddwch chi’n gallu teimlo’n ddiogel wrth siarad â ni. Ond weithiau bydd angen i ni rannu rhywfaint o wybodaeth y tu allan i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>. Rydyn ni’n egluro hyn isod."
 
 #: cla_public/templates/privacy.html:347
 msgid ""
@@ -2537,7 +2537,7 @@ msgid ""
 msgstr "Gallwch ddarganfod a ydym yn cadw unrhyw ddata personol amdanoch a gofyn am gopi o’r wybodaeth hon drwy ysgrifennu at yr Asiantaeth Cymorth Cyfreithiol i wneud ‘cais am fynediad at ddata gan y testun’. Er mwyn gwneud cais am fynediad at ddata gan y testun, bydd angen i chi gysylltu â’r Tîm Datgelu yn y cyfeiriad isod:"
 
 #: cla_public/templates/privacy.html:462
-msgid "You can also email at <a class=\"email\" href=\"mailto:data.access@justice.gov.uk\">data.access@justice.gov.uk</a>."
+msgid "You can also email at <a class=\"govuk-link email\" href=\"mailto:data.access@justice.gov.uk\">data.access@justice.gov.uk</a>."
 msgstr "Gallwch hefyd anfon e-bost i <a class=\"email\" href=\"mailto:data.access@justice.gov.uk\">data.access@justice.gov.uk</a>."
 
 #: cla_public/templates/privacy.html:465
@@ -2559,11 +2559,11 @@ msgstr "Dyddiad geni"
 
 #: cla_public/templates/privacy.html:471
 msgid "What you contacted <abbr>CLA</abbr> about"
-msgstr "Y mater yr oeddech chi wedi cysylltu â CLA yn ei gylch"
+msgstr "Y mater yr oeddech chi wedi cysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn ei gylch"
 
 #: cla_public/templates/privacy.html:472
 msgid "When you contacted <abbr>CLA</abbr>"
-msgstr "Pryd yr oeddech chi wedi cysylltu â CLA"
+msgstr "Pryd yr oeddech chi wedi cysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>"
 
 #: cla_public/templates/privacy.html:473
 msgid "What information you want to see"
@@ -2574,7 +2574,7 @@ msgid ""
 "Any additional information that might help us to check your identity e.g. <abbr>CLA</abbr> case reference number.\n"
 "      This is to help us protect your privacy by ensuring that we only give data out to the person it relates to\n"
 "      (or their appropriately authorised representative)."
-msgstr "Unrhyw wybodaeth ychwanegol i’n helpu i wirio pwy ydych chi e.e. rhif cyfeirio achos CLA. Bydd hyn yn ein helpu i ddiogelu’ch preifatrwydd drwy sicrhau mai dim ond i’r person y mae’r data’n ymwneud ag ef (neu gynrychiolydd sydd wedi’i awdurdodi’n briodol) y byddwn ni’n rhoi’r data."
+msgstr "Unrhyw wybodaeth ychwanegol i’n helpu i wirio pwy ydych chi e.e. rhif cyfeirio achos <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>. Bydd hyn yn ein helpu i ddiogelu’ch preifatrwydd drwy sicrhau mai dim ond i’r person y mae’r data’n ymwneud ag ef (neu gynrychiolydd sydd wedi’i awdurdodi’n briodol) y byddwn ni’n rhoi’r data."
 
 #: cla_public/templates/privacy.html:481
 msgid "You will also be required to provide proof of your identity. Acceptable forms of ID include:"
@@ -2608,7 +2608,7 @@ msgstr "Rhaid i unrhyw fil y byddwch yn ei anfon atom fod yn llai na 6 mis oed."
 msgid ""
 "Please note that we cannot give out any information unless the details that you provide match our records.\n"
 "    If you used an alias or pseudonym when you contacted <abbr>CLA</abbr>, you will need to prove your identity."
-msgstr "Sylwer na allwn roi unrhyw wybodaeth oni bai fod y manylion rydych chi’n eu rhoi yn cyfateb i’n cofnodion ni. Os gwnaethoch roi enw arall neu ffugenw pan wnaethoch chi gysylltu â CLA, bydd angen i chi brofi pwy ydych chi."
+msgstr "Sylwer na allwn roi unrhyw wybodaeth oni bai fod y manylion rydych chi’n eu rhoi yn cyfateb i’n cofnodion ni. Os gwnaethoch roi enw arall neu ffugenw pan wnaethoch chi gysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, bydd angen i chi brofi pwy ydych chi."
 
 #: cla_public/templates/privacy.html:499
 msgid "Once we receive the subject access request, we will deal with the request without any undue delay within one calendar month."
@@ -2620,7 +2620,7 @@ msgstr "Nid ydym yn codi tâl am ddarparu’r wybodaeth hon, ond os byddwn yn cr
 
 #: cla_public/templates/privacy.html:507
 msgid ""
-"You can also review our <a href=\"https://www.gov.uk/government/organisations/legal-aid-agency/about/personal-information-charter\" rel=\"external\">Personal Information Charter</a>\n"
+"You can also review our <a class=\"govuk-link\" href=\"https://www.gov.uk/government/organisations/legal-aid-agency/about/personal-information-charter\" rel=\"external\">Personal Information Charter</a>\n"
 "     which contains important information on your rights to access your personal information."
 msgstr "Gallwch hefyd edrych ar ein <a href=\"https://www.gov.uk/government/organisations/legal-aid-agency/about/personal-information-charter\" rel=\"external\">Siarter Gwybodaeth Bersonol</a> sy’n cynnwys gwybodaeth bwysig am eich hawl i gael mynediad at wybodaeth bersonol a gedwir amdanoch."
 
@@ -2636,7 +2636,7 @@ msgstr "Dan y ddeddfwriaeth diogelu data, nid oes gennym hawl i gadw eich gwybod
 
 #: cla_public/templates/privacy.html:518
 msgid "We will consider requests to delete some or all of your personal data but please note that, as a minimum, <abbr>CLA</abbr> will usually retain:"
-msgstr "Byddwn yn ystyried ceisiadau i ddileu eich holl ddata personol, neu rai data, ond dylech fod yn ymwybodol y bydd CLA fel arfer yn cadw’r canlynol o leiaf:"
+msgstr "Byddwn yn ystyried ceisiadau i ddileu eich holl ddata personol, neu rai data, ond dylech fod yn ymwybodol y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> fel arfer yn cadw’r canlynol o leiaf:"
 
 #: cla_public/templates/privacy.html:522
 msgid "For everyone that uses our service, a name and two other pieces of personal data, e.g. date of birth and postcode "
@@ -2646,18 +2646,18 @@ msgstr "Ar gyfer pawb sy’n defnyddio’n gwasanaeth, enw a dau ddarn arall o d
 msgid ""
 "For everyone that asks <abbr>CLA</abbr> to check whether they qualify for legal aid in order to seek advice from a\n"
 "      <abbr>CLA</abbr> Specialist, details of any financial information and case details used to prove that you qualify for legal aid"
-msgstr "Ar gyfer pawb sy’n gofyn i CLA wirio a ydynt yn gymwys i gael cymorth cyfreithiol er mwyn gofyn am gyngor gan un o Arbenigwyr CLA, manylion unrhyw wybodaeth ariannol a manylion yr achos a ddefnyddir i brofi eich bod yn gymwys i gael cymorth cyfreithiol"
+msgstr "Ar gyfer pawb sy’n gofyn i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> wirio a ydynt yn gymwys i gael cymorth cyfreithiol er mwyn gofyn am gyngor gan un o Arbenigwyr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, manylion unrhyw wybodaeth ariannol a manylion yr achos a ddefnyddir i brofi eich bod yn gymwys i gael cymorth cyfreithiol"
 
 #: cla_public/templates/privacy.html:530
 msgid ""
 "Please note that, if you qualify to receive advice from a <abbr>CLA</abbr> Specialist, they will also need to retain\n"
 "    additional personal data about you within their own Case Handling System. Such data shall be sufficient\n"
 "    to justify the provision of legal aid advice and meet professional requirements."
-msgstr "Sylwer, os byddwch yn gymwys i gael cyngor gan un o Arbenigwyr CLA, bydd angen iddynt hefyd gadw data personol ychwanegol amdanoch yn eu System Ymdrin ag Achosion. Bydd data o’r fath yn ddigon i gyfiawnhau darparu cyngor am gymorth cyfreithiol a bodloni gofynion proffesiynol."
+msgstr "Sylwer, os byddwch yn gymwys i gael cyngor gan un o Arbenigwyr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr>, bydd angen iddynt hefyd gadw data personol ychwanegol amdanoch yn eu System Ymdrin ag Achosion. Bydd data o’r fath yn ddigon i gyfiawnhau darparu cyngor am gymorth cyfreithiol a bodloni gofynion proffesiynol."
 
 #: cla_public/templates/privacy.html:535
 msgid "If the information we hold about you is inaccurate for whatever reason, you can contact CLA to have your personal information amended."
-msgstr "Os yw’r wybodaeth rydym yn ei chadw amdanoch yn anghywir am unrhyw reswm, gallwch gysylltu â CLA i ofyn i ni newid eich gwybodaeth bersonol."
+msgstr "Os yw’r wybodaeth rydym yn ei chadw amdanoch yn anghywir am unrhyw reswm, gallwch gysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> i ofyn i ni newid eich gwybodaeth bersonol."
 
 #: cla_public/templates/privacy.html:538
 msgid "When we ask you for personal data"
@@ -2749,7 +2749,7 @@ msgstr "Newidiadau yn y datganiad"
 msgid ""
 "This policy is under regular review. Any changes made to the privacy policy will be posted here and,\n"
 "    where appropriate, <abbr>CLA</abbr> staff will be notified by email."
-msgstr "Mae’r polisi hwn yn cael ei adolygu’n rheolaidd. Bydd unrhyw newidiadau yn y polisi preifatrwydd yn cael eu dangos yma ac, os yw’n briodol, bydd staff CLA yn cael eu hysbysu drwy’r e-bost"
+msgstr "Mae’r polisi hwn yn cael ei adolygu’n rheolaidd. Bydd unrhyw newidiadau yn y polisi preifatrwydd yn cael eu dangos yma ac, os yw’n briodol, bydd staff <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn cael eu hysbysu drwy’r e-bost"
 
 #: cla_public/templates/privacy.html:637
 msgid "Complaints about this statement"
@@ -2759,7 +2759,7 @@ msgstr "Cwynion am y datganiad hwn"
 msgid ""
 "If you would like to make a complaint about this statement and how it applies to you then please\n"
 "    contact <abbr title=\"Civil Legal Advice\">CLA</abbr> on <span class=\"tel\">0345 345 4 345</span>."
-msgstr "Os ydych chi’n dymuno gwneud cwyn am y datganiad hwn a’r ffordd y mae’n cael ei gymhwyso i chi, cysylltwch â CLA ar 0345 345 4 345."
+msgstr "Os ydych chi’n dymuno gwneud cwyn am y datganiad hwn a’r ffordd y mae’n cael ei gymhwyso i chi, cysylltwch â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> ar 0345 345 4 345."
 
 #: cla_public/templates/reasons-for-contacting.html:6
 msgid "Why do you want to contact Civil Legal Advice?"
@@ -3007,7 +3007,7 @@ msgstr "Eich cyfeirnod yw"
 
 #: cla_public/templates/checker/result/confirmation.html:30
 msgid "You can now call CLA on"
-msgstr "Gallwch ffonio CLA yn awr ar"
+msgstr "Gallwch ffonio <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn awr ar"
 
 #: cla_public/templates/checker/result/confirmation.html:31
 msgid ""
@@ -3054,7 +3054,7 @@ msgstr ""
 #: cla_public/templates/macros/subform.html:19
 #: cla_public/templates/macros/subform.html:46
 msgid "When a CLA operator calls, the call will come from an anonymous number."
-msgstr "Pan fydd gweithredwr CLA yn eich ffonio, bydd rhif anhysbys yn ymddangos ar yr alwad."
+msgstr "Pan fydd gweithredwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn eich ffonio, bydd rhif anhysbys yn ymddangos ar yr alwad."
 
 #: cla_public/templates/checker/result/confirmation.html:80
 msgid ""
@@ -3152,7 +3152,7 @@ msgstr ""
 
 #: cla_public/templates/checker/result/confirmation.html:146
 msgid "If CLA can’t help you, we’ll always suggest where else you might get help."
-msgstr "Os nad yw CLA yn gallu eich helpu, byddwn ni bob amser yn awgrymu rhywle arall allai’ch helpu."
+msgstr "Os nad yw <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> yn gallu eich helpu, byddwn ni bob amser yn awgrymu rhywle arall allai’ch helpu."
 
 #: cla_public/templates/checker/result/confirmation.html:149
 msgid "If we can do anything to make it easier for you to communicate with us, please tell the operator."
@@ -3240,7 +3240,7 @@ msgid ""
 "      Wales to get specialist advice."
 msgstr ""
 "Er mwyn penderfynu a allech chi fod yn gymwys i gael cymorth cyfreithiol, mae arnom angen rhagor o wybodaeth am\n"
-"eich amgylchiadau ariannol. Cysylltwch â Chyngor Cyfreithiol Sifil (CLA), llinell gymorth genedlaethol ar gyfer Cymru a Lloegr, i gael cyngor arbenigol."
+"eich amgylchiadau ariannol. Cysylltwch â Chyngor Cyfreithiol Sifil (<abbr>CLA</abbr>), llinell gymorth genedlaethol ar gyfer Cymru a Lloegr, i gael cyngor arbenigol."
 
 #: cla_public/templates/checker/result/eligible.html:17
 msgid ""
@@ -3249,7 +3249,7 @@ msgid ""
 "      Wales, to confirm that you qualify, and get specialist advice if you do."
 msgstr ""
 "Yn seiliedig ar eich atebion heddiw, efallai y byddwch yn gymwys i gael cymorth cyfreithiol. \n"
-"Cysylltwch â Chyngor Cyfreithiol Sifil (CLA), llinell gymorth ar gyfer Cymru \n"
+"Cysylltwch â Chyngor Cyfreithiol Sifil (<abbr>CLA</abbr>), llinell gymorth ar gyfer Cymru \n"
 "a Lloegr, i gael gwybod yn sicr aydych yn gymwys, a chael cyngor arbenigol os ydych yn gymwys."
 
 #: cla_public/templates/checker/result/eligible.html:22
@@ -3273,7 +3273,7 @@ msgid ""
 "    "
 msgstr ""
 "\n"
-"Gallwch ddewis cysylltu â CLA eich hun a siarad â rhywun ar unwaith (mae hwn yn rhif 0345 - %(call_charges_link)s) neu gallwch ofyn i ni eich ffonio yn ôl, sydd yn rhad ac am ddim."
+"Gallwch ddewis cysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> eich hun a siarad â rhywun ar unwaith (mae hwn yn rhif 0345 - %(call_charges_link)s) neu gallwch ofyn i ni eich ffonio yn ôl, sydd yn rhad ac am ddim."
 
 #: cla_public/templates/checker/result/face-to-face.html:14
 msgid "Results for "
@@ -3362,7 +3362,7 @@ msgstr "Annwyl %(full_name)s,"
 
 #: cla_public/templates/emails/confirmation.txt:10
 msgid "Your details have been submitted to Civil Legal Advice (CLA) and we will call you back."
-msgstr "Cyflwynwyd eich manylion i Gyngor Cyfreithiol Sifil (CLA) a byddwn yn eich ffonio’n ôl."
+msgstr "Cyflwynwyd eich manylion i Gyngor Cyfreithiol Sifil (<abbr>CLA</abbr>) a byddwn yn eich ffonio’n ôl."
 
 #: cla_public/templates/emails/confirmation.txt:12
 #, python-format
@@ -3403,7 +3403,7 @@ msgstr "Os byddwch yn methu’r alwad neu angen cyngor ar frys, gallwch ein ffon
 
 #: cla_public/templates/emails/confirmation.txt:45
 msgid "Your details have been submitted to Civil Legal Advice (CLA)."
-msgstr "Cyflwynwyd eich manylion i Gyngor Cyfreithiol Sifil (CLA)."
+msgstr "Cyflwynwyd eich manylion i Gyngor Cyfreithiol Sifil (<abbr>CLA</abbr>)."
 
 #: cla_public/templates/emails/confirmation.txt:47
 #, python-format
@@ -3412,7 +3412,7 @@ msgstr "Eich cyfeirnod yw %(case_ref)s."
 
 #: cla_public/templates/emails/confirmation.txt:51
 msgid "You can now call CLA on 0345 345 4 345. Please quote your reference number when you call."
-msgstr "Gallwch ffonio CLA nawr ar 0345 345 4 345. Dyfynnwch eich cyfeirnod pan fyddwch yn ffonio."
+msgstr "Gallwch ffonio <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA<abbr> nawr ar 0345 345 4 345. Dyfynnwch eich cyfeirnod pan fyddwch yn ffonio."
 
 #: cla_public/templates/emails/confirmation.txt:55
 msgid "Take a short survey. Help improve the service."
@@ -3759,7 +3759,7 @@ msgstr "dewisol"
 #~ msgid "When making outgoing calls to you <abbr>CLA</abbr> will ensure that:"
 #~ msgstr "Bydd maint y wybodaeth y mae CLA yn ei chasglu’n dibynnu ar ba un a ydych chi’n gymwys i gael gwasanaeth CLA neu beidio a/neu eich anghenion penodol. Er enghraifft, byddwn ni’n gofyn i chi ddarparu rhagor o wybodaeth cyn eich trosglwyddo i un o Arbenigwyr CLA."
 
-#~ msgid "You can read more about <a href=\"%(cookie_url)s\">how cookies are used</a>."
+#~ msgid "You can read more about <a class=\"govuk-link\" href=\"%(cookie_url)s\">how cookies are used</a>."
 #~ msgstr "Ar gyfer beth y mae CLA yn defnyddio’r data?"
 
 #~ msgid "Other advice organisations"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -2082,7 +2082,7 @@ msgid "What types of personal data do we process?"
 msgstr "Pa fathau o ddata personol rydym yn eu prosesu? "
 
 #: cla_public/templates/privacy.html:110
-msgid "<abbr>CLA</abbr> will only collect the minimum amount of information that is necessary and relevant, in order to deliver the <abbr>CLA</abbr> service to you."
+msgid "<abbr title=\"Civil Legal Advice\">CLA</abbr> will only collect the minimum amount of information that is necessary and relevant, in order to deliver the <abbr>CLA</abbr> service to you."
 msgstr "Ni fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn casglu mwy o wybodaeth nag sy’n angenrheidiol ac yn berthnasol er mwyn darparu’r gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> i chi."
 
 #: cla_public/templates/privacy.html:113

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -2237,12 +2237,12 @@ msgstr "Ffôn"
 #: cla_public/templates/privacy.html:211
 msgid ""
 "When you call <abbr>CLA</abbr> we will record relevant personal data that you provide within a secure digital system.\n"
-"        <br><br>\n"
-"        We may also record your calls. But you can choose to opt out of this or choose whether or not\n"
-"        to continue with the call.\n"
-"        <br><br>\n"
-"        If you leave <abbr>CLA</abbr> a voice message we will record the minimum amount of information\n"
-"        required in order to contact you back."
+"          <br><br>\n"
+"          We may also record your calls. But you can choose to opt out of this or choose whether or not\n"
+"          to continue with the call.\n"
+"          <br><br>\n"
+"          If you leave <abbr>CLA</abbr> a voice message we will record the minimum amount of information\n"
+"          required in order to contact you back."
 msgstr "Pan fyddwch chi’n ffonio <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, byddwn ni’n cofnodi data personol perthnasol yr ydych chi’n eu rhoi mewn system ddigidol ddiogel. Gallwn recordio’ch galwadau hefyd. Ond cewch chi ddewis peidio ag ymuno â hyn neu ddewis a ydych chi am barhau â’r alwad neu beidio. Os byddwch chi’n gadael neges llais i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, byddwn ni’n cofnodi’r lleiaf o wybodaeth sydd ei hangen i gysylltu â chi wedyn."
 
 #: cla_public/templates/privacy.html:221
@@ -2252,22 +2252,22 @@ msgstr "Ar-lein"
 #: cla_public/templates/privacy.html:223
 msgid ""
 "When you contact <abbr>CLA</abbr> online, the personal data that you provide will be recorded within a secure digital system.\n"
-"        <br><br>\n"
-"        Please note that transmitting information over the internet is generally not completely secure, and\n"
-"        <abbr>CLA</abbr> can’t guarantee the security of your data. Any data you transmit is at your own risk.\n"
-"        <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it."
+"          <br><br>\n"
+"          Please note that transmitting information over the internet is generally not completely secure, and\n"
+"          <abbr>CLA</abbr> can’t guarantee the security of your data. Any data you transmit is at your own risk.\n"
+"          <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it."
 msgstr "Pan fyddwch yn cysylltu â <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> ar-lein, bydd y data personol y byddwch yn eu rhoi yn cael eu cofnodi mewn system ddigidol ddiogel. Sylwer nad yw trawsyrru gwybodaeth dros y rhyngrwyd yn gwbl ddiogel bob amser, ac ni all <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> warantu diogelwch eich data. Ni allwn fod yn gyfrifol am unrhyw ddata y byddwch yn eu trawsyrru. Mae gan <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> weithdrefnau a nodweddion diogelwch er mwyn cadw eich data’n ddiogel ar ôl i ni eu derbyn."
 
 #: cla_public/templates/privacy.html:233
 msgid ""
 "Transmitting information via email is generally not completely secure, and <abbr>CLA</abbr> can’t guarantee the\n"
-"        security of your data. Any data you transmit is at your own risk.\n"
-"        <br><br>\n"
-"        <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it.\n"
-"        <br><br>\n"
-"        When you email <abbr>CLA</abbr>, relevant personal data that you provide will be recorded within a secure digital system.\n"
-"        <br><br>\n"
-"        <abbr>CLA</abbr> may monitor and store both your incoming and outgoing emails. We may also use blocking software."
+"          security of your data. Any data you transmit is at your own risk.\n"
+"          <br><br>\n"
+"          <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it.\n"
+"          <br><br>\n"
+"          When you email <abbr>CLA</abbr>, relevant personal data that you provide will be recorded within a secure digital system.\n"
+"          <br><br>\n"
+"          <abbr>CLA</abbr> may monitor and store both your incoming and outgoing emails. We may also use blocking software."
 msgstr "Nid yw trawsyrru gwybodaeth drwy e-bost yn gwbl ddiogel bob amser, ac ni all <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> warantu diogelwch eich data. Ni allwn fod yn gyfrifol am unrhyw ddata y byddwch yn eu trawsyrru"
 
 #: cla_public/templates/privacy.html:244
@@ -2277,9 +2277,9 @@ msgstr "Post"
 #: cla_public/templates/privacy.html:246
 msgid ""
 "When <abbr>CLA</abbr> receives post we may record relevant personal data included within a secure digital system.\n"
-"        <br><br>\n"
-"        <abbr>CLA</abbr> may also retain original hard-copies of information submitted by you. This must be stored in a locked\n"
-"        filing cabinet. Digital copies of letters may be scanned and stored."
+"          <br><br>\n"
+"          <abbr>CLA</abbr> may also retain original hard-copies of information submitted by you. This must be stored in a locked\n"
+"          filing cabinet. Digital copies of letters may be scanned and stored."
 msgstr "Pan fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn derbyn llythyrau, gallwn ni gofnodi data personol perthnasol sydd ynddynt mewn system ddigidol ddiogel. Hefyd gall <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> gadw llythyrau gwreiddiol sy’n cynnwys gwybodaeth a gyflwynwyd gennych chi. Rhaid storio’r rhain mewn cwpwrdd ffeiliau sydd wedi’i gloi. Gellir sganio copïau digidol o lythyrau a’u storio."
 
 #: cla_public/templates/privacy.html:255
@@ -2293,7 +2293,7 @@ msgstr "Ailgysylltu"
 #: cla_public/templates/privacy.html:260
 msgid ""
 "<abbr>CLA</abbr> will not disclose any personal information to anyone contacting the <abbr>CLA</abbr> service until\n"
-"        they have successfully verified that their identity matches that of an existing record."
+"          they have successfully verified that their identity matches that of an existing record."
 msgstr "Ni fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn datgelu unrhyw wybodaeth bersonol i rywun sy’n cysylltu â gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> nes ei fod wedi cadarnhau bod ei hunaniaeth yn cyfateb i gofnod sy’n bodoli."
 
 #: cla_public/templates/privacy.html:265
@@ -2303,12 +2303,12 @@ msgstr "Trydydd parti"
 #: cla_public/templates/privacy.html:267
 msgid ""
 "<abbr>CLA</abbr> will accept contact made by a third-party on behalf of another person. The third party has to\n"
-"        demonstrate they have appropriate authority to act on your behalf.\n"
-"        <br><br>\n"
-"        <abbr>CLA</abbr> must record the relationship between the third-party and the individual seeking advice\n"
-"        and whether they are authorised to act on their behalf.\n"
-"        <br><br>\n"
-"        They must also agree a password to verify the identity of the third-party if they contact the service again."
+"          demonstrate they have appropriate authority to act on your behalf.\n"
+"          <br><br>\n"
+"          <abbr>CLA</abbr> must record the relationship between the third-party and the individual seeking advice\n"
+"          and whether they are authorised to act on their behalf.\n"
+"          <br><br>\n"
+"          They must also agree a password to verify the identity of the third-party if they contact the service again."
 msgstr "Bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn cydnabod trydydd parti sy’n cysylltu ar ran person arall. Mae’n rhaid i’r trydydd parti ddangos bod ganddynt yr awdurdod priodol i weithredu ar eich rhan. Rhaid i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> gofnodi’r berthynas rhwng y trydydd parti a’r unigolyn sy’n gofyn am gyngor ac a yw’r trydydd parti wedi’i awdurdodi i weithredu ar ei ran. Hefyd rhaid i <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> gytuno ar gyfrinair er mwyn gwirio hunaniaeth y trydydd parti os bydd yn cysylltu â’r gwasanaeth eto."
 
 #: cla_public/templates/privacy.html:277
@@ -2328,15 +2328,11 @@ msgid "When making outgoing calls to you, <abbr>CLA</abbr> will ensure that:"
 msgstr "Pan fydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn eich ffonio chi, bydd yn:"
 
 #: cla_public/templates/privacy.html:286
-msgid ""
-"Call backs are only made where you have agreed to this. Authorised third parties\n"
-"            acting on your behalf can give agreement."
+msgid "Call backs are only made where you have agreed to this. Authorised third parties acting on your behalf can give agreement."
 msgstr "Mai dim ond os ydych chi wedi cytuno ar hynny y byddwn ni’n ffonio’n ôl. Gall trydydd parti gytuno ar hyn os yw wedi’i awdurdodi i weithredu ar eich rhan."
 
 #: cla_public/templates/privacy.html:290
-msgid ""
-"Where a call back is made to you and there is no answer and a message taker is available,\n"
-"            no message will be left unless you have previously given specific instructions that this would be acceptable."
+msgid "Where a call back is made to you and there is no answer and a message taker is available, no message will be left unless you have previously given specific instructions that this would be acceptable."
 msgstr "Os yw’n ffonio’n ôl ac nad oes ateb, a bod recordydd negeseuon ar gael, na fydd yn gadael neges oni bai eich bod wedi rhoi cyfarwyddiadau penodol cyn hynny fod hyn yn dderbyniol."
 
 #: cla_public/templates/privacy.html:294
@@ -2461,7 +2457,7 @@ msgstr "Sefydliadau llywodraeth eraill"
 
 #: cla_public/templates/privacy.html:372
 msgid "These organisations may include the Department of Work and Pensions (DWP), HM Courts and Tribunals Service (HMCTS), HM Revenue and Customs (HMRC)."
-msgstr "Gall y sefydliadau hyn gynnwys yr Adran Gwaith a Phensiynau, Gwasanaeth Llysoedd a Thribiwnlysoedd Ei Mawrhydi (GLlTEM), Cyllid a Thollau Ei Mawrhydi (CThEM)."
+msgstr "Gall y sefydliadau hyn gynnwys yr Adran Gwaith a Phensiynau (<abbr>DWP</abbr>), Gwasanaeth Llysoedd a Thribiwnlysoedd Ei Mawrhydi (<abbr>HMCTS</abbr>), Cyllid a Thollau Ei Mawrhydi (<abbr>HMRC</abbr>)."
 
 #: cla_public/templates/privacy.html:375
 msgid "To verify information provided by you and check whether you qualify for legal aid."

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -2120,9 +2120,10 @@ msgid ""
 "    before we can transfer you through to a <abbr>CLA</abbr> Specialist."
 msgstr "Bydd faint o wybodaeth y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn ei gasglu amdanoch yn amrywio gan ddibynnu a ydych yn gymwys ar gyfer y gwasanaeth <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>, a/neu a oes gennych anghenion penodol. Er enghraifft, gofynnir i chi roi mwy o wybodaeth cyn y gallwn eich trosglwyddo at Arbenigwr <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>."
 
+#heading - do not add title attribute to abbr tag
 #: cla_public/templates/privacy.html:141
 msgid "How does <abbr>CLA</abbr> use your data and why?"
-msgstr "Sut mae <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn defnyddio eich data a pham?"
+msgstr "Sut mae <abbr>CLA</abbr> yn defnyddio eich data a pham?"
 
 #: cla_public/templates/privacy.html:142
 msgid "collects and records information about you to:"
@@ -3460,7 +3461,7 @@ msgstr ""
 #: cla_public/templates/privacy.html:625
 #: cla_public/templates/errors/5xx.html:12
 msgid "Telephone:"
-msgstr "Ffôn"
+msgstr "Ffôn:"
 
 #: cla_public/templates/errors/5xx.html:13
 msgid "0345 345 4345"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -1693,7 +1693,7 @@ msgstr ""
 "Gallwch ddarllen mwy am %(govuk_cookies_link)s."
 
 #: cla_public/templates/feedback-confirmation.html:6
-msgid "Thanks for your feedback"
+msgid "Thank you for your feedback"
 msgstr "Diolch am eich adborth"
 
 #: cla_public/templates/feedback-confirmation.html:11
@@ -1709,10 +1709,8 @@ msgid "Report a problem"
 msgstr ""
 
 #: cla_public/templates/feedback.html:12
-msgid ""
-"Please don't include any personal or financial details,\n"
-"    for example, your National Insurance or credit card numbers."
-msgstr "Peidiwch â rhoi unrhyw fanylion personol neu fanylion ariannol, er enghraifft, eich rhif Yswiriant Gwladol neu rifau cardiau credyd"
+msgid "Do not include any personal or financial details, for example, your National Insurance or credit card numbers."
+msgstr "Peidiwch â rhoi unrhyw fanylion personol neu fanylion ariannol, er enghraifft, eich rhif Yswiriant Gwladol neu rifau cardiau credyd."
 
 #: cla_public/templates/feedback.html:36
 #: cla_public/templates/reasons-for-contacting.html:29

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -2338,8 +2338,8 @@ msgstr "Os yw’n ffonio’n ôl ac nad oes ateb, a bod recordydd negeseuon ar g
 #: cla_public/templates/privacy.html:294
 msgid ""
 "Where the phone is answered and someone other than you answers the phone and says that you are\n"
-"            unavailable or asks who is calling, <abbr>CLA</abbr> will state that the call is confidential and will not say\n"
-"            that they are calling from <abbr>CLA</abbr>."
+"              unavailable or asks who is calling, <abbr>CLA</abbr> will state that the call is confidential and will not say\n"
+"              that they are calling from <abbr>CLA</abbr>."
 msgstr "Os bydd rhywun heblaw chi’n ateb y ffôn ac yn dweud nad ydych chi ar gael neu’n gofyn pwy sy’n galw, y bydd <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr> yn dweud bod yr alwad yn gyfrinachol ac na fydd yn dweud ei fod yn ffonio o <abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>."
 
 #: cla_public/templates/privacy.html:304

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -1952,9 +1952,9 @@ msgstr "Telerau ac Amodau a phreifatrwydd"
 
 #: cla_public/templates/privacy.html:9
 msgid ""
-"When using this service you agree to the terms of use for both <a href=\"http://gov.uk/help/terms-conditions\">gov.uk/help/terms-conditions</a> as well as\n"
+"When using this service you agree to the terms of use for both <a class=\"govuk-link\" href=\"http://gov.uk/help/terms-conditions\">gov.uk/help/terms-conditions</a> as well as\n"
 "    the terms and conditions specific to this service found below."
-msgstr "Pan fyddwch yn defnyddio’r gwasanaeth hwn, byddwch yn cytuno i delerau defnydd <a href=\"http://gov.uk/help/terms-conditions\">gov.uk</a> yn ogystal â thelerau ac amodau penodol ar gyfer y gwasanaeth hwn fel y nodir isod."
+msgstr "Pan fyddwch yn defnyddio’r gwasanaeth hwn, byddwch yn cytuno i delerau defnydd <a class=\"govuk-link\" href=\"http://gov.uk/help/terms-conditions\">gov.uk</a> yn ogystal â thelerau ac amodau penodol ar gyfer y gwasanaeth hwn fel y nodir isod."
 
 #: cla_public/templates/privacy.html:13
 msgid "If you do not agree to these terms and privacy policy, do not use this service."
@@ -1966,9 +1966,9 @@ msgstr "Pwy sy’n rheoli’r gwasanaeth digidol hwn a Chyngor Cyfreithiol Sifil
 
 #: cla_public/templates/privacy.html:17
 msgid ""
-"The Legal Aid Agency (<abbr title=\"The Legal Aid Agency\">LAA</abbr>) is responsible for the Civil Legal Advice (<abbr title=\"Civil Legal Advice\">CLA</abbr>) service. The <abbr title=\"The Legal Aid Agency\">LAA</abbr> works with other\n"
+"The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for the Civil Legal Advice (<abbr>CLA</abbr>) service. The <abbr title=\"Legal Aid Agency\">LAA</abbr> works with other\n"
 "    organisations who deliver the <abbr title=\"Civil Legal Advice\">CLA</abbr> service. For example this digital service is managed by the Ministry of\n"
-"    Justice."
+"    Justice (<abbr>MoJ</abbr>)."
 msgstr "Yr Asiantaeth Cymorth Cyfreithiol (LAA) sy’n gyfrifol am y gwasanaeth Cyngor Cyfreithiol Sifil (CLA). Mae’r Asiantaeth Cymorth Cyfreithiol yn gweithio gyda sefydliadau eraill sy’n darparu’r gwasanaeth CLA. Er enghraifft, mae’r gwasanaeth digidol hwn yn cael ei reoli gan y Weinyddiaeth Gyfiawnder."
 
 #: cla_public/templates/privacy.html:23
@@ -1979,7 +1979,7 @@ msgstr "Y tro cyntaf y byddwch yn dod i gysylltiad â CLA byddwch yn cyfathrebu 
 
 #: cla_public/templates/privacy.html:28
 msgid ""
-"Hinduja Global Solutions UK Limited is a contractor employed by the <abbr title=\"The Legal Aid Agency\">LAA</abbr>\n"
+"Hinduja Global Solutions UK Limited is a contractor employed by the <abbr title=\"Legal Aid Agency\">LAA</abbr>\n"
 "    to deliver the <abbr title=\"Civil Legal Advice\">CLA</abbr> Operator Service."
 msgstr "Contractwr sy’n cael ei gyflogi gan yr Asiantaeth Cymorth Cyfreithiol i ddarparu Gwasanaeth Gweithredwr y CLA yw Hinduja Global Solutions UK Limited."
 
@@ -2051,17 +2051,17 @@ msgstr "Mae’r datganiad hwn yn egluro sut y bydd CLA yn prosesu unrhyw ddata p
 
 #: cla_public/templates/privacy.html:84
 msgid ""
-"The Legal Aid Agency (<abbr title=\"The Legal Aid Agency\">LAA</abbr>) is responsible for the <abbr>CLA</abbr>\n"
-"    service and the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"The Legal Aid Agency\">LAA</abbr>) is an\n"
+"The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is responsible for the <abbr>CLA</abbr>\n"
+"    service and the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is an\n"
 "     Executive Agency of the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>)."
 msgstr "Yr Asiantaeth Cymorth Cyfreithiol (LAA) sy’n gyfrifol am y gwasanaeth CLA, a’r Weinyddiaeth Gyfiawnder yw Rheolwr y Data. Mae’r Asiantaeth Cymorth Cyfreithiol  yn Asiantaeth Weithredol i’r Weinyddiaeth Gyfiawnder."
 
 #: cla_public/templates/privacy.html:90
 msgid ""
-"The <abbr title=\"The Legal Aid Agency\">LAA</abbr> works with other organisations who deliver the <abbr>CLA</abbr> service.\n"
+"The <abbr title=\"Legal Aid Agency\">LAA</abbr> works with other organisations who deliver the <abbr>CLA</abbr> service.\n"
 "    For example, when you first make contact with <abbr>CLA</abbr>, you will communicate with\n"
 "    the <abbr>CLA</abbr> Operator Service, which is delivered by Hinduja Global Solutions UK Limited\n"
-"    (a contractor employed by the <abbr title=\"The Legal Aid Agency\">LAA</abbr>)."
+"    (a contractor employed by the <abbr title=\"Legal Aid Agency\">LAA</abbr>)."
 msgstr "Mae’r Asiantaeth Cymorth Cyfreithiol yn gweithio gyda sefydliadau eraill sy’n darparu’r gwasanaeth CLA. Er enghraifft, y tro cyntaf y byddwch yn dod i gysylltiad â CLA, byddwch yn cyfathrebu â Gwasanaeth Gweithredwr y CLA, sy’n cael ei ddarparu gan Hinduja Global Solutions UK Limited (contractwr sy’n cael ei gyflogi gan yr Asiantaeth Cymorth Cyfreithiol)."
 
 #: cla_public/templates/privacy.html:97
@@ -2442,7 +2442,7 @@ msgstr "Pam"
 
 #: cla_public/templates/privacy.html:360
 msgid ""
-"External research organisations engaged by <abbr title=\"The Legal Aid Agency\">LAA</abbr>\n"
+"External research organisations engaged by <abbr title=\"Legal Aid Agency\">LAA</abbr>\n"
 "          or <abbr title=\"The Ministry of Justice\">MoJ</abbr>"
 msgstr "Sefydliadau ymchwil allanol sy’n gweithio i’r LAA neu’r Weinyddiaeth Cyfiawnder"
 
@@ -2477,7 +2477,7 @@ msgid "To help you get further help and advice from appropriate organisations."
 msgstr "I’ch helpu i gael help a chyngor pellach gan sefydliadau priodol."
 
 #: cla_public/templates/privacy.html:387
-msgid "To verify information provided by you, when conducting audits on our decisions and eligibility assessments.\n"
+msgid "To verify information provided by you, when conducting audits on our decisions and eligibility assessments."
 msgstr "I wirio gwybodaeth a roddir gennych, wrth gynnal archwiliadau yn ymwneud â’n penderfyniadau ac asesiadau cymhwystra."
 
 #: cla_public/templates/privacy.html:395
@@ -2728,8 +2728,8 @@ msgid "How to make a complaint."
 msgstr "Sut i wneud cwyn."
 
 #: cla_public/templates/privacy.html:594
-msgid "For more information about the above issues, please contact the MoJ Data Protection Officer;"
-msgstr "I gael rhagor o wybodaeth am y materion uchod, cysylltwch â Swyddog Diogelu Data’r Weinyddiaeth Gyfiawnder;"
+msgid "For more information about the above issues, please contact the <abbr>MoJ</abbr> Data Protection Officer:"
+msgstr "I gael rhagor o wybodaeth am y materion uchod, cysylltwch â Swyddog Diogelu Data’r Weinyddiaeth Gyfiawnder:"
 
 #: cla_public/templates/privacy.html:609
 msgid "For more information on how and why your information is processed, please see the information provided when you accessed our services or were contacted by us."
@@ -2740,10 +2740,6 @@ msgid ""
 "When we ask you for information, we will comply with the law. If you consider that your information has been handled incorrectly, \n"
 "      you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:"
 msgstr "Pan fyddwn yn gofyn i chi am wybodaeth, byddwn yn cydymffurfio â’r gyfraith. Os ydych yn credu nad yw eich gwybodaeth wedi cael ei thrin yn iawn, gallwch gysylltu â’r Comisiynydd Gwybodaeth i gael cyngor annibynnol am ddiogelu data. Gallwch gysylltu â’r Comisiynydd Gwybodaeth yn y cyfeiriad isod:"
-
-#: cla_public/templates/privacy.html:625
-msgid "Tel:"
-msgstr "Ffôn:"
 
 #: cla_public/templates/privacy.html:631
 msgid "Changes to the statement"
@@ -3459,6 +3455,7 @@ msgstr ""
 msgid "We have not saved any information you have entered. When the service is available, you will have to start again."
 msgstr ""
 
+#: cla_public/templates/privacy.html:625
 #: cla_public/templates/errors/5xx.html:12
 msgid "Telephone:"
 msgstr "Ffôn"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -2051,10 +2051,10 @@ msgstr "Mae’r datganiad hwn yn egluro sut y bydd CLA yn prosesu unrhyw ddata p
 
 #: cla_public/templates/privacy.html:84
 msgid ""
-"The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is responsible for the <abbr>CLA</abbr>\n"
-"    service and the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is an\n"
-"     Executive Agency of the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>)."
-msgstr "Yr Asiantaeth Cymorth Cyfreithiol (LAA) sy’n gyfrifol am y gwasanaeth CLA, a’r Weinyddiaeth Gyfiawnder yw Rheolwr y Data. Mae’r Asiantaeth Cymorth Cyfreithiol  yn Asiantaeth Weithredol i’r Weinyddiaeth Gyfiawnder."
+"The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for <abbr title=\"Civil Legal Advice\">CLA</abbr>\n"
+"    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is an\n"
+"    Executive Agency of the (<abbr title=\"Ministry of Justice\">MoJ</abbr>)."
+msgstr "Yr Asiantaeth Cymorth Cyfreithiol (<abbr>LAA</abbr>) sy’n gyfrifol am y gwasanaeth <abbr>CLA</abbr>, a’r Weinyddiaeth Gyfiawnder yw Rheolwr y Data. Mae’r Asiantaeth Cymorth Cyfreithiol  yn Asiantaeth Weithredol i’r Weinyddiaeth Gyfiawnder."
 
 #: cla_public/templates/privacy.html:90
 msgid ""

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -2443,8 +2443,8 @@ msgstr "Pam"
 #: cla_public/templates/privacy.html:360
 msgid ""
 "External research organisations engaged by <abbr title=\"Legal Aid Agency\">LAA</abbr>\n"
-"          or <abbr title=\"The Ministry of Justice\">MoJ</abbr>"
-msgstr "Sefydliadau ymchwil allanol sy’n gweithio i’r LAA neu’r Weinyddiaeth Cyfiawnder"
+"          or the <abbr title=\"Ministry of Justice\">MoJ</abbr>"
+msgstr "Sefydliadau ymchwil allanol sy’n gweithio i’r <abbr title=\"Asiantaeth Cymorth Cyfreithiol\">LAA</abbr> neu’r Weinyddiaeth Cyfiawnder"
 
 #: cla_public/templates/privacy.html:364
 msgid ""

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -2060,7 +2060,7 @@ msgid "What types of personal data do we process?"
 msgstr ""
 
 #: cla_public/templates/privacy.html:110
-msgid "<abbr>CLA</abbr> will only collect the minimum amount of information that is necessary and relevant, in order to deliver the <abbr>CLA</abbr> service to you."
+msgid "<abbr title=\"Civil Legal Advice\">CLA</abbr> will only collect the minimum amount of information that is necessary and relevant, in order to deliver the <abbr>CLA</abbr> service to you."
 msgstr ""
 
 #: cla_public/templates/privacy.html:113

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -2314,8 +2314,8 @@ msgstr ""
 #: cla_public/templates/privacy.html:294
 msgid ""
 "Where the phone is answered and someone other than you answers the phone and says that you are\n"
-"            unavailable or asks who is calling, <abbr>CLA</abbr> will state that the call is confidential and will not say\n"
-"            that they are calling from <abbr>CLA</abbr>."
+"              unavailable or asks who is calling, <abbr>CLA</abbr> will state that the call is confidential and will not say\n"
+"              that they are calling from <abbr>CLA</abbr>."
 msgstr ""
 
 #: cla_public/templates/privacy.html:304

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -2031,7 +2031,7 @@ msgstr ""
 msgid ""
 "The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for <abbr title=\"Civil Legal Advice\">CLA</abbr>\n"
 "    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr>LAA</abbr>) is an\n"
-"    Executive Agency of the (<abbr title=\"Ministry of Justice\">MoJ</abbr>)."
+"    Executive Agency of the <abbr title=\"Ministry of Justice\">MoJ</abbr>."
 msgstr ""
 
 #: cla_public/templates/privacy.html:90

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -1930,7 +1930,7 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:9
 msgid ""
-"When using this service you agree to the terms of use for both <a href=\"http://gov.uk/help/terms-conditions\">gov.uk/help/terms-conditions</a> as well as\n"
+"When using this service you agree to the terms of use for both <a class=\"govuk-link\" href=\"http://gov.uk/help/terms-conditions\">gov.uk/help/terms-conditions</a> as well as\n"
 "    the terms and conditions specific to this service found below."
 msgstr ""
 
@@ -1944,9 +1944,9 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:17
 msgid ""
-"The Legal Aid Agency (<abbr title=\"The Legal Aid Agency\">LAA</abbr>) is responsible for the Civil Legal Advice (<abbr title=\"Civil Legal Advice\">CLA</abbr>) service. The <abbr title=\"The Legal Aid Agency\">LAA</abbr> works with other\n"
+"The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for the Civil Legal Advice (<abbr>CLA</abbr>) service. The <abbr title=\"Legal Aid Agency\">LAA</abbr> works with other\n"
 "    organisations who deliver the <abbr title=\"Civil Legal Advice\">CLA</abbr> service. For example this digital service is managed by the Ministry of\n"
-"    Justice."
+"    Justice (<abbr>MoJ</abbr>)."
 msgstr ""
 
 #: cla_public/templates/privacy.html:23
@@ -1957,7 +1957,7 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:28
 msgid ""
-"Hinduja Global Solutions UK Limited is a contractor employed by the <abbr title=\"The Legal Aid Agency\">LAA</abbr>\n"
+"Hinduja Global Solutions UK Limited is a contractor employed by the <abbr title=\"Legal Aid Agency\">LAA</abbr>\n"
 "    to deliver the <abbr title=\"Civil Legal Advice\">CLA</abbr> Operator Service."
 msgstr ""
 
@@ -2029,17 +2029,17 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:84
 msgid ""
-"The Legal Aid Agency (<abbr title=\"The Legal Aid Agency\">LAA</abbr>) is responsible for the <abbr>CLA</abbr>\n"
-"    service and the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"The Legal Aid Agency\">LAA</abbr>) is an\n"
+"The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is responsible for the <abbr>CLA</abbr>\n"
+"    service and the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is an\n"
 "     Executive Agency of the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>)."
 msgstr ""
 
 #: cla_public/templates/privacy.html:90
 msgid ""
-"The <abbr title=\"The Legal Aid Agency\">LAA</abbr> works with other organisations who deliver the <abbr>CLA</abbr> service.\n"
+"The <abbr title=\"Legal Aid Agency\">LAA</abbr> works with other organisations who deliver the <abbr>CLA</abbr> service.\n"
 "    For example, when you first make contact with <abbr>CLA</abbr>, you will communicate with\n"
 "    the <abbr>CLA</abbr> Operator Service, which is delivered by Hinduja Global Solutions UK Limited\n"
-"    (a contractor employed by the <abbr title=\"The Legal Aid Agency\">LAA</abbr>)."
+"    (a contractor employed by the <abbr title=\"Legal Aid Agency\">LAA</abbr>)."
 msgstr ""
 
 #: cla_public/templates/privacy.html:97
@@ -2420,7 +2420,7 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:360
 msgid ""
-"External research organisations engaged by <abbr title=\"The Legal Aid Agency\">LAA</abbr>\n"
+"External research organisations engaged by <abbr title=\"Legal Aid Agency\">LAA</abbr>\n"
 "          or <abbr title=\"The Ministry of Justice\">MoJ</abbr>"
 msgstr ""
 
@@ -2455,7 +2455,7 @@ msgid "To help you get further help and advice from appropriate organisations."
 msgstr ""
 
 #: cla_public/templates/privacy.html:387
-msgid "To verify information provided by you, when conducting audits on our decisions and eligibility assessments.\n"
+msgid "To verify information provided by you, when conducting audits on our decisions and eligibility assessments."
 msgstr ""
 
 #: cla_public/templates/privacy.html:395
@@ -2706,7 +2706,7 @@ msgid "How to make a complaint."
 msgstr ""
 
 #: cla_public/templates/privacy.html:594
-msgid "For more information about the above issues, please contact the MoJ Data Protection Officer;"
+msgid "For more information about the above issues, please contact the <abbr>MoJ</abbr> Data Protection Officer:"
 msgstr ""
 
 #: cla_public/templates/privacy.html:609
@@ -2717,10 +2717,6 @@ msgstr ""
 msgid ""
 "When we ask you for information, we will comply with the law. If you consider that your information has been handled incorrectly, \n"
 "      you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:"
-msgstr ""
-
-#: cla_public/templates/privacy.html:625
-msgid "Tel:"
 msgstr ""
 
 #: cla_public/templates/privacy.html:631
@@ -3371,6 +3367,7 @@ msgstr ""
 msgid "We have not saved any information you have entered. When the service is available, you will have to start again."
 msgstr ""
 
+#: cla_public/templates/privacy.html:625
 #: cla_public/templates/errors/5xx.html:12
 msgid "Telephone:"
 msgstr ""

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -1987,14 +1987,14 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:49
 msgid ""
-"At this point, you will need to tell us your name and phone number and all the information you've entered will\n"
+"At this point, you will need to tell us your name and phone number and all the information you’ve entered will\n"
 "    be stored when you click 'Submit your application'. We store this information so that the operator can see it\n"
 "    when they speak to you."
 msgstr ""
 
 #: cla_public/templates/privacy.html:55
 msgid ""
-"If you don't want to speak to an operator, you don't need to enter any personal details and we don't store\n"
+"If you don’t want to speak to an operator, you don’t need to enter any personal details and we don’t store\n"
 "    any of the information you have entered."
 msgstr ""
 
@@ -2030,7 +2030,7 @@ msgstr ""
 #: cla_public/templates/privacy.html:84
 msgid ""
 "The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for <abbr title=\"Civil Legal Advice\">CLA</abbr>\n"
-"    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is an\n"
+"    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr>LAA</abbr>) is an\n"
 "    Executive Agency of the (<abbr title=\"Ministry of Justice\">MoJ</abbr>)."
 msgstr ""
 
@@ -2515,7 +2515,7 @@ msgid ""
 msgstr ""
 
 #: cla_public/templates/privacy.html:462
-msgid "You can also email at <a class=\"email\" href=\"mailto:data.access@justice.gov.uk\">data.access@justice.gov.uk</a>."
+msgid "You can also email at <a class=\"govuk-link email\" href=\"mailto:data.access@justice.gov.uk\">data.access@justice.gov.uk</a>."
 msgstr ""
 
 #: cla_public/templates/privacy.html:465
@@ -2598,7 +2598,7 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:507
 msgid ""
-"You can also review our <a href=\"https://www.gov.uk/government/organisations/legal-aid-agency/about/personal-information-charter\" rel=\"external\">Personal Information Charter</a>\n"
+"You can also review our <a class=\"govuk-link\" href=\"https://www.gov.uk/government/organisations/legal-aid-agency/about/personal-information-charter\" rel=\"external\">Personal Information Charter</a>\n"
 "     which contains important information on your rights to access your personal information."
 msgstr ""
 

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -1691,9 +1691,7 @@ msgid "Report a problem"
 msgstr ""
 
 #: cla_public/templates/feedback.html:12
-msgid ""
-"Please don't include any personal or financial details,\n"
-"    for example, your National Insurance or credit card numbers."
+msgid "Please don't include any personal or financial details for example, your National Insurance or credit card numbers."
 msgstr ""
 
 #: cla_public/templates/feedback.html:36

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -2213,12 +2213,12 @@ msgstr ""
 #: cla_public/templates/privacy.html:211
 msgid ""
 "When you call <abbr>CLA</abbr> we will record relevant personal data that you provide within a secure digital system.\n"
-"        <br><br>\n"
-"        We may also record your calls. But you can choose to opt out of this or choose whether or not\n"
-"        to continue with the call.\n"
-"        <br><br>\n"
-"        If you leave <abbr>CLA</abbr> a voice message we will record the minimum amount of information\n"
-"        required in order to contact you back."
+"          <br><br>\n"
+"          We may also record your calls. But you can choose to opt out of this or choose whether or not\n"
+"          to continue with the call.\n"
+"          <br><br>\n"
+"          If you leave <abbr>CLA</abbr> a voice message we will record the minimum amount of information\n"
+"          required in order to contact you back."
 msgstr ""
 
 #: cla_public/templates/privacy.html:221
@@ -2228,22 +2228,22 @@ msgstr ""
 #: cla_public/templates/privacy.html:223
 msgid ""
 "When you contact <abbr>CLA</abbr> online, the personal data that you provide will be recorded within a secure digital system.\n"
-"        <br><br>\n"
-"        Please note that transmitting information over the internet is generally not completely secure, and\n"
-"        <abbr>CLA</abbr> can’t guarantee the security of your data. Any data you transmit is at your own risk.\n"
-"        <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it."
+"          <br><br>\n"
+"          Please note that transmitting information over the internet is generally not completely secure, and\n"
+"          <abbr>CLA</abbr> can’t guarantee the security of your data. Any data you transmit is at your own risk.\n"
+"          <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it."
 msgstr ""
 
 #: cla_public/templates/privacy.html:233
 msgid ""
 "Transmitting information via email is generally not completely secure, and <abbr>CLA</abbr> can’t guarantee the\n"
-"        security of your data. Any data you transmit is at your own risk.\n"
-"        <br><br>\n"
-"        <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it.\n"
-"        <br><br>\n"
-"        When you email <abbr>CLA</abbr>, relevant personal data that you provide will be recorded within a secure digital system.\n"
-"        <br><br>\n"
-"        <abbr>CLA</abbr> may monitor and store both your incoming and outgoing emails. We may also use blocking software."
+"          security of your data. Any data you transmit is at your own risk.\n"
+"          <br><br>\n"
+"          <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it.\n"
+"          <br><br>\n"
+"          When you email <abbr>CLA</abbr>, relevant personal data that you provide will be recorded within a secure digital system.\n"
+"          <br><br>\n"
+"          <abbr>CLA</abbr> may monitor and store both your incoming and outgoing emails. We may also use blocking software."
 msgstr ""
 
 #: cla_public/templates/privacy.html:244
@@ -2253,9 +2253,9 @@ msgstr ""
 #: cla_public/templates/privacy.html:246
 msgid ""
 "When <abbr>CLA</abbr> receives post we may record relevant personal data included within a secure digital system.\n"
-"        <br><br>\n"
-"        <abbr>CLA</abbr> may also retain original hard-copies of information submitted by you. This must be stored in a locked\n"
-"        filing cabinet. Digital copies of letters may be scanned and stored."
+"          <br><br>\n"
+"          <abbr>CLA</abbr> may also retain original hard-copies of information submitted by you. This must be stored in a locked\n"
+"          filing cabinet. Digital copies of letters may be scanned and stored."
 msgstr ""
 
 #: cla_public/templates/privacy.html:255
@@ -2279,12 +2279,12 @@ msgstr ""
 #: cla_public/templates/privacy.html:267
 msgid ""
 "<abbr>CLA</abbr> will accept contact made by a third-party on behalf of another person. The third party has to\n"
-"        demonstrate they have appropriate authority to act on your behalf.\n"
-"        <br><br>\n"
-"        <abbr>CLA</abbr> must record the relationship between the third-party and the individual seeking advice\n"
-"        and whether they are authorised to act on their behalf.\n"
-"        <br><br>\n"
-"        They must also agree a password to verify the identity of the third-party if they contact the service again."
+"          demonstrate they have appropriate authority to act on your behalf.\n"
+"          <br><br>\n"
+"          <abbr>CLA</abbr> must record the relationship between the third-party and the individual seeking advice\n"
+"          and whether they are authorised to act on their behalf.\n"
+"          <br><br>\n"
+"          They must also agree a password to verify the identity of the third-party if they contact the service again."
 msgstr ""
 
 #: cla_public/templates/privacy.html:277
@@ -2304,15 +2304,11 @@ msgid "When making outgoing calls to you, <abbr>CLA</abbr> will ensure that:"
 msgstr ""
 
 #: cla_public/templates/privacy.html:286
-msgid ""
-"Call backs are only made where you have agreed to this. Authorised third parties\n"
-"            acting on your behalf can give agreement."
+msgid "Call backs are only made where you have agreed to this. Authorised third parties acting on your behalf can give agreement."
 msgstr ""
 
 #: cla_public/templates/privacy.html:290
-msgid ""
-"Where a call back is made to you and there is no answer and a message taker is available,\n"
-"            no message will be left unless you have previously given specific instructions that this would be acceptable."
+msgid "Where a call back is made to you and there is no answer and a message taker is available, no message will be left unless you have previously given specific instructions that this would be acceptable."
 msgstr ""
 
 #: cla_public/templates/privacy.html:294

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -2029,9 +2029,9 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:84
 msgid ""
-"The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is responsible for the <abbr>CLA</abbr>\n"
-"    service and the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is an\n"
-"     Executive Agency of the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>)."
+"The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for <abbr title=\"Civil Legal Advice\">CLA</abbr>\n"
+"    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is an\n"
+"    Executive Agency of the (<abbr title=\"Ministry of Justice\">MoJ</abbr>)."
 msgstr ""
 
 #: cla_public/templates/privacy.html:90

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -2421,7 +2421,7 @@ msgstr ""
 #: cla_public/templates/privacy.html:360
 msgid ""
 "External research organisations engaged by <abbr title=\"Legal Aid Agency\">LAA</abbr>\n"
-"          or <abbr title=\"The Ministry of Justice\">MoJ</abbr>"
+"          or the <abbr title=\"Ministry of Justice\">MoJ</abbr>"
 msgstr ""
 
 #: cla_public/templates/privacy.html:364

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -2423,7 +2423,7 @@ msgstr ""
 #: cla_public/templates/privacy.html:360
 msgid ""
 "External research organisations engaged by <abbr title=\"Legal Aid Agency\">LAA</abbr>\n"
-"          or <abbr title=\"The Ministry of Justice\">MoJ</abbr>"
+"          or the <abbr title=\"Ministry of Justice\">MoJ</abbr>"
 msgstr ""
 
 #: cla_public/templates/privacy.html:364

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -1675,7 +1675,7 @@ msgid ""
 msgstr ""
 
 #: cla_public/templates/feedback-confirmation.html:6
-msgid "Thanks for your feedback"
+msgid "Thank you for your feedback"
 msgstr ""
 
 #: cla_public/templates/feedback-confirmation.html:11

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -2316,8 +2316,8 @@ msgstr ""
 #: cla_public/templates/privacy.html:294
 msgid ""
 "Where the phone is answered and someone other than you answers the phone and says that you are\n"
-"            unavailable or asks who is calling, <abbr>CLA</abbr> will state that the call is confidential and will not say\n"
-"            that they are calling from <abbr>CLA</abbr>."
+"              unavailable or asks who is calling, <abbr>CLA</abbr> will state that the call is confidential and will not say\n"
+"              that they are calling from <abbr>CLA</abbr>."
 msgstr ""
 
 #: cla_public/templates/privacy.html:304

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -2215,12 +2215,12 @@ msgstr ""
 #: cla_public/templates/privacy.html:211
 msgid ""
 "When you call <abbr>CLA</abbr> we will record relevant personal data that you provide within a secure digital system.\n"
-"        <br><br>\n"
-"        We may also record your calls. But you can choose to opt out of this or choose whether or not\n"
-"        to continue with the call.\n"
-"        <br><br>\n"
-"        If you leave <abbr>CLA</abbr> a voice message we will record the minimum amount of information\n"
-"        required in order to contact you back."
+"          <br><br>\n"
+"          We may also record your calls. But you can choose to opt out of this or choose whether or not\n"
+"          to continue with the call.\n"
+"          <br><br>\n"
+"          If you leave <abbr>CLA</abbr> a voice message we will record the minimum amount of information\n"
+"          required in order to contact you back."
 msgstr ""
 
 #: cla_public/templates/privacy.html:221
@@ -2230,22 +2230,22 @@ msgstr ""
 #: cla_public/templates/privacy.html:223
 msgid ""
 "When you contact <abbr>CLA</abbr> online, the personal data that you provide will be recorded within a secure digital system.\n"
-"        <br><br>\n"
-"        Please note that transmitting information over the internet is generally not completely secure, and\n"
-"        <abbr>CLA</abbr> can’t guarantee the security of your data. Any data you transmit is at your own risk.\n"
-"        <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it."
+"          <br><br>\n"
+"          Please note that transmitting information over the internet is generally not completely secure, and\n"
+"          <abbr>CLA</abbr> can’t guarantee the security of your data. Any data you transmit is at your own risk.\n"
+"          <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it."
 msgstr ""
 
 #: cla_public/templates/privacy.html:233
 msgid ""
 "Transmitting information via email is generally not completely secure, and <abbr>CLA</abbr> can’t guarantee the\n"
-"        security of your data. Any data you transmit is at your own risk.\n"
-"        <br><br>\n"
-"        <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it.\n"
-"        <br><br>\n"
-"        When you email <abbr>CLA</abbr>, relevant personal data that you provide will be recorded within a secure digital system.\n"
-"        <br><br>\n"
-"        <abbr>CLA</abbr> may monitor and store both your incoming and outgoing emails. We may also use blocking software."
+"          security of your data. Any data you transmit is at your own risk.\n"
+"          <br><br>\n"
+"          <abbr>CLA</abbr> have procedures and security features in place to keep your data secure once we receive it.\n"
+"          <br><br>\n"
+"          When you email <abbr>CLA</abbr>, relevant personal data that you provide will be recorded within a secure digital system.\n"
+"          <br><br>\n"
+"          <abbr>CLA</abbr> may monitor and store both your incoming and outgoing emails. We may also use blocking software."
 msgstr ""
 
 #: cla_public/templates/privacy.html:244
@@ -2255,9 +2255,9 @@ msgstr ""
 #: cla_public/templates/privacy.html:246
 msgid ""
 "When <abbr>CLA</abbr> receives post we may record relevant personal data included within a secure digital system.\n"
-"        <br><br>\n"
-"        <abbr>CLA</abbr> may also retain original hard-copies of information submitted by you. This must be stored in a locked\n"
-"        filing cabinet. Digital copies of letters may be scanned and stored."
+"          <br><br>\n"
+"          <abbr>CLA</abbr> may also retain original hard-copies of information submitted by you. This must be stored in a locked\n"
+"          filing cabinet. Digital copies of letters may be scanned and stored."
 msgstr ""
 
 #: cla_public/templates/privacy.html:255
@@ -2281,12 +2281,12 @@ msgstr ""
 #: cla_public/templates/privacy.html:267
 msgid ""
 "<abbr>CLA</abbr> will accept contact made by a third-party on behalf of another person. The third party has to\n"
-"        demonstrate they have appropriate authority to act on your behalf.\n"
-"        <br><br>\n"
-"        <abbr>CLA</abbr> must record the relationship between the third-party and the individual seeking advice\n"
-"        and whether they are authorised to act on their behalf.\n"
-"        <br><br>\n"
-"        They must also agree a password to verify the identity of the third-party if they contact the service again."
+"          demonstrate they have appropriate authority to act on your behalf.\n"
+"          <br><br>\n"
+"          <abbr>CLA</abbr> must record the relationship between the third-party and the individual seeking advice\n"
+"          and whether they are authorised to act on their behalf.\n"
+"          <br><br>\n"
+"          They must also agree a password to verify the identity of the third-party if they contact the service again."
 msgstr ""
 
 #: cla_public/templates/privacy.html:277
@@ -2306,15 +2306,11 @@ msgid "When making outgoing calls to you, <abbr>CLA</abbr> will ensure that:"
 msgstr ""
 
 #: cla_public/templates/privacy.html:286
-msgid ""
-"Call backs are only made where you have agreed to this. Authorised third parties\n"
-"            acting on your behalf can give agreement."
+msgid "Call backs are only made where you have agreed to this. Authorised third parties acting on your behalf can give agreement."
 msgstr ""
 
 #: cla_public/templates/privacy.html:290
-msgid ""
-"Where a call back is made to you and there is no answer and a message taker is available,\n"
-"            no message will be left unless you have previously given specific instructions that this would be acceptable."
+msgid "Where a call back is made to you and there is no answer and a message taker is available, no message will be left unless you have previously given specific instructions that this would be acceptable."
 msgstr ""
 
 #: cla_public/templates/privacy.html:294

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -2031,9 +2031,9 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:84
 msgid ""
-"The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is responsible for the <abbr>CLA</abbr>\n"
-"    service and the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is an\n"
-"     Executive Agency of the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>)."
+"The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for <abbr title=\"Civil Legal Advice\">CLA</abbr>\n"
+"    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is an\n"
+"    Executive Agency of the (<abbr title=\"Ministry of Justice\">MoJ</abbr>)."
 msgstr ""
 
 #: cla_public/templates/privacy.html:90

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -2062,7 +2062,7 @@ msgid "What types of personal data do we process?"
 msgstr ""
 
 #: cla_public/templates/privacy.html:110
-msgid "<abbr>CLA</abbr> will only collect the minimum amount of information that is necessary and relevant, in order to deliver the <abbr>CLA</abbr> service to you."
+msgid "<abbr title=\"Civil Legal Advice\">CLA</abbr> will only collect the minimum amount of information that is necessary and relevant, in order to deliver the <abbr>CLA</abbr> service to you."
 msgstr ""
 
 #: cla_public/templates/privacy.html:113

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -1989,14 +1989,14 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:49
 msgid ""
-"At this point, you will need to tell us your name and phone number and all the information you've entered will\n"
+"At this point, you will need to tell us your name and phone number and all the information you’ve entered will\n"
 "    be stored when you click 'Submit your application'. We store this information so that the operator can see it\n"
 "    when they speak to you."
 msgstr ""
 
 #: cla_public/templates/privacy.html:55
 msgid ""
-"If you don't want to speak to an operator, you don't need to enter any personal details and we don't store\n"
+"If you don’t want to speak to an operator, you don’t need to enter any personal details and we don’t store\n"
 "    any of the information you have entered."
 msgstr ""
 
@@ -2032,7 +2032,7 @@ msgstr ""
 #: cla_public/templates/privacy.html:84
 msgid ""
 "The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for <abbr title=\"Civil Legal Advice\">CLA</abbr>\n"
-"    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is an\n"
+"    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr>LAA</abbr>) is an\n"
 "    Executive Agency of the (<abbr title=\"Ministry of Justice\">MoJ</abbr>)."
 msgstr ""
 
@@ -2517,7 +2517,7 @@ msgid ""
 msgstr ""
 
 #: cla_public/templates/privacy.html:462
-msgid "You can also email at <a class=\"email\" href=\"mailto:data.access@justice.gov.uk\">data.access@justice.gov.uk</a>."
+msgid "You can also email at <a class=\"govuk-link email\" href=\"mailto:data.access@justice.gov.uk\">data.access@justice.gov.uk</a>."
 msgstr ""
 
 #: cla_public/templates/privacy.html:465
@@ -2600,7 +2600,7 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:507
 msgid ""
-"You can also review our <a href=\"https://www.gov.uk/government/organisations/legal-aid-agency/about/personal-information-charter\" rel=\"external\">Personal Information Charter</a>\n"
+"You can also review our <a class=\"govuk-link\" href=\"https://www.gov.uk/government/organisations/legal-aid-agency/about/personal-information-charter\" rel=\"external\">Personal Information Charter</a>\n"
 "     which contains important information on your rights to access your personal information."
 msgstr ""
 

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -1932,7 +1932,7 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:9
 msgid ""
-"When using this service you agree to the terms of use for both <a href=\"http://gov.uk/help/terms-conditions\">gov.uk/help/terms-conditions</a> as well as\n"
+"When using this service you agree to the terms of use for both <a class=\"govuk-link\" href=\"http://gov.uk/help/terms-conditions\">gov.uk/help/terms-conditions</a> as well as\n"
 "    the terms and conditions specific to this service found below."
 msgstr ""
 
@@ -1946,9 +1946,9 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:17
 msgid ""
-"The Legal Aid Agency (<abbr title=\"The Legal Aid Agency\">LAA</abbr>) is responsible for the Civil Legal Advice (<abbr title=\"Civil Legal Advice\">CLA</abbr>) service. The <abbr title=\"The Legal Aid Agency\">LAA</abbr> works with other\n"
+"The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for the Civil Legal Advice (<abbr>CLA</abbr>) service. The <abbr title=\"Legal Aid Agency\">LAA</abbr> works with other\n"
 "    organisations who deliver the <abbr title=\"Civil Legal Advice\">CLA</abbr> service. For example this digital service is managed by the Ministry of\n"
-"    Justice."
+"    Justice (<abbr>MoJ</abbr>)."
 msgstr ""
 
 #: cla_public/templates/privacy.html:23
@@ -1959,7 +1959,7 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:28
 msgid ""
-"Hinduja Global Solutions UK Limited is a contractor employed by the <abbr title=\"The Legal Aid Agency\">LAA</abbr>\n"
+"Hinduja Global Solutions UK Limited is a contractor employed by the <abbr title=\"Legal Aid Agency\">LAA</abbr>\n"
 "    to deliver the <abbr title=\"Civil Legal Advice\">CLA</abbr> Operator Service."
 msgstr ""
 
@@ -2031,17 +2031,17 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:84
 msgid ""
-"The Legal Aid Agency (<abbr title=\"The Legal Aid Agency\">LAA</abbr>) is responsible for the <abbr>CLA</abbr>\n"
-"    service and the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"The Legal Aid Agency\">LAA</abbr>) is an\n"
+"The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is responsible for the <abbr>CLA</abbr>\n"
+"    service and the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is an\n"
 "     Executive Agency of the Ministry of Justice (<abbr title=\"The Ministry of Justice\">MoJ</abbr>)."
 msgstr ""
 
 #: cla_public/templates/privacy.html:90
 msgid ""
-"The <abbr title=\"The Legal Aid Agency\">LAA</abbr> works with other organisations who deliver the <abbr>CLA</abbr> service.\n"
+"The <abbr title=\"Legal Aid Agency\">LAA</abbr> works with other organisations who deliver the <abbr>CLA</abbr> service.\n"
 "    For example, when you first make contact with <abbr>CLA</abbr>, you will communicate with\n"
 "    the <abbr>CLA</abbr> Operator Service, which is delivered by Hinduja Global Solutions UK Limited\n"
-"    (a contractor employed by the <abbr title=\"The Legal Aid Agency\">LAA</abbr>)."
+"    (a contractor employed by the <abbr title=\"Legal Aid Agency\">LAA</abbr>)."
 msgstr ""
 
 #: cla_public/templates/privacy.html:97
@@ -2422,7 +2422,7 @@ msgstr ""
 
 #: cla_public/templates/privacy.html:360
 msgid ""
-"External research organisations engaged by <abbr title=\"The Legal Aid Agency\">LAA</abbr>\n"
+"External research organisations engaged by <abbr title=\"Legal Aid Agency\">LAA</abbr>\n"
 "          or <abbr title=\"The Ministry of Justice\">MoJ</abbr>"
 msgstr ""
 
@@ -2457,7 +2457,7 @@ msgid "To help you get further help and advice from appropriate organisations."
 msgstr ""
 
 #: cla_public/templates/privacy.html:387
-msgid "To verify information provided by you, when conducting audits on our decisions and eligibility assessments.\n"
+msgid "To verify information provided by you, when conducting audits on our decisions and eligibility assessments."
 msgstr ""
 
 #: cla_public/templates/privacy.html:395
@@ -2708,7 +2708,7 @@ msgid "How to make a complaint."
 msgstr ""
 
 #: cla_public/templates/privacy.html:594
-msgid "For more information about the above issues, please contact the MoJ Data Protection Officer;"
+msgid "For more information about the above issues, please contact the <abbr>MoJ</abbr> Data Protection Officer:"
 msgstr ""
 
 #: cla_public/templates/privacy.html:609
@@ -2719,10 +2719,6 @@ msgstr ""
 msgid ""
 "When we ask you for information, we will comply with the law. If you consider that your information has been handled incorrectly, \n"
 "      you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:"
-msgstr ""
-
-#: cla_public/templates/privacy.html:625
-msgid "Tel:"
 msgstr ""
 
 #: cla_public/templates/privacy.html:631
@@ -3373,6 +3369,7 @@ msgstr ""
 msgid "We have not saved any information you have entered. When the service is available, you will have to start again."
 msgstr ""
 
+#: cla_public/templates/privacy.html:625
 #: cla_public/templates/errors/5xx.html:12
 msgid "Telephone:"
 msgstr ""

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -2033,7 +2033,7 @@ msgstr ""
 msgid ""
 "The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for <abbr title=\"Civil Legal Advice\">CLA</abbr>\n"
 "    service and the Ministry of Justice (<abbr>MoJ</abbr>) is the Data Controller. The Legal Aid Agency (<abbr>LAA</abbr>) is an\n"
-"    Executive Agency of the (<abbr title=\"Ministry of Justice\">MoJ</abbr>)."
+"    Executive Agency of the <abbr title=\"Ministry of Justice\">MoJ</abbr>."
 msgstr ""
 
 #: cla_public/templates/privacy.html:90


### PR DESCRIPTION
## What does this pull request do?

Changes all headings and paragraphs to use new GDS classes.
Tidies up other HTML errors - such as adding table summaries
Rationalises the abbreviation tags, especially in Welsh.

## Any other changes that would benefit highlighting?

Updated a radio button field on the feedback page that had been missed.
Updated contact address at PF to omit the floor and office number and add in LAA.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
