### PR TITLE
LGA-832 Stopped links opening in new tabs

### DIFF
--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -109,7 +109,7 @@
                   {% if item.organisation.website %}
                     <p>
                       <span>{{ _('Website') }}:</span>
-                      {{ Element.link_new_window(item.organisation.website|human_to_url, item.organisation.website|url_to_human, is_external=True, **{'class': 'url'}) }}
+                      {{ Element.link_same_window(item.organisation.website|human_to_url, item.organisation.website|url_to_human, is_external=True, **{'class': 'url'}) }}
                     </p>
                   {% endif %}
                 </div>

--- a/cla_public/templates/checker/result/eligible.html
+++ b/cla_public/templates/checker/result/eligible.html
@@ -27,7 +27,7 @@
     below.{% endtrans %}
   </p>
   <p class="govuk-body">
-    {% trans call_charges_link=Element.link_new_window('https://www.gov.uk/call-charges', _('call charges'), True) %}
+    {% trans call_charges_link=Element.link_same_window('https://www.gov.uk/call-charges', _('call charges'), True) %}
       You can choose to contact CLA yourself and speak to someone immediately (this is an 0345 number -
       {{ call_charges_link }} apply) or ask us to call you back, which is free.
     {% endtrans %}

--- a/cla_public/templates/checker/result/ineligible.html
+++ b/cla_public/templates/checker/result/ineligible.html
@@ -54,7 +54,7 @@
   {% if category == 'family' %}
     <p class="govuk-body">
       {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'Family Mediation Council') %}
-      {% trans family_mediation_link=Element.link_new_window('http://www.familymediationcouncil.org.uk/', _('Family Mediation Council'), True, **{'data-ga': ga_event}) %}
+      {% trans family_mediation_link=Element.link_same_window('http://www.familymediationcouncil.org.uk/', _('Family Mediation Council'), True, **{'data-ga': ga_event}) %}
         If you want to make an application to court about a family matter you need to first of all
         see if family mediation will help. Use the {{ family_mediation_link }} directory to find a mediator
         and make an appointment for a Mediation Information and Assessment Meeting (MIAM).
@@ -91,7 +91,7 @@
 
   <p class="govuk-body">
     {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'Find a solicitor') %}
-    {{ Element.link_new_window('https://www.gov.uk/find-a-legal-adviser', _('Find a solicitor'), **{'class': 'govuk-button', 'data-ga': ga_event}) }}
+    {{ Element.link_same_window('https://www.gov.uk/find-a-legal-adviser', _('Find a solicitor'), **{'class': 'govuk-button', 'data-ga': ga_event}) }}
   </p>
 
   {{ HelpOrganisations.org_list_container(organisations, category_name, truncate=5) }}

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -31,7 +31,7 @@
         </strong>
       </div>
       <p class="govuk-body">
-        {% trans call_charges_link=Element.link_new_window('https://www.gov.uk/call-charges', _('Call charges apply'), True) %}
+        {% trans call_charges_link=Element.link_same_window('https://www.gov.uk/call-charges', _('Call charges apply'), True) %}
             If you’re in immediate danger please call Civil Legal Advice on <strong class="laa-telephone">0345 345 4 345</strong>.
             {{ call_charges_link }}.
           {% endtrans %}
@@ -44,7 +44,7 @@
         {% trans %}Please submit your details to get in touch with Civil Legal Advice (CLA).{% endtrans %}
       </p>
       <p class="govuk-body">
-        {% trans call_charges_link=Element.link_new_window('https://www.gov.uk/call-charges', _('call charges'), True) %}
+        {% trans call_charges_link=Element.link_same_window('https://www.gov.uk/call-charges', _('call charges'), True) %}
           You can choose to contact CLA yourself and speak to someone immediately
           (this is an 0345 number - {{ call_charges_link }} apply) or ask us to call you back, which is free.
         {% endtrans %}
@@ -117,7 +117,7 @@
   {% include "checker/time-out-warning.html" %}
   {% block notice %}
     <p class="notice">
