### PR TITLE
LGA-1074 Amended CSS for currency input

### DIFF
--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -190,6 +190,9 @@ hr {
 
   .govuk-input{
     padding-left:1.35em;
+    background: transparent;
+    position: relative;
+    z-index: 1;
   }
 }
 .laa-currency-prefix {


### PR DESCRIPTION
## What does this pull request do?

Changed the CSS so the input box was "above" the £ sign and so was receiving the focus when the pound sign was clicked on.  

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
