### PR TITLE
LGA-695 - Add test coverage to project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,8 @@ jobs:
           command: |
             source env/bin/activate
             python manage.py test
+      - store_artifacts:
+          path: htmlcov
 
   staging_deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
           name: Run unit tests
           command: |
             source env/bin/activate
-            python manage.py test_with_coverage
+            python manage.py test
             coveralls
       - store_test_results:
           path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,10 +129,13 @@ jobs:
           name: Run unit tests
           command: |
             source env/bin/activate
-            # nosetests doesn't --with-xunit doesn't create the test-reports directory if doesn't exist and complains about it
-            mkdir -p test-reports
-            python manage.py test
+            coverage run manage.py test
+            coverage report -m
+            coverage html
             coveralls
+      - store_artifacts:
+          path: htmlcov
+          destination: coverage
       - store_test_results:
           path: test-reports
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,8 @@ jobs:
           name: Run unit tests
           command: |
             source env/bin/activate
+            # nosetests doesn't --with-xunit doesn't create the test-reports directory if doesn't exist and complains about it
+            mkdir -p test-reports
             python manage.py test
             coveralls
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,8 @@ jobs:
           name: Run unit tests
           command: |
             source env/bin/activate
-            python manage.py test
+            python manage.py test_with_coverage
+            coveralls
       - store_artifacts:
           path: htmlcov
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,8 @@ jobs:
             source env/bin/activate
             python manage.py test_with_coverage
             coveralls
+      - store_test_results:
+          path: test-results
       - store_artifacts:
           path: htmlcov
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,9 +132,9 @@ jobs:
             python manage.py test_with_coverage
             coveralls
       - store_test_results:
-          path: test-results
+          path: test-reports
       - store_artifacts:
-          path: htmlcov
+          path: test-reports
 
   staging_deploy:
     docker:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source = cla_public
