### PR TITLE
LGA-1123 changed text number back to 80010 from 78900

### DIFF
--- a/cla_public/templates/errors/5xx.html
+++ b/cla_public/templates/errors/5xx.html
@@ -21,7 +21,7 @@
     </p>
     <p class="govuk-body">
       If you are worried about the cost, you can request a call-back within 24 hours by either calling the helpline
-      or texting 'legal aid' and your name to <strong class="govuk-!-font-weight-bold">78900</strong>. {% endtrans %}
+      or texting 'legal aid' and your name to <strong class="govuk-!-font-weight-bold">80010</strong>. {% endtrans %}
     </p>
   </div>
   <p class="govuk-body">{{ _('Opening times:') }}<br />

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -3562,8 +3562,8 @@ msgid ""
 "    </p>\n"
 "    <p class=\"govuk-body\">\n"
 "      If you are worried about the cost, you can request a call-back within 24 hours by either calling the helpline\n"
-"      or texting 'legal aid' and your name to <strong class=\"govuk-!-font-weight-bold\">78900</strong>. "
-msgstr "Bydd galwadau yn costio oddeutu 9c y funud o linell dir. Bydd galwadau o ffonau symudol yn costio mwy fel arfer. </p><p class=\"govuk-body\">Os ydych yn pryderu am y gost, gallwch wneud cais i aelod o staff eich ffonio yn ôl o fewn 24 awr, un ai trwy ffonio’r llinell gymorth neu drwy anfon neges destun gyda’r geiriau ‘legal aid’ a’ch enw i <strong class=\"govuk-!-font-weight-bold\">78900</strong>."
+"      or texting 'legal aid' and your name to <strong class=\"govuk-!-font-weight-bold\">80010</strong>. "
+msgstr "Bydd galwadau yn costio oddeutu 9c y funud o linell dir. Bydd galwadau o ffonau symudol yn costio mwy fel arfer. </p><p class=\"govuk-body\">Os ydych yn pryderu am y gost, gallwch wneud cais i aelod o staff eich ffonio yn ôl o fewn 24 awr, un ai trwy ffonio’r llinell gymorth neu drwy anfon neges destun gyda’r geiriau ‘legal aid’ a’ch enw i <strong class=\"govuk-!-font-weight-bold\">80010</strong>."
 
 #: cla_public/templates/errors/5xx.html:27
 msgid "Opening times:"
@@ -3914,7 +3914,7 @@ msgstr "Dewch o hyd i’ch cyfryngwr lleol"
 #~ msgid "Minicom: 0345 609 6677"
 #~ msgstr "Os byddwch chi’n gymwys i gael cyngor gan un o Arbenigwyr CLA, bydd angen hefyd iddo gadw data personol ychwanegol amdanoch chi yn ei System Trafod Achosion ei hun.  Rhaid cadw digon o ddata o’r fath i gyfiawnhau darparu cyngor drwy gymorth cyfreithiol ac i gwrdd â gofynion proffesiynol."
 
-#~ msgid "Or text <strong>legalaid</strong> and your name to 78900."
+#~ msgid "Or text <strong>legalaid</strong> and your name to 80010."
 #~ msgstr "Cyn i chi gysylltu â Chyngor Cyfreithiol Sifil"
 
 #~ msgid "Find out about call charges here"
@@ -3942,7 +3942,7 @@ msgstr "Dewch o hyd i’ch cyfryngwr lleol"
 #~ msgstr "Minicom: 0345 609 6677"
 
 #~ msgid "Help organisations"
-#~ msgstr "Neu anfonwch neges destun a’ch enw i 78900."
+#~ msgstr "Neu anfonwch neges destun a’ch enw i 80010."
 
 #~ msgid "you and your partner"
 #~ msgstr "Beth oeddech chi’n feddwl o’r gwasanaeth hwn? "

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -3557,7 +3557,7 @@ msgid ""
 "    </p>\n"
 "    <p class=\"govuk-body\">\n"
 "      If you are worried about the cost, you can request a call-back within 24 hours by either calling the helpline\n"
-"      or texting 'legal aid' and your name to <strong class=\"govuk-!-font-weight-bold\">78900</strong>. "
+"      or texting 'legal aid' and your name to <strong class=\"govuk-!-font-weight-bold\">80010</strong>. "
 msgstr ""
 
 #: cla_public/templates/errors/5xx.html:27
@@ -3907,7 +3907,7 @@ msgstr ""
 #~ msgid "Minicom: 0345 609 6677"
 #~ msgstr ""
 
-#~ msgid "Or text <strong>legalaid</strong> and your name to 78900."
+#~ msgid "Or text <strong>legalaid</strong> and your name to 80010."
 #~ msgstr ""
 
 #~ msgid "Find out about call charges here"


### PR DESCRIPTION
## What does this pull request do?

Changes all instances of the number 78900 back to 80010.  
This reverts [PR 932](https://github.com/ministryofjustice/cla_public/pull/932/files).  

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