-      {% trans privacy_link=Element.link_new_window(url_for('base.privacy'), _('Civil Legal Advice Privacy Statement')) %}
+      {% trans privacy_link=Element.link_same_window(url_for('base.privacy'), _('Civil Legal Advice Privacy Statement')) %}
         Protecting your personal data and your privacy is important to us.
         Read the full {{ privacy_link }}.
       {% endtrans %}

--- a/cla_public/templates/cookies.html
+++ b/cla_public/templates/cookies.html
@@ -22,7 +22,7 @@
 
   <p class="govuk-body">{{ _('You’ll normally see a message on the site before we store a cookie on your computer.') }}</p>
   <p class="govuk-body">
-    {% trans manage_cookies_link=Element.link_new_window('http://www.aboutcookies.org/', _('how to manage cookies'), True) %}
+    {% trans manage_cookies_link=Element.link_same_window('http://www.aboutcookies.org/', _('how to manage cookies'), True) %}
       Find out more about {{ manage_cookies_link }}.
     {% endtrans %}
   </p>
@@ -75,7 +75,7 @@
   </table>
 
   <p class="govuk-body">
-    {% trans opt_out_link=Element.link_new_window('https://tools.google.com/dlpage/gaoptout', _('opt out of Google Analytics cookies'), True) %}
+    {% trans opt_out_link=Element.link_same_window('https://tools.google.com/dlpage/gaoptout', _('opt out of Google Analytics cookies'), True) %}
       You can {{ opt_out_link }}.
     {% endtrans %}
   </p>
@@ -142,7 +142,7 @@
   </table>
 
   <p class="govuk-body">
-    {% trans govuk_cookies_link=Element.link_new_window('https://www.gov.uk/help/cookies', _('how cookies are used on gov.uk'), True) %}
+    {% trans govuk_cookies_link=Element.link_same_window('https://www.gov.uk/help/cookies', _('how cookies are used on gov.uk'), True) %}
       You can read more about {{ govuk_cookies_link }}.
     {% endtrans %}
   </p>

--- a/cla_public/templates/macros/element.html
+++ b/cla_public/templates/macros/element.html
@@ -98,8 +98,8 @@
 #}
 
 {% macro staying_safe_online_link() %}
-  <p id="aria-staying-safe-online">
-    {%- set link=link_new_window(url_for('base.online_safety'), 'Staying safe online') -%}
+  <p class="govuk-body" id="aria-staying-safe-online">
+    {%- set link=link_same_window(url_for('base.online_safety'), 'staying safe online') -%}
     {%- trans -%}The information you enter won’t be stored on this device. Find out more about {{ link }}.{%- endtrans -%}
   </p>
 {% endmacro %}
@@ -116,38 +116,29 @@
     title="{{ _('Opens in new window') }}"
     {% if kwargs %}
       {% for attr in kwargs %}
-        {% if attr == 'class' %}
-          {% if kwargs[attr].startswith('govuk-button') %}
-            role="button"
-            class="govuk-link {{ kwargs[attr] }}"
-          {% endif %}
-        {% else %}
-          class="govuk-link"
-        {{ attr }}="{{ kwargs[attr] }}"
+        {% if attr == 'class' and kwargs[attr].startswith('govuk-button') %}
+          role="button"
+          class="govuk-link {{ kwargs[attr] }}"
+          {{ attr }}="{{ kwargs[attr] }}"
         {% endif %}
-     {% endfor %}
+      {% endfor %}
     {% endif %}
-  >
-    {{ _(text) }}
-    <span class="govuk-visually-hidden"> {{ _('Opens in new window') }}</span></a>
+    class="govuk-link"
+  >{{ _(text) }}<span class="govuk-visually-hidden"> {{ _('Opens in new window') }}</span></a>
 {%- endmacro %}
 
 {% macro link_same_window(url, text, is_external=False) %}
   <a href="{{ url }}"