+omit =
+ cla_public/config/*
+ */tests.py
+ */tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ cla_public/config/local.py
 cla_public/static-src/vendor/**
 cla_public/static/
 htmlcov/
+test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ cla_public/config/local.py
 cla_public/static-src/vendor/**
 cla_public/static/
 test-reports/
+htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,4 @@ node_modules/
 cla_public/config/local.py
 cla_public/static-src/vendor/**
 cla_public/static/
-htmlcov/
-test-results/
+test-reports/

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ node_modules/
 cla_public/config/local.py
 cla_public/static-src/vendor/**
 cla_public/static/
+htmlcov/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Logs](https://img.shields.io/badge/logs-view-005571.svg?logo=kibana)](https://kibana.apps.cloud-platform-live-0.k8s.integration.dsd.io/_plugin/kibana/goto/5593d9bee2fffcfbb6d93dabee450dfb)
 [![Feature tests](https://img.shields.io/badge/feature%20tests-view-brightgreen.svg?logo=github)](https://github.com/ministryofjustice/laa-cla-e2e-tests)
 [![CircleCI](https://circleci.com/gh/ministryofjustice/cla_public/tree/master.svg?style=svg)](https://circleci.com/gh/ministryofjustice/cla_public/tree/master)
+[![Coverage Status](https://coveralls.io/repos/github/ministryofjustice/cla_public/badge.svg?branch=master)](https://coveralls.io/github/ministryofjustice/cla_public?branch=master)
 
 # Civil Legal Advice
   

--- a/cla_public/apps/base/tests/__init__.py
+++ b/cla_public/apps/base/tests/__init__.py
@@ -1,0 +1,18 @@
+import unittest
+from cla_public.app import create_app
+
+
+class FlaskAppTestCase(unittest.TestCase):
+    CONFIG_FILE = "config/testing.py"
+
+    def setUp(self):
+        super(FlaskAppTestCase, self).setUp()
+        self.app = self.create_flask_app()
+        self.context = self.app.test_request_context()
+        self.context.push()
+
+    def tearDown(self):
+        self.context.pop()
+
+    def create_flask_app(self):
+        return create_app(self.CONFIG_FILE)

--- a/cla_public/apps/base/tests/test_healthchecks.py
+++ b/cla_public/apps/base/tests/test_healthchecks.py
@@ -38,7 +38,11 @@ class DiskSpaceHealthcheckTest(unittest.TestCase):
 class BackendAPIHealthcheckTest(unittest.TestCase):
     def setUp(self):
         self.app = app.create_app("config/testing.py")
-        self.app.test_request_context().push()
+        self.ctx = self.app.test_request_context()
+        self.ctx.push()
+
+    def tearDown(self):
+        self.ctx.pop()
 
     @mock.patch("requests.get")
     def test_backend_check_fails_if_request_fails(self, request_mock):
@@ -70,8 +74,12 @@ class HealthcheckEndpointTest(unittest.TestCase):
 
     def setUp(self):
         self.app = app.create_app("config/testing.py")
-        self.app.test_request_context().push()
+        self.ctx = self.app.test_request_context()
+        self.ctx.push()
         self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.ctx.pop()
 
     def assert_response_is_service_unavailable(self):
         result = self.client.get("/healthcheck.json")

--- a/cla_public/apps/base/tests/test_locale.py
+++ b/cla_public/apps/base/tests/test_locale.py
@@ -8,9 +8,12 @@ from cla_public.app import create_app
 class LocaleTest(unittest.TestCase):
     def setUp(self):
         self.app = create_app("config/testing.py")
-        ctx = self.app.test_request_context()
-        ctx.push()
+        self.ctx = self.app.test_request_context()
+        self.ctx.push()
         self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.ctx.pop()
 
     def test_locale_cookie_is_set(self):
         with self.app.test_client() as client:

--- a/cla_public/apps/base/tests/test_locale.py
+++ b/cla_public/apps/base/tests/test_locale.py
@@ -1,19 +1,12 @@
-import unittest
-
 from werkzeug.http import parse_cookie
 
-from cla_public.app import create_app
+from cla_public.apps.base.tests import FlaskAppTestCase
 
 
-class LocaleTest(unittest.TestCase):
+class LocaleTest(FlaskAppTestCase):
     def setUp(self):
-        self.app = create_app("config/testing.py")
-        self.ctx = self.app.test_request_context()
-        self.ctx.push()
+        super(LocaleTest, self).setUp()
         self.client = self.app.test_client()
-
-    def tearDown(self):
-        self.ctx.pop()
 
     def test_locale_cookie_is_set(self):
         with self.app.test_client() as client:

--- a/cla_public/apps/base/tests/test_reasons_for_contacting.py
+++ b/cla_public/apps/base/tests/test_reasons_for_contacting.py
@@ -16,6 +16,7 @@ class ReasonsForContactingTestCase(unittest.TestCase):
         self.app.test_request_context().push()
         self.client = self.app.test_client()
 
+    @unittest.skip("Skip this tests until request is mocked. These were ignored before with nosetests")
     def test_submission(self):
         income_page_url = url_for("checker.wizard", step="income")
         random_reason = str(choice(REASONS_FOR_CONTACTING_CHOICES)[0])

--- a/cla_public/apps/base/tests/test_reasons_for_contacting.py
+++ b/cla_public/apps/base/tests/test_reasons_for_contacting.py
@@ -13,8 +13,12 @@ from cla_public.apps.checker.api import post_reasons_for_contacting
 class ReasonsForContactingTestCase(unittest.TestCase):
     def setUp(self):
         self.app = app.create_app("config/testing.py")
-        self.app.test_request_context().push()
+        self.ctx = self.app.test_request_context()
+        self.ctx.push()
         self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.ctx.pop()
 
     @unittest.skip("Skip this tests until request is mocked. These were ignored before with nosetests")
     def test_submission(self):

--- a/cla_public/apps/base/tests/test_reasons_for_contacting.py
+++ b/cla_public/apps/base/tests/test_reasons_for_contacting.py
@@ -4,21 +4,16 @@ import unittest
 from flask import url_for
 from werkzeug.datastructures import MultiDict
 
-from cla_public import app
 from cla_public.apps.base.constants import REASONS_FOR_CONTACTING_CHOICES
 from cla_public.apps.base.forms import ReasonsForContactingForm
 from cla_public.apps.checker.api import post_reasons_for_contacting
+from cla_public.apps.base.tests import FlaskAppTestCase
 
 
-class ReasonsForContactingTestCase(unittest.TestCase):
+class ReasonsForContactingTestCase(FlaskAppTestCase):
     def setUp(self):
-        self.app = app.create_app("config/testing.py")
-        self.ctx = self.app.test_request_context()
-        self.ctx.push()
+        super(ReasonsForContactingTestCase, self).setUp()
         self.client = self.app.test_client()
-
-    def tearDown(self):
-        self.ctx.pop()
 
     @unittest.skip("Skip this tests until request is mocked. These were ignored before with nosetests")
     def test_submission(self):

--- a/cla_public/apps/checker/tests/test_api_already_saved_error.py
+++ b/cla_public/apps/checker/tests/test_api_already_saved_error.py
@@ -1,15 +1,14 @@
 # coding: utf-8
 import json
-import unittest
 from cla_public.apps.contact.views import session
 from mock import patch
 from slumber.exceptions import SlumberHttpBaseException
 
 from cla_common.constants import ELIGIBILITY_STATES
-from cla_public import app
 from cla_public.apps.checker.api import post_to_case_api, AlreadySavedApiError
 from cla_public.apps.contact.forms import ContactForm
 from cla_public.apps.contact.views import Contact
+from cla_public.apps.base.tests import FlaskAppTestCase
 
 
 def _mock_session_send(*args, **kwargs):
@@ -35,15 +34,10 @@ def _mock_post_to_is_eligible_api(*args, **kwargs):
     return ELIGIBILITY_STATES.YES, []
 
 
-class ApiAlreadySavedErrorTestCase(unittest.TestCase):
+class ApiAlreadySavedErrorTestCase(FlaskAppTestCase):
     def setUp(self):
-        self.app = app.create_app("config/testing.py")
-        self._ctx = self.app.test_request_context()
-        self._ctx.push()
+        super(ApiAlreadySavedErrorTestCase, self).setUp()
         self.client = self.app.test_client()
-
-    def tearDown(self):
-        self._ctx.pop()
 
     def test_mock_session_send_post_to_case_api(self):
         form = ContactForm()

--- a/cla_public/apps/checker/tests/test_api_already_saved_error.py
+++ b/cla_public/apps/checker/tests/test_api_already_saved_error.py
@@ -42,6 +42,9 @@ class ApiAlreadySavedErrorTestCase(unittest.TestCase):
         self._ctx.push()
         self.client = self.app.test_client()
 
+    def tearDown(self):
+        self._ctx.pop()
+
     def test_mock_session_send_post_to_case_api(self):
         form = ContactForm()
         with patch("requests.Session.send", _mock_session_send), patch(

--- a/cla_public/apps/checker/tests/test_api_timeout.py
+++ b/cla_public/apps/checker/tests/test_api_timeout.py
@@ -1,24 +1,18 @@
-import unittest
 from mock import patch
 
 from requests.exceptions import ConnectionError, Timeout
 
-from cla_public.app import create_app
 from cla_public.apps.checker.constants import NO, YES
+from cla_public.apps.base.tests import FlaskAppTestCase
 
 
-class TestApiTimeout(unittest.TestCase):
+class TestApiTimeout(FlaskAppTestCase):
     def setUp(self):
-        app = create_app("config/testing.py")
-        self.ctx = app.test_request_context()
-        self.ctx.push()
-        self.client = app.test_client()
+        super(TestApiTimeout, self).setUp()
+        self.client = self.app.test_client()
         with self.client.session_transaction() as session:
             session["test"] = True
             session.checker["test"] = True
-
-    def tearDown(self):
-        self.ctx.pop()
 
     def test_form_error_on_api_timeout(self):
         def timeout(*args, **kwargs):

--- a/cla_public/apps/checker/tests/test_api_timeout.py
+++ b/cla_public/apps/checker/tests/test_api_timeout.py
@@ -10,11 +10,15 @@ from cla_public.apps.checker.constants import NO, YES
 class TestApiTimeout(unittest.TestCase):
     def setUp(self):
         app = create_app("config/testing.py")
-        app.test_request_context().push()
+        self.ctx = app.test_request_context()
+        self.ctx.push()
         self.client = app.test_client()
         with self.client.session_transaction() as session:
             session["test"] = True
             session.checker["test"] = True
+
+    def tearDown(self):
+        self.ctx.pop()
 
     def test_form_error_on_api_timeout(self):
         def timeout(*args, **kwargs):

--- a/cla_public/apps/checker/tests/test_cait_intervention.py
+++ b/cla_public/apps/checker/tests/test_cait_intervention.py
@@ -64,7 +64,11 @@ class TestCaitIntervention(unittest.TestCase):
     def setUp(self):
         self.app = create_app("config/testing.py")
         self.client = self.app.test_client()
-        self.app.test_request_context().push()
+        self.ctx = self.app.test_request_context()
+        self.ctx.push()
+
+    def tearDown(self):
+        self.ctx.pop()
 
     @mock.patch(ORGANISATION_LIST, setup_organisation_list())
     def test_direct_pathway(self):

--- a/cla_public/apps/checker/tests/test_cait_intervention.py
+++ b/cla_public/apps/checker/tests/test_cait_intervention.py
@@ -1,12 +1,11 @@
 from copy import copy
 import json
 import os
-import unittest
-
 import mock
 
-from cla_public.app import create_app
 from cla_public.apps.checker.cait_intervention import get_cait_params
+from cla_public.apps.base.tests import FlaskAppTestCase
+
 
 # Load dummy config data
 configs = {}
@@ -60,15 +59,10 @@ DEFAULT_PARAMS_OUT = {"truncate": 5}
 DEFAULT_SURVEY = "http://survey/default"
 
 
-class TestCaitIntervention(unittest.TestCase):
+class TestCaitIntervention(FlaskAppTestCase):
     def setUp(self):
-        self.app = create_app("config/testing.py")
+        super(TestCaitIntervention, self).setUp()
         self.client = self.app.test_client()
-        self.ctx = self.app.test_request_context()
-        self.ctx.push()
-
-    def tearDown(self):
-        self.ctx.pop()
 
     @mock.patch(ORGANISATION_LIST, setup_organisation_list())
     def test_direct_pathway(self):

--- a/cla_public/apps/checker/tests/test_form_config.py
+++ b/cla_public/apps/checker/tests/test_form_config.py
@@ -43,6 +43,7 @@ class TestFormConfig(unittest.TestCase):
 
     def tearDown(self):
         self.patcher.stop()
+        self._ctx.pop()
 
     def test_field_more_info(self):
         form = TestConfigForm(config_path=FORMS_CONFIG_PATH)

--- a/cla_public/apps/checker/tests/test_form_config.py
+++ b/cla_public/apps/checker/tests/test_form_config.py
@@ -1,12 +1,11 @@
 import os
-import unittest
 from wtforms import StringField
 from flask_wtf import Form
 from mock import patch
 
-from cla_public import app
 from cla_public.apps.checker.fields import DescriptionRadioField
 from cla_public.libs.form_config_parser import ConfigFormMixin
+from cla_public.apps.base.tests import FlaskAppTestCase
 
 
 FORMS_CONFIG = "config/forms_config.yml"
@@ -33,17 +32,15 @@ class TestDescriptionRadioFieldForm(ConfigFormMixin, Form):
     radio_select = DescriptionRadioField(u"Description Radio Field", choices=CHOICES, coerce=unicode)
 
 
-class TestFormConfig(unittest.TestCase):
+class TestFormConfig(FlaskAppTestCase):
     def setUp(self):
+        super(TestFormConfig, self).setUp()
         self.patcher = patch("cla_public.libs.utils.get_locale", get_en_locale)
         self.patcher.start()
-        self.app = app.create_app("config/testing.py")
-        self._ctx = self.app.test_request_context()
-        self._ctx.push()
 
     def tearDown(self):
+        super(TestFormConfig, self).tearDown()
         self.patcher.stop()
-        self._ctx.pop()
 
     def test_field_more_info(self):
         form = TestConfigForm(config_path=FORMS_CONFIG_PATH)

--- a/cla_public/apps/checker/tests/test_integration.py
+++ b/cla_public/apps/checker/tests/test_integration.py
@@ -102,9 +102,12 @@ def is_eligible(acc, step):
 class TestMeansTest(unittest.TestCase):
     def setUp(self):
         self.app = app.create_app("config/testing.py")
-        ctx = self.app.test_request_context()
-        ctx.push()
+        self.ctx = self.app.test_request_context()
+        self.ctx.push()
         self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.ctx.pop()
 
     def assertMeansTest(self, expected_result, case):
         def debug_is_eligible(acc, step):

--- a/cla_public/apps/checker/tests/test_integration.py
+++ b/cla_public/apps/checker/tests/test_integration.py
@@ -235,6 +235,7 @@ def create_tests():
             setattr(TestMeansTest, test_name(row), make_test(row))
 
 
-create_tests.__test__ = False
+# create_tests.__test__ = False
 
-create_tests()
+# Skip this tests until request is mocked. These were ignored before with nosetests
+# create_tests()

--- a/cla_public/apps/checker/tests/test_integration.py
+++ b/cla_public/apps/checker/tests/test_integration.py
@@ -6,14 +6,12 @@ import os
 from pprint import pformat
 import re
 import unicodedata
-import unittest
 import urlparse
 
 from bs4 import BeautifulSoup
 from flask import session, url_for
 import xlrd
 
-from cla_public import app
 from cla_public.apps.checker.means_test import MeansTest
 from cla_public.apps.checker.api import post_to_eligibility_check_api
 from cla_public.apps.checker.forms import (
@@ -27,6 +25,7 @@ from cla_public.apps.checker.forms import (
     ReviewForm,
 )
 from cla_public.apps.checker.tests.utils.forms_utils import CATEGORY_MAPPING, FormDataConverter
+from cla_public.apps.base.tests import FlaskAppTestCase
 
 
 logging.getLogger("MARKDOWN").setLevel(logging.WARNING)
@@ -99,15 +98,10 @@ def is_eligible(acc, step):
     return result
 
 
-class TestMeansTest(unittest.TestCase):
+class TestMeansTest(FlaskAppTestCase):
     def setUp(self):
-        self.app = app.create_app("config/testing.py")
-        self.ctx = self.app.test_request_context()
-        self.ctx.push()
+        super(TestMeansTest, self).setUp()
         self.client = self.app.test_client()
-
-    def tearDown(self):
-        self.ctx.pop()
 
     def assertMeansTest(self, expected_result, case):
         def debug_is_eligible(acc, step):

--- a/cla_public/apps/checker/tests/test_means_test.py
+++ b/cla_public/apps/checker/tests/test_means_test.py
@@ -97,8 +97,12 @@ class TestMeansTest(unittest.TestCase):
     def setUp(self):
         self.app = create_app("config/testing.py")
         self.client = self.app.test_client()
-        self.app.test_request_context().push()
+        self.ctx = self.app.test_request_context()
+        self.ctx.push()
         session.clear()
+
+    def tearDown(self):
+        self.ctx.pop()
 
     def assertDictValues(self, expected, actual):
         for key, val in actual.items():

--- a/cla_public/apps/checker/tests/test_means_test.py
+++ b/cla_public/apps/checker/tests/test_means_test.py
@@ -1,14 +1,14 @@
 from collections import defaultdict
 from itertools import chain
 import logging
-import unittest
 
 from flask import session
 
-from cla_public.app import create_app
 from cla_public.apps.checker.constants import YES, NO
 from cla_public.apps.checker.means_test import MeansTest
 from cla_public.libs.money_interval import MoneyInterval
+from cla_public.apps.base.tests import FlaskAppTestCase
+
 
 logging.getLogger("MARKDOWN").setLevel(logging.WARNING)
 
@@ -93,16 +93,11 @@ def update_session(form, **kwargs):
     session.checker[form].update(**kwargs)
 
 
-class TestMeansTest(unittest.TestCase):
+class TestMeansTest(FlaskAppTestCase):
     def setUp(self):
-        self.app = create_app("config/testing.py")
+        super(TestMeansTest, self).setUp()
         self.client = self.app.test_client()
-        self.ctx = self.app.test_request_context()
-        self.ctx.push()
         session.clear()
-
-    def tearDown(self):
-        self.ctx.pop()
 
     def assertDictValues(self, expected, actual):
         for key, val in actual.items():

--- a/cla_public/apps/checker/tests/test_payloads.py
+++ b/cla_public/apps/checker/tests/test_payloads.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 import datetime
-import unittest
 
 from cla_common import call_centre_availability
 from cla_common.constants import THIRDPARTY_RELATIONSHIP
@@ -9,7 +8,6 @@ from mock import patch
 import pytz
 from werkzeug.datastructures import MultiDict
 
-from cla_public import app
 from cla_public.apps.contact.tests.test_availability import override_current_time
 from cla_public.apps.checker.constants import NO, YES, SAFE_TO_CONTACT, CONTACT_PREFERENCE
 from cla_public.apps.contact.forms import ContactForm
@@ -23,25 +21,24 @@ from cla_public.apps.checker.means_test import (
     OutgoingsPayload,
 )
 from cla_public.apps.checker.tests.utils.forms_utils import flatten_dict, flatten_list_of_dicts
+from cla_public.apps.base.tests import FlaskAppTestCase
 
 
 def get_en_locale():
     return "en"
 
 
-class TestApiPayloads(unittest.TestCase):
+class TestApiPayloads(FlaskAppTestCase):
     def setUp(self):
         self.patcher = patch("cla_public.libs.utils.get_locale", get_en_locale)
         self.patcher.start()
-        self.app = app.create_app("config/testing.py")
-        self._ctx = self.app.test_request_context()
-        self._ctx.push()
+        super(TestApiPayloads, self).setUp()
         self.client = self.app.test_client()
         self.now = datetime.datetime(2015, 1, 26, 9, 0)
 
     def tearDown(self):
         self.patcher.stop()
-        self._ctx.pop()
+        super(TestApiPayloads, self).tearDown()
 
     def merge_money_intervals(self, form_data, form_mi_data):
         for field_name, money_interval_dict in form_mi_data.items():

--- a/cla_public/apps/checker/tests/test_payloads.py
+++ b/cla_public/apps/checker/tests/test_payloads.py
@@ -41,6 +41,7 @@ class TestApiPayloads(unittest.TestCase):
 
     def tearDown(self):
         self.patcher.stop()
+        self._ctx.pop()
 
     def merge_money_intervals(self, form_data, form_mi_data):
         for field_name, money_interval_dict in form_mi_data.items():

--- a/cla_public/apps/checker/tests/test_validation.py
+++ b/cla_public/apps/checker/tests/test_validation.py
@@ -27,6 +27,10 @@ class TestValidation(unittest.TestCase):
         self.context = app.test_request_context()
         self.context.push()
 
+    def tearDown(self):
+        super(TestValidation, self).tearDown()
+        self.context.pop()
+
     def test_too_many_kids(self):
         num = 51
         form = submit(have_children=True, num_children=num)

--- a/cla_public/apps/checker/tests/test_validation.py
+++ b/cla_public/apps/checker/tests/test_validation.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 from mock import Mock
 
 import flask
@@ -9,27 +8,25 @@ from wtforms.fields.html5 import EmailField
 
 from cla_public.apps.checker.forms import AboutYouForm
 from cla_public.apps.contact.validators import EmailValidator
+from cla_public.apps.base.tests import FlaskAppTestCase
 
 
 def submit(**kwargs):
     return AboutYouForm(MultiDict(kwargs), csrf_enabled=False)
 
 
-class TestValidation(unittest.TestCase):
+class TestValidation(FlaskAppTestCase):
     def setUp(self):
-        app = flask.Flask(__name__)
-        app.config["TESTING"] = True
+        super(TestValidation, self).setUp()
+        self.app.config["TESTING"] = True
         config = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../config/forms/en/forms_config.yml"))
-        app.config["FORM_CONFIG_TRANSLATIONS"] = {"en": config}
-        app.babel = Mock()
-        app.babel.locale_selector_func.return_value = "en"
-        app.extensions["babel"] = app.babel
-        self.context = app.test_request_context()
-        self.context.push()
+        self.app.config["FORM_CONFIG_TRANSLATIONS"] = {"en": config}
+        self.app.babel = Mock()
+        self.app.babel.locale_selector_func.return_value = "en"
+        self.app.extensions["babel"] = self.app.babel
 
-    def tearDown(self):
-        super(TestValidation, self).tearDown()
-        self.context.pop()
+    def create_flask_app(self):
+        return flask.Flask(__name__)
 
     def test_too_many_kids(self):
         num = 51

--- a/cla_public/apps/contact/tests/test_availability.py
+++ b/cla_public/apps/contact/tests/test_availability.py
@@ -45,6 +45,7 @@ class TestAvailability(unittest.TestCase):
 
     def tearDown(self):
         self.patcher.stop()
+        self.ctx.pop()
 
     def assertAvailable(self, time, form=None):
         form = form or Mock()
@@ -208,7 +209,11 @@ class TestCallbackInPastBug(unittest.TestCase):
 
     def setUp(self):
         self.app = create_app("config/testing.py")
-        self.app.test_request_context().push()
+        self.ctx = self.app.test_request_context()
+        self.ctx.push()
+
+    def tearDown(self):
+        self.ctx.pop()
 
     def test_EU_5247_5578(self):
         with override_current_time(datetime.datetime(2015, 2, 11, 23, 3)):

--- a/cla_public/apps/contact/tests/test_notes.py
+++ b/cla_public/apps/contact/tests/test_notes.py
@@ -1,24 +1,14 @@
-import unittest
-
 from werkzeug.datastructures import MultiDict
 
-from cla_public.app import create_app
 from cla_public.apps.contact.forms import ContactForm
+from cla_public.apps.base.tests import FlaskAppTestCase
 
 
 def submit(**kwargs):
     return ContactForm(MultiDict(kwargs), csrf_enabled=False)
 
 
-class NotesTest(unittest.TestCase):
-    def setUp(self):
-        app = create_app("config/testing.py")
-        self.ctx = app.test_request_context()
-        self.ctx.push()
-
-    def tearDown(self):
-        self.ctx.pop()
-
+class NotesTest(FlaskAppTestCase):
     def validate_notes(self, notes):
         form = submit(extra_notes=notes)
         form.validate()

--- a/cla_public/apps/contact/tests/test_notes.py
+++ b/cla_public/apps/contact/tests/test_notes.py
@@ -13,7 +13,11 @@ def submit(**kwargs):
 class NotesTest(unittest.TestCase):
     def setUp(self):
         app = create_app("config/testing.py")
-        app.test_request_context().push()
+        self.ctx = app.test_request_context()
+        self.ctx.push()
+
+    def tearDown(self):
+        self.ctx.pop()
 
     def validate_notes(self, notes):
         form = submit(extra_notes=notes)

--- a/cla_public/apps/geocoder/tests.py
+++ b/cla_public/apps/geocoder/tests.py
@@ -1,22 +1,16 @@
 import json
-import unittest
 
 import mock
-from cla_public.app import create_app
 from cla_public.apps.geocoder.views import geocode
+from cla_public.apps.base.tests import FlaskAppTestCase
 
 
-class GeocoderTest(unittest.TestCase):
+class GeocoderTest(FlaskAppTestCase):
     prerecorded_result = "Ministry of Justice\n52 Queen Annes Gate\nLondon\nSW1H 9AG"
 
     def setUp(self):
-        app = create_app("config/testing.py")
-        app.config["OS_PLACES_API_KEY"] = "DUMMY_TOKEN"
-        self.ctx = app.test_request_context()
-        self.ctx.push()
-
-    def tearDown(self):
-        self.ctx.pop()
+        super(GeocoderTest, self).setUp()
+        self.app.config["OS_PLACES_API_KEY"] = "DUMMY_TOKEN"
 
     def test_response_packaging(self):
         expected_formatted_result = json.dumps([{"formatted_address": self.prerecorded_result}])

--- a/cla_public/apps/geocoder/tests.py
+++ b/cla_public/apps/geocoder/tests.py
@@ -12,7 +12,11 @@ class GeocoderTest(unittest.TestCase):
     def setUp(self):
         app = create_app("config/testing.py")
         app.config["OS_PLACES_API_KEY"] = "DUMMY_TOKEN"
-        app.test_request_context().push()
+        self.ctx = app.test_request_context()
+        self.ctx.push()
+
+    def tearDown(self):
+        self.ctx.pop()
 
     def test_response_packaging(self):
         expected_formatted_result = json.dumps([{"formatted_address": self.prerecorded_result}])

--- a/cla_public/apps/scope/tests/test_diagnosis_api.py
+++ b/cla_public/apps/scope/tests/test_diagnosis_api.py
@@ -8,10 +8,13 @@ from cla_public.apps.scope.api import diagnosis_api_client as api
 class TestReviewPage(unittest.TestCase):
     def setUp(self):
         self.app = create_app("config/testing.py")
-        ctx = self.app.test_request_context()
-        ctx.push()
+        self.ctx = self.app.test_request_context()
+        self.ctx.push()
         self.client = self.app.test_client()
         api.create_diagnosis()
+
+    def tearDown(self):
+        self.ctx.pop()
 
     def assertResponseHasNNodes(self, resp, n):
         self.assertEqual(resp.status_code, 200)

--- a/cla_public/apps/scope/tests/test_diagnosis_api.py
+++ b/cla_public/apps/scope/tests/test_diagnosis_api.py
@@ -1,20 +1,13 @@
 # coding: utf-8
-import unittest
-
-from cla_public.app import create_app
 from cla_public.apps.scope.api import diagnosis_api_client as api
+from cla_public.apps.base.tests import FlaskAppTestCase
 
 
-class TestReviewPage(unittest.TestCase):
+class TestReviewPage(FlaskAppTestCase):
     def setUp(self):
-        self.app = create_app("config/testing.py")
-        self.ctx = self.app.test_request_context()
-        self.ctx.push()
+        super(TestReviewPage, self).setUp()
         self.client = self.app.test_client()
         api.create_diagnosis()
-
-    def tearDown(self):
-        self.ctx.pop()
 
     def assertResponseHasNNodes(self, resp, n):
         self.assertEqual(resp.status_code, 200)

--- a/cla_public/libs/tests/test_views.py
+++ b/cla_public/libs/tests/test_views.py
@@ -32,6 +32,7 @@ class TestSessionBackedFormView(unittest.TestCase):
         app.add_url_rule(
             "/session-expired", endpoint="base.session_expired", view_func=lambda request: "Session expired"
         )
+        self.ctx = app.test_request_context()
         self.client = app.test_client()
         with self.client.session_transaction() as sess:
             sess.checker["foo"] = "bar"

--- a/cla_public/libs/tests/test_views.py
+++ b/cla_public/libs/tests/test_views.py
@@ -32,7 +32,6 @@ class TestSessionBackedFormView(unittest.TestCase):
         app.add_url_rule(
             "/session-expired", endpoint="base.session_expired", view_func=lambda request: "Session expired"
         )
-        self.ctx = app.test_request_context()
         self.client = app.test_client()
         with self.client.session_transaction() as sess:
             sess.checker["foo"] = "bar"

--- a/manage.py
+++ b/manage.py
@@ -34,7 +34,7 @@ def test():
     import xmlrunner
     import unittest
 
-    xmlrunner.XMLTestRunner(output="xml_test_result").run(unittest.TestLoader().discover("cla_public"))
+    xmlrunner.XMLTestRunner(output="test-reports", verbosity=3).run(unittest.TestLoader().discover("cla_public"))
 
 
 def add_msgctxt(**format_kwargs):

--- a/manage.py
+++ b/manage.py
@@ -40,7 +40,7 @@ def test(i=False):
 @manager.command
 def test_with_coverage():
     """Run the tests. Pass -i to run integration tests as well"""
-    ignore_integration = " --with-coverage --cover-package=cla_public --cover-html --cover-html-dir=htmlcov -e=*_integration.py -e=*test_diagnosis_api* -e=*test_reasons_for_contacting*"
+    ignore_integration = " --with-coverage --cover-package=cla_public --cover-html --cover-html-dir=htmlcov --cover-xml --cover-xml-file=test-results/junit.xml -e=*_integration.py -e=*test_diagnosis_api* -e=*test_reasons_for_contacting*"
     nosetests = "{venv}/bin/nosetests{integration}".format(venv=VENV, integration=ignore_integration)
     run(nosetests)
 

--- a/manage.py
+++ b/manage.py
@@ -37,6 +37,14 @@ def test(i=False):
     run(nosetests)
 
 
+@manager.command
+def test_with_coverage():
+    """Run the tests. Pass -i to run integration tests as well"""
+    ignore_integration = " --with-coverage --cover-package=cla_public --cover-html --cover-html-dir=htmlcov -e=*_integration.py -e=*test_diagnosis_api* -e=*test_reasons_for_contacting*"
+    nosetests = "{venv}/bin/nosetests{integration}".format(venv=VENV, integration=ignore_integration)
+    run(nosetests)
+
+
 def add_msgctxt(**format_kwargs):
     """add msgctxt to pot file as babel doesn't seem to correctly add this for pgettext"""
     cmd = (

--- a/manage.py
+++ b/manage.py
@@ -31,10 +31,7 @@ def run(command, **kwargs):
 
 @manager.command
 def test():
-    """Run the tests. Pass -i to run integration tests as well"""
-    ignore_integration = " --with-coverage --cover-package=cla_public --cover-html --cover-html-dir=test-reports --with-xunit --xunit-file=test-reports/junit.xml -e=*_integration.py -e=*test_diagnosis_api* -e=*test_reasons_for_contacting*"
-    nosetests = "{venv}/bin/nosetests{integration}".format(venv=VENV, integration=ignore_integration)
-    run(nosetests)
+    run("python -m xmlrunner discover -t . -o test-reports")
 
 
 def add_msgctxt(**format_kwargs):

--- a/manage.py
+++ b/manage.py
@@ -31,7 +31,10 @@ def run(command, **kwargs):
 
 @manager.command
 def test():
-    run("python -m xmlrunner discover -t . -o test-reports")
+    import xmlrunner
+    import unittest
+
+    xmlrunner.XMLTestRunner(output="xml_test_result").run(unittest.TestLoader().discover("cla_public"))
 
 
 def add_msgctxt(**format_kwargs):

--- a/manage.py
+++ b/manage.py
@@ -30,17 +30,9 @@ def run(command, **kwargs):
 
 
 @manager.command
-def test(i=False):
+def test():
     """Run the tests. Pass -i to run integration tests as well"""
-    ignore_integration = "" if i else " -e=*_integration.py -e=*test_diagnosis_api* -e=*test_reasons_for_contacting*"
-    nosetests = "{venv}/bin/nosetests{integration}".format(venv=VENV, integration=ignore_integration)
-    run(nosetests)
-
-
-@manager.command
-def test_with_coverage():
-    """Run the tests. Pass -i to run integration tests as well"""
-    ignore_integration = " --with-coverage --cover-package=cla_public --cover-html --cover-html-dir=htmlcov --cover-xml --cover-xml-file=test-reports/junit.xml -e=*_integration.py -e=*test_diagnosis_api* -e=*test_reasons_for_contacting*"
+    ignore_integration = " --with-coverage --cover-package=cla_public --cover-html --cover-html-dir=test-reports --with-xunit --xunit-file=test-reports/junit.xml -e=*_integration.py -e=*test_diagnosis_api* -e=*test_reasons_for_contacting*"
     nosetests = "{venv}/bin/nosetests{integration}".format(venv=VENV, integration=ignore_integration)
     run(nosetests)
 

--- a/manage.py
+++ b/manage.py
@@ -40,7 +40,7 @@ def test(i=False):
 @manager.command
 def test_with_coverage():
     """Run the tests. Pass -i to run integration tests as well"""
-    ignore_integration = " --with-coverage --cover-package=cla_public --cover-html --cover-html-dir=htmlcov --cover-xml --cover-xml-file=test-results/junit.xml -e=*_integration.py -e=*test_diagnosis_api* -e=*test_reasons_for_contacting*"
+    ignore_integration = " --with-coverage --cover-package=cla_public --cover-html --cover-html-dir=htmlcov --cover-xml --cover-xml-file=test-reports/junit.xml -e=*_integration.py -e=*test_diagnosis_api* -e=*test_reasons_for_contacting*"
     nosetests = "{venv}/bin/nosetests{integration}".format(venv=VENV, integration=ignore_integration)
     run(nosetests)
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 mock==1.0.1
-nose==1.3.4
+unittest-xml-reporting==2.5.2
 requests_mock==1.5.2
 coverage==5.0.3
 coveralls==1.10.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
 mock==1.0.1
 nose==1.3.4
 requests_mock==1.5.2
+coverage==5.0.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@ mock==1.0.1
 nose==1.3.4
 requests_mock==1.5.2
 coverage==5.0.3
+coveralls==1.10.0


### PR DESCRIPTION
## What does this pull request do?

- Wraps test running in coverage
- Stores the output on circleci as artifacts
- Sends coverage results to coveralls.io
- Adds a coveralls badge to the readme
- Swapped test runner from nosetests to unittest-xml-reporting to generate xml result files to be used by circleci
- Generates and stores test metadata in xml format for CircleCI to monitor
- Added a tearDown method to cleanup after tests that create a temporary flask app and use app.test_request_context. If this is not done then the flask will raise an AssertionError: Popped wrong request context.


## Any other changes that would benefit highlighting?

Similar to https://github.com/ministryofjustice/cla_backend/pull/583

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
