### PR TITLE
LGA-945 - Remove django dependecy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,10 @@ jobs:
             source env/bin/activate
             pip install --requirement requirements.txt --requirement requirements/test.txt
             pip check
+            # Don't do pip check for packages installed with --no-deps as that will complain about missing dependencies
+            pip install --requirement requirements/no-deps.txt --no-deps
       - save_cache:
-          key: pip-v2-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/test.txt" }}
+          key: pip-v2-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/test.txt" }}-{{ checksum "requirements/no-deps.txt" }}
           paths:
             - "~/.cache/pip"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /home/app/flask
 
 COPY requirements.txt .
 COPY requirements/ requirements/
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt &&  pip install -r requirements/no-deps.txt --no-deps
 
 COPY package.json package-lock.json ./
 RUN npm install

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,7 +17,7 @@ To lint with Black and flake8, install pre-commit hooks:
 
 ```
 . env/bin/activate
-pip install -r requirements/dev.txt
+pip install -r requirements/dev.txt &&  pip install -r requirements/no-deps.txt --no-deps
 pre-commit install
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ Next, create the environment and start it up:
 
     source env/bin/activate
 
-    pip install -r requirements/dev.txt
+    pip install -r requirements/dev.txt  && pip install -r requirements/no-deps.txt --no-deps
 
     nvm install v8.12
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,6 @@ Flask-Cache==0.13.1
 Flask-Mail==0.9.1
 Flask-Markdown==0.3
 Jinja2==2.7.3
-django>=1.3,<2
 MarkupSafe==0.23
 PyYAML==3.11
 Werkzeug==0.9.6
@@ -14,7 +13,6 @@ blinker==1.3
 git+https://github.com/ministryofjustice/cla_common.git@a9af895a91aaa71b1b4df41e1761cd95baaadffe#egg=cla_common==0.3.6
 speaklater==1.3 # Required by cla_common
 itsdangerous==0.24
-jinja-moj-template==0.19.0
 logstash_formatter==0.5.9
 markdown2==2.3.5
 python-dateutil==2.2

--- a/requirements/no-deps.txt
+++ b/requirements/no-deps.txt
@@ -1,0 +1,4 @@
+# This package is no longer maintained it has a dependency on django >= 1.3
+# so that it can use the static helper in it's single template file.
+# However mimic for this has already been added (see cla_public/django_to_jinja.py)
+jinja-moj-template==0.19.0


### PR DESCRIPTION
## What does this pull request do?

- Requires https://github.com/ministryofjustice/cla_public/pull/917
- Remove django dependecy

## Any other changes that would benefit highlighting?

The package jinja-moj-template is no longer being maintained and has a dependency on django >= 1.3 so that it can use the static helper in it's template file.  However a mimic for this has already been added (see cla_public/django_to_jinja.py) for the flask app. So this package can be used without django.

To remove this package dependency on the old version of django I have created a no-deps.txt requirements file, that should install it without also installing django

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
