### PR TITLE
LGA-1082 quick escape button

### DIFF
--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -271,3 +271,27 @@ dl.govuk-list.govuk-list--bullet {
 .js-enabled .no-js-hide-inline-block {
   display: inline-block;
 }
+
+.js-enabled .laa-flee-button-container {
+  display:block;
+  float: right;
+  
+  .laa-flee-button-position {
+    position: fixed;
+    z-index:1000;
+    
+    .laa-flee-button {
+      width:100%;
+    }
+  }
+  
+  .laa-flee-button-sizing,
+  .exit-info-sizing {
+    visibility:hidden;
+  }
+}
+
+
+.laa-flee-button-container {
+  display:none;
+}

--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -272,25 +272,51 @@ dl.govuk-list.govuk-list--bullet {
   display: inline-block;
 }
 
-.js-enabled .laa-flee-button-container {
-  display:block;
-  float: right;
-  
-  .laa-flee-button-position {
-    position: fixed;
-    z-index:1000;
-    
-    .laa-flee-button {
-      width:100%;
+@media only screen {
+  .js-enabled .laa-flee-button-container {
+    display:block;
+    float: right;
+
+    .laa-flee-button-position {
+      position: fixed;
+      z-index:1000;
+
+      .laa-flee-button {
+        width:100%;
+      }
+
+      .laa-quick-exit-info {
+        text-align:center;
+      }
     }
-  }
-  
-  .laa-flee-button-sizing,
-  .exit-info-sizing {
-    visibility:hidden;
+
+    .laa-flee-button-sizing,
+    .exit-info-sizing {
+      visibility:hidden;
+    }
   }
 }
 
+@media only screen and (max-width: 640px) {
+  footer.govuk-footer {
+    padding-bottom: 95px;
+  }
+  .js-enabled .laa-flee-button-container {
+    float: none;
+
+    .laa-flee-button-position {
+      bottom: 0;
+      width: 100vw;
+      left: 0;
+      background: govuk-colour("light-grey");
+    }
+
+    .laa-flee-button-sizing,
+    .exit-info-sizing {
+      display:none;
+    }
+  }
+}
 
 .laa-flee-button-container {
   display:none;

--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -273,7 +273,7 @@ dl.govuk-list.govuk-list--bullet {
 }
 
 @media only screen {
-  .js-enabled .laa-flee-button-container {
+  .js-enabled .laa-flee-button-container.laa-fee-button-enabled {
     display:block;
     float: right;
 
@@ -301,7 +301,7 @@ dl.govuk-list.govuk-list--bullet {
   footer.govuk-footer {
     padding-bottom: 95px;
   }
-  .js-enabled .laa-flee-button-container {
+  .js-enabled .laa-flee-button-container.laa-fee-button-enabled {
     float: none;
 
     .laa-flee-button-position {

--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -295,6 +295,10 @@ dl.govuk-list.govuk-list--bullet {
     .exit-info-sizing {
       visibility:hidden;
     }
+
+    .laa-explanation-long {
+      display:inline;
+    }
   }
 }
 
@@ -321,7 +325,16 @@ dl.govuk-list.govuk-list--bullet {
     .exit-info-sizing {
       display:none;
     }
+
+    .laa-explanation-short {
+      display:inline;
+    }
   }
+}
+
+.laa-explanation-long,
+.laa-explanation-short {
+  display:none;
 }
 
 .laa-flee-button-container {

--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -280,6 +280,7 @@ dl.govuk-list.govuk-list--bullet {
     .laa-flee-button-position {
       position: fixed;
       z-index:1000;
+      background-color:govuk-colour("white");
 
       .laa-flee-button {
         width:100%;

--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -316,6 +316,11 @@ dl.govuk-list.govuk-list--bullet {
     .exit-info-sizing {
       display:none;
     }
+    
+    .laa-quick-exit-info,
+    .exit-info-sizing {
+      display:none;
+    }
   }
 }
 

--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -295,10 +295,6 @@ dl.govuk-list.govuk-list--bullet {
     .exit-info-sizing {
       visibility:hidden;
     }
-
-    .laa-explanation-long {
-      display:inline;
-    }
   }
 }
 
@@ -321,6 +317,7 @@ dl.govuk-list.govuk-list--bullet {
       display:none;
     }
     
+    .laa-explanation-long,
     .laa-quick-exit-info,
     .exit-info-sizing {
       display:none;
@@ -332,7 +329,6 @@ dl.govuk-list.govuk-list--bullet {
   }
 }
 
-.laa-explanation-long,
 .laa-explanation-short {
   display:none;
 }

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -124,7 +124,7 @@
       $(".laa-flee-button-container").addClass("laa-fee-button-enabled");
     }
 
-    function flee() {
+    function fleeFromPage() {
       $("body").hide();
       {#
         The below are all other possibilities but not necessarily the best approach. 
@@ -138,13 +138,13 @@
       window.location.replace("http://www.google.co.uk");
     }
     $("#quick-exit").on("click", function() {
-      flee();
       ga('moj-send', 'event', 'quick-exit', 'Mouse-click');
+      fleeFromPage();
     });
     $(document).keyup(function(e) {
       if (e.keyCode == 27) { // escape key
-        flee();
         ga('moj-send', 'event', 'quick-exit', 'Escape-key');
+        fleeFromPage();
       }
     });
 

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -53,16 +53,16 @@
       {% endfor %}
     {% endif %}
   {% endif %}
-  <div class="laa-flee-button-container" style="float:right;">
+  <div class="laa-flee-button-container">
     <div class="laa-flee-button-position">
-      <button id="quick-exit" class="govuk-button govuk-button--warning laa-flee-button">
+      <button id="quick-exit" class="govuk-button govuk-button--warning govuk-!-margin-bottom-2 laa-flee-button">
         {{ _('Quick exit') }}
       </button>
-      <p class="exit-info govuk-body-s govuk-!-font-size-14">
+      <p class="laa-quick-exit-info govuk-body-s govuk-!-font-size-14">
         {{ _('Click to hide this page') }}
       </p>
     </div>
-    <button class="govuk-button govuk-button--warning laa-flee-button-sizing" style="visibility: hidden;">
+    <button class="govuk-button govuk-button--warning govuk-!-margin-bottom-2 laa-flee-button-sizing" style="visibility: hidden;">
       {{ _('Quick exit') }}
     </button>
     <p class="govuk-body-s govuk-!-font-size-14 exit-info-sizing" style="visibility: hidden;">
@@ -102,8 +102,9 @@
 {% block javascripts %}
   <script>
   $("#quick-exit").on("click", function() {
+    $("body").hide();
     window.open("http://bbc.co.uk/weather", "_newtab");
-    window.location.replace('http://regia.org');
+    window.location.replace("http://www.google.co.uk");
   });
   
     /* Modernizr 2.8.3 (Custom Build) | MIT & BSD

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -54,7 +54,10 @@
     {% endif %}
   {% endif %}
   <div class="laa-flee-button-container
-    {% if 'n43n3' in session.checker.diagnosis_previous_choices %}
+    {%  if 'n43n3' in session.checker.diagnosis_previous_choices or 
+        if 'n86' in session.checker.diagnosis_previous_choices or
+        if 'n88' in session.checker.diagnosis_previous_choices
+    %}
       laa-fee-button-enabled
     {% endif %}
     ">

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -122,14 +122,6 @@
 
     function fleeFromPage() {
       $("body").hide();
-      {#
-        The below are all other possibilities but not necessarily the best approach. 
-
-        var histLength = history.length;
-        window.history.go(-histLength);
-        history.pushState({page: 1}, "Cookies", "/cookies")
-        history.pushState({page: 2}, "Bank Holidays in the UK", "/bank-holidays")
-      #}
       window.open("http://bbc.co.uk/weather", "_newtab");
       window.location.replace("http://www.google.co.uk");
     }

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -56,6 +56,9 @@
   <div class="laa-flee-button-container
     {% if ('n43n3' in session.checker.diagnosis_previous_choices) or
         ('n86' in session.checker.diagnosis_previous_choices) or
+        ('n149' in session.checker.diagnosis_previous_choices) or
+        ('n18' in session.checker.diagnosis_previous_choices) or
+        ('n19' in session.checker.diagnosis_previous_choices) or
         ('n88' in session.checker.diagnosis_previous_choices)
     %}
       laa-fee-button-enabled
@@ -114,7 +117,7 @@
   <script>
 
     var currentLocation = window.location.href;
-    if (currentLocation.indexOf("n43n3") > 0 || currentLocation.indexOf("n43n14/n97") > 0) {
+    if (currentLocation.indexOf("n43n3") > 0 || currentLocation.indexOf("n43n14/n97") > 0 || currentLocation.indexOf("n88") > 0 || currentLocation.indexOf("n149") > 0 || currentLocation.indexOf("n86") > 0) {
       $(".laa-flee-button-container").addClass("laa-fee-button-enabled");
     }
 

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -138,12 +138,12 @@
     }
     $("#quick-exit").on("click", function() {
       flee();
-      ga('send', 'event', 'quick-exit', 'Mouse click');
+      ga('send', 'event', 'quick-exit', 'Mouse-click');
     });
     $(document).keyup(function(e) {
       if (e.keyCode == 27) { // escape key
         flee();
-        ga('send', 'event', 'quick-exit', 'Esc key');
+        ga('send', 'event', 'quick-exit', 'Escape-key');
       }
     });
 

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -105,6 +105,12 @@
 
 {% block javascripts %}
   <script>
+
+    var currentLocation = window.location.href;
+    if (currentLocation.indexOf("n43n3") > 0 || currentLocation.indexOf("n43n14/n97") > 0) {
+      $(".laa-flee-button-container").addClass("laa-fee-button-enabled");
+    }
+
     function flee() {
       $("body").hide();
       {#

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -57,16 +57,20 @@
     <div class="laa-flee-button-position">
       <button id="quick-exit" class="govuk-button govuk-button--warning govuk-!-margin-bottom-2 laa-flee-button">
         {{ _('Quick exit') }}
+        <br />
+        <span class="govuk-!-font-size-14">{{ _('Click to hide this page') }}</span>
       </button>
       <p class="laa-quick-exit-info govuk-body-s govuk-!-font-size-14">
-        {{ _('Click to hide this page') }}
+        ({{ _('Or press Esc key') }})
       </p>
     </div>
     <button class="govuk-button govuk-button--warning govuk-!-margin-bottom-2 laa-flee-button-sizing" style="visibility: hidden;">
       {{ _('Quick exit') }}
+        <br />
+      <span class="govuk-!-font-size-14">{{ _('Click to hide this page') }}</span>
     </button>
     <p class="govuk-body-s govuk-!-font-size-14 exit-info-sizing" style="visibility: hidden;">
-      {{ _('Click to hide this page') }}
+      {{ _('Or press Esc key') }}
     </p>
     <!-- identical with above to space out.-->
 
@@ -101,12 +105,20 @@
 
 {% block javascripts %}
   <script>
-  $("#quick-exit").on("click", function() {
-    $("body").hide();
-    window.open("http://bbc.co.uk/weather", "_newtab");
-    window.location.replace("http://www.google.co.uk");
-  });
-  
+    function flee() {
+      $("body").hide();
+      window.open("http://bbc.co.uk/weather", "_newtab");
+      window.location.replace("http://www.google.co.uk");
+    }
+    $("#quick-exit").on("click", function() {
+      flee();
+    });
+    $(document).keyup(function(e) {
+      if (e.keyCode == 27) { // escape key
+        flee();
+      }
+    });
+
     /* Modernizr 2.8.3 (Custom Build) | MIT & BSD
      * Build: http://modernizr.com/download/#-mq-teststyles
      */

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -54,9 +54,9 @@
     {% endif %}
   {% endif %}
   <div class="laa-flee-button-container
-    {%  if 'n43n3' in session.checker.diagnosis_previous_choices or 
-        if 'n86' in session.checker.diagnosis_previous_choices or
-        if 'n88' in session.checker.diagnosis_previous_choices
+    {% if ('n43n3' in session.checker.diagnosis_previous_choices) or
+        ('n86' in session.checker.diagnosis_previous_choices) or
+        ('n88' in session.checker.diagnosis_previous_choices)
     %}
       laa-fee-button-enabled
     {% endif %}

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -68,7 +68,8 @@
       <button id="quick-exit" class="govuk-button govuk-button--warning govuk-!-margin-bottom-2 laa-flee-button">
         <strong>{{ _('Quick exit') }}</strong>
         <br />
-        <span class="govuk-!-font-size-14">{{ _('Click to hide this page') }}</span>
+        <span class="govuk-!-font-size-14 laa-explanation-long">{{ _('Click to hide this page') }}</span>
+        <span class="govuk-!-font-size-14 laa-explanation-short">{{ _('Hide this page') }}</span>
       </button>
       <p class="laa-quick-exit-info govuk-body-s govuk-!-font-size-14">
         ({{ _('Or press Esc key') }})
@@ -77,7 +78,8 @@
     <button class="govuk-button govuk-button--warning govuk-!-margin-bottom-2 laa-flee-button-sizing" style="visibility: hidden;">
       <strong>{{ _('Quick exit') }}</strong>
       <br />
-      <span class="govuk-!-font-size-14">{{ _('Click to hide this page') }}</span>
+      <span class="govuk-!-font-size-14 laa-explanation-long">{{ _('Click to hide this page') }}</span>
+      <span class="govuk-!-font-size-14 laa-explanation-short">{{ _('Hide this page') }}</span>
     </button>
     <p class="govuk-body-s govuk-!-font-size-14 exit-info-sizing" style="visibility: hidden;">
       {{ _('Or press Esc key') }}
@@ -136,10 +138,12 @@
     }
     $("#quick-exit").on("click", function() {
       flee();
+      ga('send', 'event', 'quick-exit', 'Mouse click');
     });
     $(document).keyup(function(e) {
       if (e.keyCode == 27) { // escape key
         flee();
+        ga('send', 'event', 'quick-exit', 'Esc key');
       }
     });
 

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -119,10 +119,10 @@
 {% block javascripts %}
   <script>
 
-    var currentLocation = window.location.href;
-    if (currentLocation.indexOf("n43n3") > 0 || currentLocation.indexOf("n43n14/n97") > 0 || currentLocation.indexOf("n88") > 0 || currentLocation.indexOf("n149") > 0 || currentLocation.indexOf("n86") > 0) {
-      $(".laa-flee-button-container").addClass("laa-fee-button-enabled");
-    }
+  //  var currentLocation = window.location.href;
+  //  if (currentLocation.indexOf("n43n3") > 0 || currentLocation.indexOf("n43n14/n97") > 0 || currentLocation.indexOf("n88") > 0 || currentLocation.indexOf("n149") > 0 || currentLocation.indexOf("n86") > 0) {
+  //    $(".laa-flee-button-container").addClass("laa-fee-button-enabled");
+  //  }
 
     function fleeFromPage() {
       $("body").hide();

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -70,6 +70,7 @@
         <br />
         <span class="govuk-!-font-size-14 laa-explanation-long">{{ _('Click to hide this page') }}</span>
         <span class="govuk-!-font-size-14 laa-explanation-short">{{ _('Hide this page') }}</span>
+        <span class="govuk-visually-hidden">{{ _('Or press escape key to hide this page') }}</span>
       </button>
       <p class="laa-quick-exit-info govuk-body-s govuk-!-font-size-14">
         ({{ _('Or press Esc key') }})

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -138,12 +138,12 @@
     }
     $("#quick-exit").on("click", function() {
       flee();
-      ga('send', 'event', 'quick-exit', 'Mouse-click');
+      ga('moj-send', 'event', 'quick-exit', 'Mouse-click');
     });
     $(document).keyup(function(e) {
       if (e.keyCode == 27) { // escape key
         flee();
-        ga('send', 'event', 'quick-exit', 'Escape-key');
+        ga('moj-send', 'event', 'quick-exit', 'Escape-key');
       }
     });
 

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -53,7 +53,11 @@
       {% endfor %}
     {% endif %}
   {% endif %}
-  <div class="laa-flee-button-container">
+  <div class="laa-flee-button-container
+    {% if 'n43n3' in session.checker.diagnosis_previous_choices %}
+      laa-fee-button-enabled
+    {% endif %}
+    ">
     <div class="laa-flee-button-position">
       <button id="quick-exit" class="govuk-button govuk-button--warning govuk-!-margin-bottom-2 laa-flee-button">
         <strong>{{ _('Quick exit') }}</strong>

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -53,7 +53,24 @@
       {% endfor %}
     {% endif %}
   {% endif %}
+  <div class="laa-flee-button-container" style="float:right;">
+    <div class="laa-flee-button-position">
+      <button id="quick-exit" class="govuk-button govuk-button--warning laa-flee-button">
+        {{ _('Quick exit') }}
+      </button>
+      <p class="exit-info govuk-body-s govuk-!-font-size-14">
+        {{ _('Click to hide this page') }}
+      </p>
+    </div>
+    <button class="govuk-button govuk-button--warning laa-flee-button-sizing" style="visibility: hidden;">
+      {{ _('Quick exit') }}
+    </button>
+    <p class="govuk-body-s govuk-!-font-size-14 exit-info-sizing" style="visibility: hidden;">
+      {{ _('Click to hide this page') }}
+    </p>
+    <!-- identical with above to space out.-->
 
+  </div>
   <main class="govuk-main-wrapper " id="main-content" role="main" lang="{{ request.cookies.get('locale', 'en')[:2] }}">
     <div class="govuk-grid-row">
         {% with flash_messages = get_flashed_messages() %}
@@ -84,6 +101,11 @@
 
 {% block javascripts %}
   <script>
+  $("#quick-exit").on("click", function() {
+    window.open("http://bbc.co.uk/weather", "_newtab");
+    window.location.replace('http://regia.org');
+  });
+  
     /* Modernizr 2.8.3 (Custom Build) | MIT & BSD
      * Build: http://modernizr.com/download/#-mq-teststyles
      */

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -56,7 +56,7 @@
   <div class="laa-flee-button-container">
     <div class="laa-flee-button-position">
       <button id="quick-exit" class="govuk-button govuk-button--warning govuk-!-margin-bottom-2 laa-flee-button">
-        {{ _('Quick exit') }}
+        <strong>{{ _('Quick exit') }}</strong>
         <br />
         <span class="govuk-!-font-size-14">{{ _('Click to hide this page') }}</span>
       </button>
@@ -65,8 +65,8 @@
       </p>
     </div>
     <button class="govuk-button govuk-button--warning govuk-!-margin-bottom-2 laa-flee-button-sizing" style="visibility: hidden;">
-      {{ _('Quick exit') }}
-        <br />
+      <strong>{{ _('Quick exit') }}</strong>
+      <br />
       <span class="govuk-!-font-size-14">{{ _('Click to hide this page') }}</span>
     </button>
     <p class="govuk-body-s govuk-!-font-size-14 exit-info-sizing" style="visibility: hidden;">
@@ -107,6 +107,14 @@
   <script>
     function flee() {
       $("body").hide();
+      {#
+        The below are all other possibilities but not necessarily the best approach. 
+
+        var histLength = history.length;
+        window.history.go(-histLength);
+        history.pushState({page: 1}, "Cookies", "/cookies")
+        history.pushState({page: 2}, "Bank Holidays in the UK", "/bank-holidays")
+      #}
       window.open("http://bbc.co.uk/weather", "_newtab");
       window.location.replace("http://www.google.co.uk");
     }

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -55,6 +55,7 @@
   {% endif %}
   <div class="laa-flee-button-container
     {% if ('n43n3' in session.checker.diagnosis_previous_choices) or
+        ('n97' in session.checker.diagnosis_previous_choices) or
         ('n86' in session.checker.diagnosis_previous_choices) or
         ('n149' in session.checker.diagnosis_previous_choices) or
         ('n18' in session.checker.diagnosis_previous_choices) or
@@ -118,11 +119,6 @@
 
 {% block javascripts %}
   <script>
-
-  //  var currentLocation = window.location.href;
-  //  if (currentLocation.indexOf("n43n3") > 0 || currentLocation.indexOf("n43n14/n97") > 0 || currentLocation.indexOf("n88") > 0 || currentLocation.indexOf("n149") > 0 || currentLocation.indexOf("n86") > 0) {
-  //    $(".laa-flee-button-container").addClass("laa-fee-button-enabled");
-  //  }
 
     function fleeFromPage() {
       $("body").hide();


### PR DESCRIPTION
## What does this pull request do?

Adds a quick escape button to the service for certain routes:
- Javascript only
- When displayed, always visible
- Fires of a GA function
- Replaces current tab with google and opens BBC weather in a new tab

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