-    class="govuk-link"
     {% if is_external %} rel="external"{% endif %}
     {% if kwargs %}
       {% for attr in kwargs %}
-        {{ attr }}="{{ kwargs[attr] }}"
-        {% if attr == 'class' %}
-          {% if kwargs[attr].startswith('govuk-button') %}
-            role="button"
-          {% endif %}
-        {% else %}
-          class="govuk-link"
+        {% if attr == 'class' and kwargs[attr].startswith('govuk-button') %}
+          role="button"
+          class="govuk-link {{ kwargs[attr] }}"
+          {{ attr }}="{{ kwargs[attr] }}"
         {% endif %}
       {% endfor %}
     {% endif %}
-  >
-    {{ _(text) }}
+    class="govuk-link"
+  >{{ _(text) }}</a>
 {%- endmacro %}

--- a/cla_public/templates/macros/element.html
+++ b/cla_public/templates/macros/element.html
@@ -111,17 +111,43 @@
 
 {% macro link_new_window(url, text, is_external=False) %}
   <a href="{{ url }}"
-     class="govuk-link"
-     {% if is_external %} rel="external"{% endif %}
-     target="_blank"
-     title="{{ _('Opens in new window') }}"
-     {% if kwargs %}
-       {% for attr in kwargs %}
-         {{ attr }}="{{ kwargs[attr] }}"
-         {% if attr == 'class' and kwargs[attr].startswith('button') %}role="button"{% endif %}
-       {% endfor %}
-     {% endif %}
+    {% if is_external %} rel="external"{% endif %}
+    target="_blank"
+    title="{{ _('Opens in new window') }}"
+    {% if kwargs %}
+      {% for attr in kwargs %}
+        {% if attr == 'class' %}
+          {% if kwargs[attr].startswith('govuk-button') %}
+            role="button"
+            class="govuk-link {{ kwargs[attr] }}"
+          {% endif %}
+        {% else %}
+          class="govuk-link"
+        {{ attr }}="{{ kwargs[attr] }}"
+        {% endif %}
+     {% endfor %}
+    {% endif %}
   >
     {{ _(text) }}
     <span class="govuk-visually-hidden"> {{ _('Opens in new window') }}</span></a>
+{%- endmacro %}
+
+{% macro link_same_window(url, text, is_external=False) %}
+  <a href="{{ url }}"
+    class="govuk-link"
+    {% if is_external %} rel="external"{% endif %}
+    {% if kwargs %}
+      {% for attr in kwargs %}
+        {{ attr }}="{{ kwargs[attr] }}"
+        {% if attr == 'class' %}
+          {% if kwargs[attr].startswith('govuk-button') %}
+            role="button"
+          {% endif %}
+        {% else %}
+          class="govuk-link"
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  >
+    {{ _(text) }}
 {%- endmacro %}

--- a/cla_public/templates/macros/help-orgs.html
+++ b/cla_public/templates/macros/help-orgs.html
@@ -16,11 +16,11 @@
       {% if caller %}
         {{ caller() }}
       {% else %}
-        <h2>
+        <h2 class="govuk-heading-l">
           {{ _('Help organisations for problems about %(category_name)s',
             category_name=category_name|lower) }}
         </h2>
