### PR TITLE
LGA-973 - Use Flasks current_app.cache to cache bank holidays

### DIFF
--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -2,6 +2,7 @@ import os
 import datetime
 
 from flask.ext.babel import lazy_gettext as _
+from cla_common.services import CacheAdapter, TranslationAdapter
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
@@ -103,6 +104,19 @@ MAIL_PASSWORD = os.environ.get("SMTP_PASSWORD")
 MAIL_DEFAULT_SENDER = ("Civil Legal Advice", "no-reply@civillegaladvice.service.gov.uk")
 
 GOOGLE_MAPS_API_KEY = os.environ.get("GOOGLE_MAPS_API_KEY", "")
+
+
+def current_app_cache_factory(*args, **kwargs):
+    from flask import current_app  # noqa: E402
+
+    return current_app.cache
+
+
+# Use Flasks current_app.cache to cache bank holidays lookups
+CacheAdapter.set_adapter_factory(current_app_cache_factory)
+
+# Use the Flask babel extension to translate strings in cla_common
+TranslationAdapter.set_adapter_factory(lambda: _)
 
 # local.py overrides all the common settings.
 try:

--- a/cla_public/libs/call_centre_availability.py
+++ b/cla_public/libs/call_centre_availability.py
@@ -1,23 +1,5 @@
 import datetime
 
-import requests
-from flask import current_app
-from cla_common import call_centre_availability
-from cla_common.call_centre_availability import BankHolidays
-
-
-class FlaskCacheBankHolidays(BankHolidays):
-    def init_cache(self):
-        self._cache = current_app.cache
-
-    def _load_dates(self):
-        timeout = current_app.config.get("API_CLIENT_TIMEOUT", None)
-        return requests.get(self.url, timeout=timeout).json()["events"]
-
-
-# monkey patch cla_common to avoid invoking django code
-call_centre_availability.bank_holidays = lambda: FlaskCacheBankHolidays()
-
 
 def time_choice(time):
     display_format = "%I:%M %p"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,8 @@ PyYAML==3.11
 Werkzeug==0.9.6
 argparse==1.2.1
 blinker==1.3
-git+https://github.com/ministryofjustice/cla_common.git@0.3.6#egg=cla_common==0.3.6
+git+https://github.com/ministryofjustice/cla_common.git@a9af895a91aaa71b1b4df41e1761cd95baaadffe#egg=cla_common==0.3.6
+speaklater==1.3 # Required by cla_common
 itsdangerous==0.24
 jinja-moj-template==0.19.0
 logstash_formatter==0.5.9


### PR DESCRIPTION
## What does this pull request do?

Use Flasks current_app.cache to cache bank holidays
Requires https://github.com/ministryofjustice/cla_common/pull/91

## Any other changes that would benefit highlighting?

cla_common.call_centre_availability.BankHolidays now has a pluggable cache factory which was introduced in https://github.com/ministryofjustice/cla_common/pull/91

## Checklist

## Requires
https://github.com/ministryofjustice/cla_common/pull/91

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