-        <p>
+        <p class="govuk-body">
           {{ _('You may still get help and advice from the organisations listed
             below. You don’t have to qualify for legal aid.') }}
         </p>
@@ -29,7 +29,9 @@
       {{ org_list(organisations, category_name) }}
     {% else %}
       {% call Element.alert() %}
-        <p>{{ _('There has been a problem with listing help organisations. Please refresh this page or try again later.') }}</p>
+        <p class="govuk-body">
+          {{ _('There has been a problem with listing help organisations. Please refresh this page or try again later.') }}
+        </p>
       {% endcall %}
     {% endif %}
   </div>
@@ -47,9 +49,9 @@
   <ul class="org-list">
     {% for org in organisations %}
       <li class="vcard {{ org.classname }}">
-        <h3>
+        <h3 class="govuk-heading-m">
           {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', org.service_name) %}
-          {{ Element.link_new_window(org.website, org.service_name, is_external=True, **{'class': 'url', 'data-ga': ga_event}) }}
+          {{ Element.link_same_window(org.website, org.service_name, is_external=True, **{'class': 'url', 'data-ga': ga_event}) }}
         </h3>
         {% if org.public_description %}
           <div class="org-description">

--- a/cla_public/templates/scope/ineligible.html
+++ b/cla_public/templates/scope/ineligible.html
@@ -21,14 +21,14 @@
 
       <p class="govuk-body">
         {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'ask a legal adviser') %}
-        {% trans ask_legal_adviser_link=Element.link_new_window('http://find-legal-advice.justice.gov.uk/', _('ask a legal adviser'), True, **{'data-ga': ga_event}) %}
+        {% trans ask_legal_adviser_link=Element.link_same_window('http://find-legal-advice.justice.gov.uk/', _('ask a legal adviser'), True, **{'data-ga': ga_event}) %}
           You can {{ ask_legal_adviser_link }} if an application might succeed in your case and how to apply.
         {% endtrans %}
       </p>
 
       <p class="govuk-body">
         {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'apply directly') %}
-        {% trans apply_directly_link=Element.link_new_window('https://www.gov.uk/legal-aid-apply-for-exceptional-case-funding', _('apply directly'), True, **{'data-ga': ga_event}) %}
+        {% trans apply_directly_link=Element.link_same_window('https://www.gov.uk/legal-aid-apply-for-exceptional-case-funding', _('apply directly'), True, **{'data-ga': ga_event}) %}
           You can also {{ apply_directly_link }} to the Legal Aid Agency.
         {% endtrans %}
       </p>
@@ -53,7 +53,7 @@
 
   <p class="govuk-body">
     {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'Find a solicitor') %}
-    {{ Element.link_new_window('https://www.gov.uk/find-a-legal-adviser', _('Find a solicitor'), **{'class': 'govuk-button', 'data-ga': ga_event}) }}
+    {{ Element.link_same_window('https://www.gov.uk/find-a-legal-adviser', _('Find a solicitor'), **{'class': 'govuk-button', 'data-ga': ga_event}) }}
   </p>
 
   <p class="govuk-body">

--- a/cla_public/templates/scope/ineligible.html
+++ b/cla_public/templates/scope/ineligible.html
@@ -53,7 +53,7 @@
 
   <p class="govuk-body">
     {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'Find a solicitor') %}
-    {{ Element.link_new_window('https://www.gov.uk/find-a-legal-adviser', _('Find a solicitor'), **{'class': 'button', 'data-ga': ga_event}) }}
+    {{ Element.link_new_window('https://www.gov.uk/find-a-legal-adviser', _('Find a solicitor'), **{'class': 'govuk-button', 'data-ga': ga_event}) }}
   </p>
 
   <p class="govuk-body">

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -1411,6 +1411,10 @@ msgstr "Dangos {count} mwy"
 msgid "Staying safe online"
 msgstr "Cadw’n ddiogel ar-lein"
 
+#: cla_public/templates/element.html:102
+msgid "staying safe online"
+msgstr "cadw’n ddiogel ar-lein"
+
 #: cla_public/templates/base.html:156
 msgid "Privacy Policy"
 msgstr "Polisi preifatrwydd"

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -1407,6 +1407,10 @@ msgstr ""
 msgid "Staying safe online"
 msgstr ""
 
+#: cla_public/templates/element.html:102
+msgid "staying safe online"
+msgstr ""
+
 #: cla_public/templates/base.html:156
 msgid "Privacy Policy"
 msgstr ""


### PR DESCRIPTION
## What does this pull request do?

Stopped links opening in new tabs by writing another macro `link_same_window()`.  

## Any other changes that would benefit highlighting?

Kept old `link_new_window()` macro to be used if needed in future.
Removed newline from macro to remove trailing space from link when on page.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
