### PR TITLE
LGA-1085 - Helm deploys for staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  slack: circleci/slack@2.5.0
+  slack: circleci/slack@3.4.2
 
 jobs:
   build:
@@ -158,6 +158,54 @@ jobs:
           command: .circleci/deploy_to_kubernetes staging
       - slack/status
 
+  staging_deploy_helm:
+    docker:
+      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+    steps:
+      - checkout
+      - run:
+          name: Install helm v3
+          command: |
+            wget https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz
+            tar -zxvf helm-v3.1.2-linux-amd64.tar.gz
+            mv linux-amd64/helm /usr/local/bin/helm
+      - run:
+          name: Initialise Kubernetes staging context
+          command: |
+            setup-kube-auth
+            kubectl config use-context staging
+      - deploy:
+          name: Deploy laa-cla-public to staging
+          command: |
+            source .circleci/define_build_environment_variables
+            ./bin/staging_deploy.sh
+            echo "export RELEASE_HOST=$RELEASE_HOST" >> $BASH_ENV
+      - slack/notify:
+          message: ':tada: Deployed branch $CIRCLE_BRANCH'
+          title: '$RELEASE_HOST'
+          title_link: 'https://$RELEASE_HOST/start/'
+
+  cleanup_merged:
+    docker:
+      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+    steps:
+      - checkout
+      - run:
+          name: Install helm v3
+          command: |
+            wget https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz
+            tar -zxvf helm-v3.1.2-linux-amd64.tar.gz
+            mv linux-amd64/helm /usr/local/bin/helm
+      - run:
+          name: Initialise Kubernetes staging context
+          command: |
+            setup-kube-auth
+            kubectl config use-context staging
+      - run:
+          name: Delete staging release
+          command: |
+            ./bin/delete_staging_release.sh
+
   production_deploy:
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
@@ -180,6 +228,8 @@ workflows:
       - lint-with-py2-tools
       - lint-with-py3-tools
       - test
+      - cleanup_merged:
+          context: laa-cla-public-live-1
       - build:
           requires:
             - lint-with-py2-tools
@@ -191,6 +241,10 @@ workflows:
           requires:
             - build
       - staging_deploy:
+          requires:
+            - staging_deploy_approval
+          context: laa-cla-public-live-1
+      - staging_deploy_helm:
           requires:
             - staging_deploy_approval
           context: laa-cla-public-live-1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,21 +144,6 @@ jobs:
           path: test-reports
 
   staging_deploy:
-    docker:
-      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
-    steps:
-      - checkout
-      - run:
-          name: Initialise Kubernetes staging context
-          command: |
-            setup-kube-auth
-            kubectl config use-context staging
-      - deploy:
-          name: Deploy laa-cla-public to staging
-          command: .circleci/deploy_to_kubernetes staging
-      - slack/status
-
-  staging_deploy_helm:
     parameters:
       multideploy:
         type: boolean
@@ -260,22 +245,15 @@ workflows:
           requires:
             - staging_deploy_approval
           context: laa-cla-public-live-1
-      - staging_deploy_helm_approval:
-          type: approval
-          requires:
-            - build
-      - staging_deploy_helm:
-          requires:
-            - staging_deploy_helm_approval
-          context: laa-cla-public-live-1
+          name: staging_deploy_master
           multideploy: false
           filters:
             branches:
               only:
                 - master
-      - staging_deploy_helm:
+      - staging_deploy:
           requires:
-            - staging_deploy_helm_approval
+            - staging_deploy_approval
           context: laa-cla-public-live-1
           multideploy: true
           filters:
@@ -285,7 +263,7 @@ workflows:
       - production_deploy_approval:
           type: approval
           requires:
-            - staging_deploy
+            - staging_deploy_master
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
       - slack/notify:
           message: ':tada: Deployed branch $CIRCLE_BRANCH'
           title: '$RELEASE_HOST'
-          title_link: 'https://$RELEASE_HOST/start/'
+          title_link: 'https://$RELEASE_HOST/start'
 
   cleanup_merged:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,20 +182,20 @@ jobs:
           condition: << parameters.multideploy >>
           steps:
             - deploy:
-              name: Deploy laa-cla-public to fixed staging
-              command: |
-                source .circleci/define_build_environment_variables
-                ./bin/staging_deploy.sh
-                echo "export RELEASE_HOST=$STAGING_HOST" >> $BASH_ENV
+                name: Deploy laa-cla-public to fixed staging
+                command: |
+                  source .circleci/define_build_environment_variables
+                  ./bin/staging_deploy.sh
+                  echo "export RELEASE_HOST=$STAGING_HOST" >> $BASH_ENV
       - when:
           condition: << parameters.multideploy >>
           steps:
             - deploy:
-              name: Deploy laa-cla-public to multideploy staging
-              command: |
-                source .circleci/define_build_environment_variables
-                ./bin/staging_multideploy.sh
-                echo "export RELEASE_HOST=$CLEANED_BRANCH_NAME.$STAGING_HOST" >> $BASH_ENV
+                name: Deploy laa-cla-public to multideploy staging
+                command: |
+                  source .circleci/define_build_environment_variables
+                  ./bin/staging_multideploy.sh
+                  echo "export RELEASE_HOST=$CLEANED_BRANCH_NAME.$STAGING_HOST" >> $BASH_ENV
       - slack/notify:
           message: ':tada: Deployed branch $CIRCLE_BRANCH'
           title: '$RELEASE_HOST'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ workflows:
           requires:
             - staging_deploy_helm_approval
           context: laa-cla-public-live-1
-          multideploy: true
+          multideploy: false
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ workflows:
           requires:
             - staging_deploy_helm_approval
           context: laa-cla-public-live-1
-          multideploy: false
+          multideploy: true
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,10 @@ jobs:
       - slack/status
 
   staging_deploy_helm:
+    parameters:
+      multideploy:
+        type: boolean
+        default: false
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
     steps:
@@ -174,12 +178,24 @@ jobs:
           command: |
             setup-kube-auth
             kubectl config use-context staging
-      - deploy:
-          name: Deploy laa-cla-public to staging
-          command: |
-            source .circleci/define_build_environment_variables
-            ./bin/staging_deploy.sh
-            echo "export RELEASE_HOST=$RELEASE_HOST" >> $BASH_ENV
+      - unless:
+          condition: << parameters.multideploy >>
+          steps:
+            - deploy:
+              name: Deploy laa-cla-public to fixed staging
+              command: |
+                source .circleci/define_build_environment_variables
+                ./bin/staging_deploy.sh
+                echo "export RELEASE_HOST=$STAGING_HOST" >> $BASH_ENV
+      - when:
+          condition: << parameters.multideploy >>
+          steps:
+            - deploy:
+              name: Deploy laa-cla-public to multideploy staging
+              command: |
+                source .circleci/define_build_environment_variables
+                ./bin/staging_multideploy.sh
+                echo "export RELEASE_HOST=$CLEANED_BRANCH_NAME.$STAGING_HOST" >> $BASH_ENV
       - slack/notify:
           message: ':tada: Deployed branch $CIRCLE_BRANCH'
           title: '$RELEASE_HOST'
@@ -252,6 +268,20 @@ workflows:
           requires:
             - staging_deploy_helm_approval
           context: laa-cla-public-live-1
+          multideploy: false
+          filters:
+            branches:
+              only:
+                - master
+      - staging_deploy_helm:
+          requires:
+            - staging_deploy_helm_approval
+          context: laa-cla-public-live-1
+          multideploy: true
+          filters:
+            branches:
+              ignore:
+                - master
       - production_deploy_approval:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,9 +244,13 @@ workflows:
           requires:
             - staging_deploy_approval
           context: laa-cla-public-live-1
+      - staging_deploy_helm_approval:
+          type: approval
+          requires:
+            - build
       - staging_deploy_helm:
           requires:
-            - staging_deploy_approval
+            - staging_deploy_helm_approval
           context: laa-cla-public-live-1
       - production_deploy_approval:
           type: approval

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -1,6 +1,11 @@
-#!/bin/bash -eu
-short_sha="$(git rev-parse --short=7 "$CIRCLE_SHA1")"
-export short_sha
+#!/bin/sh -eu
+export DOCKER_REPOSITORY="$ECR_DOCKER_REPOSITORY"
+
 export safe_git_branch=${CIRCLE_BRANCH//\//-}
-export deploy_image_and_tag="$ECR_DOCKER_IMAGE:$safe_git_branch.$short_sha"
-export ECR_DEPLOY_IMAGE="$ECR_DOCKER_REGISTRY/$deploy_image_and_tag"
+export short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
+export IMAGE_TAG="$safe_git_branch.$short_sha"
+export ECR_DEPLOY_IMAGE="$DOCKER_REPOSITORY/$IMAGE_TAG"
+
+export CLEANED_BRANCH_NAME=$(echo $CIRCLE_BRANCH | sed 's/^feature[-/]//' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-28 | sed 's/-$//')
+export RELEASE_NAME=${CLEANED_BRANCH_NAME}
+export RELEASE_HOST="$RELEASE_NAME-$STAGING_HOST"

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -4,6 +4,6 @@ export DOCKER_REPOSITORY="$ECR_DOCKER_REPOSITORY"
 export safe_git_branch=${CIRCLE_BRANCH//\//-}
 export short_sha="$(git rev-parse --short=7 $CIRCLE_SHA1)"
 export IMAGE_TAG="$safe_git_branch.$short_sha"
-export ECR_DEPLOY_IMAGE="$DOCKER_REPOSITORY/$IMAGE_TAG"
+export ECR_DEPLOY_IMAGE="$DOCKER_REPOSITORY:$IMAGE_TAG"
 
 export CLEANED_BRANCH_NAME=$(echo $CIRCLE_BRANCH | sed 's/^feature[-/]//' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-28 | sed 's/-$//')

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -7,10 +7,3 @@ export IMAGE_TAG="$safe_git_branch.$short_sha"
 export ECR_DEPLOY_IMAGE="$DOCKER_REPOSITORY/$IMAGE_TAG"
 
 export CLEANED_BRANCH_NAME=$(echo $CIRCLE_BRANCH | sed 's/^feature[-/]//' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-28 | sed 's/-$//')
-export RELEASE_NAME=${CLEANED_BRANCH_NAME}
-if [[ $RELEASE_NAME == "master" ]]
-then
-    export RELEASE_HOST="$PRODUCTION_HOST"
-else
-    export RELEASE_HOST="$RELEASE_NAME.$STAGING_HOST"
-fi

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -8,4 +8,9 @@ export ECR_DEPLOY_IMAGE="$DOCKER_REPOSITORY/$IMAGE_TAG"
 
 export CLEANED_BRANCH_NAME=$(echo $CIRCLE_BRANCH | sed 's/^feature[-/]//' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-28 | sed 's/-$//')
 export RELEASE_NAME=${CLEANED_BRANCH_NAME}
-export RELEASE_HOST="$RELEASE_NAME-$STAGING_HOST"
+if [[ $RELEASE_NAME == "master" ]]
+then
+    export RELEASE_HOST="$PRODUCTION_HOST"
+else
+    export RELEASE_HOST="$RELEASE_NAME.$STAGING_HOST"
+fi

--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -11,8 +11,9 @@ function tag_and_push() {
   docker push $tag
 }
 
+tag_and_push "$ECR_DOCKER_REPOSITORY:$safe_git_branch.$short_sha"
+tag_and_push "$ECR_DOCKER_REPOSITORY:$safe_git_branch"
+
 if [ "$CIRCLE_BRANCH" == "master" ]; then
-  tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$CIRCLE_SHA1"
+  tag_and_push "$ECR_DOCKER_REPOSITORY:latest"
 fi
-tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch"
-tag_and_push "$ECR_DEPLOY_IMAGE"

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,6 @@ dist
 build
 eggs
 parts
-bin
 var
 sdist
 develop-eggs

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ dist
 build
 eggs
 parts
-bin
 var
 sdist
 develop-eggs

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN apk add --no-cache \
       nasm \
       openssl-dev \
       python2-dev \
-      zlib-dev
+      zlib-dev \
+      curl
 
 RUN cp /usr/share/zoneinfo/Europe/London /etc/localtime
 RUN pip install -U setuptools pip==18.1 wheel

--- a/bin/delete_staging_release.sh
+++ b/bin/delete_staging_release.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+GIT_MESSAGE=$(git log --format=%B -n 1 $CIRCLE_SHA1)
+
+echo "git message is:"
+echo "$GIT_MESSAGE"
+
+if [[ $GIT_MESSAGE == "Merge pull request #"* ]]
+then
+  MERGED_BRANCH=$(echo $GIT_MESSAGE | sed -n "s/^.*from ministryofjustice\/\s*\(\S*\).*$/\1/p")
+  RELEASE_NAME=$(echo $MERGED_BRANCH | sed 's/^feature[-/]//' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-28 | sed 's/-$//')
+
+  echo "Attempting to delete release $RELEASE_NAME"
+
+  RELEASES=$(helm list --all)
+
+  echo "Current releases:"
+  echo "$RELEASES"
+
+  if [[ $RELEASES == *"$RELEASE_NAME"* ]]
+  then
+    echo "Deleting release $RELEASE_NAME"
+    helm delete $RELEASE_NAME
+  else
+    echo "Release $RELEASE_NAME was not found"
+  fi
+
+else
+  echo "This commit is not a merged pull request"
+fi

--- a/bin/local_deploy.sh
+++ b/bin/local_deploy.sh
@@ -4,6 +4,8 @@ set -e
 ROOT=$(dirname "$0")
 HELM_DIR="$ROOT/../helm_deploy/cla-public/"
 
+docker build -t cla_public_local "$ROOT/.."
+
 kubectl config use-context docker-for-desktop
 
 helm upgrade cla-public \

--- a/bin/local_deploy.sh
+++ b/bin/local_deploy.sh
@@ -9,4 +9,5 @@ kubectl config use-context docker-for-desktop
 helm upgrade cla-public \
   $HELM_DIR \
   --values ${HELM_DIR}/values-dev.yaml \
+  --force \
   --install

--- a/bin/local_deploy.sh
+++ b/bin/local_deploy.sh
@@ -2,11 +2,11 @@
 set -e
 
 ROOT=$(dirname "$0")
-HELM_DIR="$ROOT/../helm_deploy/cla-backend/"
+HELM_DIR="$ROOT/../helm_deploy/cla-public/"
 
 kubectl config use-context docker-for-desktop
 
-helm upgrade cla-backend \
+helm upgrade cla-public \
   $HELM_DIR \
   --values ${HELM_DIR}/values-dev.yaml \
   --install

--- a/bin/local_deploy.sh
+++ b/bin/local_deploy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+ROOT=$(dirname "$0")
+HELM_DIR="$ROOT/../helm_deploy/cla-backend/"
+
+kubectl config use-context docker-for-desktop
+
+helm upgrade cla-backend \
+  $HELM_DIR \
+  --values ${HELM_DIR}/values-dev.yaml \
+  --install

--- a/bin/production_deploy.sh
+++ b/bin/production_deploy.sh
@@ -6,9 +6,9 @@ HELM_DIR="$ROOT/../helm_deploy/cla-public/"
 
 helm upgrade cla-public \
   $HELM_DIR \
-  --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
-  --values ${HELM_DIR}/values-staging.yaml \
-  --set host=$STAGING_HOST \
+  --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} \
+  --values ${HELM_DIR}/values-production.yaml \
+  --set host=$PRODUCTION_HOST \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --force \

--- a/bin/production_deploy.sh
+++ b/bin/production_deploy.sh
@@ -9,6 +9,7 @@ helm upgrade cla-public \
   --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} \
   --values ${HELM_DIR}/values-production.yaml \
   --set host=$PRODUCTION_HOST \
+  --set ingress.enabled=false \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --force \

--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -2,7 +2,7 @@
 set -e
 
 ROOT=$(dirname "$0")
-HELM_DIR="$ROOT/../helm_deploy/cla-backend/"
+HELM_DIR="$ROOT/../helm_deploy/cla-public/"
 
 helm upgrade $RELEASE_NAME \
   $HELM_DIR \

--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+ROOT=$(dirname "$0")
+HELM_DIR="$ROOT/../helm_deploy/cla-backend/"
+
+helm upgrade $RELEASE_NAME \
+  $HELM_DIR \
+  --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
+  --values ${HELM_DIR}/values-staging.yaml \
+  --set fullnameOverride=$RELEASE_NAME \
+  --set host=$RELEASE_HOST \
+  --set image.repository=$DOCKER_REPOSITORY \
+  --set image.tag=$IMAGE_TAG \
+  --install

--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -9,6 +9,7 @@ helm upgrade cla-public \
   --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
   --values ${HELM_DIR}/values-staging.yaml \
   --set host=$STAGING_HOST \
+  --set ingress.enabled=false \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --force \

--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -9,7 +9,6 @@ helm upgrade cla-public \
   --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
   --values ${HELM_DIR}/values-staging.yaml \
   --set host=$STAGING_HOST \
-  --set ingress.redirectFrom=laa-cla-public-staging.apps.live-1.cloud-platform.service.justice.gov.uk \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --force \

--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -9,6 +9,7 @@ helm upgrade cla-public \
   --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
   --values ${HELM_DIR}/values-staging.yaml \
   --set host=$STAGING_HOST \
+  --set ingress.redirectFrom=laa-cla-public-staging.apps.live-1.cloud-platform.service.justice.gov.uk \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --force \

--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -12,4 +12,5 @@ helm upgrade $RELEASE_NAME \
   --set host=$RELEASE_HOST \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
+  --force \
   --install

--- a/bin/staging_multideploy.sh
+++ b/bin/staging_multideploy.sh
@@ -13,5 +13,6 @@ helm upgrade $CLEANED_BRANCH_NAME \
   --set ingress.secretName=tls-wildcard-certificate \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
+  --set dashboard.enabled=false \
   --force \
   --install

--- a/bin/staging_multideploy.sh
+++ b/bin/staging_multideploy.sh
@@ -4,11 +4,13 @@ set -e
 ROOT=$(dirname "$0")
 HELM_DIR="$ROOT/../helm_deploy/cla-public/"
 
-helm upgrade cla-public \
+helm upgrade $CLEANED_BRANCH_NAME \
   $HELM_DIR \
   --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
   --values ${HELM_DIR}/values-staging.yaml \
-  --set host=$STAGING_HOST \
+  --set fullnameOverride=$CLEANED_BRANCH_NAME \
+  --set host=$CLEANED_BRANCH_NAME.$STAGING_HOST \
+  --set ingress.secretName=tls-wildcard-certificate \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --force \

--- a/helm_deploy/cla-public/.helmignore
+++ b/helm_deploy/cla-public/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm_deploy/cla-public/Chart.yaml
+++ b/helm_deploy/cla-public/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: cla-public
+description: The public facing CLA service
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0

--- a/helm_deploy/cla-public/templates/NOTES.txt
+++ b/helm_deploy/cla-public/templates/NOTES.txt
@@ -6,12 +6,12 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cla-public.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cla-public.fullname" . }}-app)
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cla-public.fullname" . }}'
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cla-public.fullname" . }}-app'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cla-public.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}

--- a/helm_deploy/cla-public/templates/NOTES.txt
+++ b/helm_deploy/cla-public/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cla-public.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cla-public.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cla-public.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cla-public.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/helm_deploy/cla-public/templates/NOTES.txt
+++ b/helm_deploy/cla-public/templates/NOTES.txt
@@ -8,7 +8,7 @@
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cla-public.fullname" . }}-app)
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  echo http://$NODE_IP:$NODE_PORT or http://localhost:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cla-public.fullname" . }}-app'

--- a/helm_deploy/cla-public/templates/_helpers.tpl
+++ b/helm_deploy/cla-public/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cla-public.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cla-public.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cla-public.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "cla-public.labels" -}}
+helm.sh/chart: {{ include "cla-public.chart" . }}
+{{ include "cla-public.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cla-public.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cla-public.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cla-public.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cla-public.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/helm_deploy/cla-public/templates/dashboard.yml
+++ b/helm_deploy/cla-public/templates/dashboard.yml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -448,3 +449,4 @@ data:
       "title": {{ include "cla-public.fullname" . }},
       "version": 1
     }
+{{- end }}

--- a/helm_deploy/cla-public/templates/dashboard.yml
+++ b/helm_deploy/cla-public/templates/dashboard.yml
@@ -1,0 +1,450 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cla-public.fullname" . }}
+  labels:
+    grafana_dashboard: ""
+data:
+  laa-cla-public-staging-dashboard.json: |
+    {
+      "__inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "label": "prometheus",
+          "description": "",
+          "type": "datasource",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus"
+        }
+      ],
+      "__requires": [
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "5.4.2"
+        },
+        {
+          "type": "panel",
+          "id": "graph",
+          "name": "Graph",
+          "version": "5.0.0"
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "5.0.0"
+        }
+      ],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "limit": 100,
+            "name": "Annotations & Alerts",
+            "showIn": 0,
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 1,
+      "id": null,
+      "iteration": 1548242989805,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 12,
+          "panels": [],
+          "title": "",
+          "type": "row"
+        },
+        {
+          "aliasColors": {
+            "Limit": "#bf1b00",
+            "Limit (hard limit)": "#bf1b00",
+            "Requested (soft limit)": "#f2c96d"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 450,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by(pod_name)(container_memory_usage_bytes{namespace='$namespace'})",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "POD: {{` pod_name `}}",
+              "refId": "A"
+            },
+            {
+              "expr": "avg(kube_pod_container_resource_requests_memory_bytes{namespace='$namespace'})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Requested (soft limit)",
+              "refId": "C"
+            },
+            {
+              "expr": "avg(kube_pod_container_resource_limits_memory_bytes{namespace='$namespace'})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Limit (hard limit)",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "Limit": "#bf1b00",
+            "Requested (soft limit)": "#f2c96d"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": null,
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 13,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 450,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (pod_name)(rate(container_cpu_usage_seconds_total{namespace='$namespace'}[5m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "POD: {{` pod_name `}}",
+              "refId": "A"
+            },
+            {
+              "expr": "avg(kube_pod_container_resource_requests_cpu_cores{namespace='$namespace'})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Requested (soft limit)",
+              "refId": "B"
+            },
+            {
+              "expr": "avg(kube_pod_container_resource_limits_cpu_cores{namespace='$namespace'})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Limit (hard limit)",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "Limit": "#bf1b00"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": null,
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 17
+          },
+          "id": 14,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 450,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sort_desc(avg(sum by (pod_name) (rate(container_network_receive_bytes_total{namespace='$namespace'}[5m]))))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Recv",
+              "refId": "A"
+            },
+            {
+              "expr": "sort_desc(avg(sum by (pod_name) (rate(container_network_transmit_bytes_total{namespace='$namespace'}[5m]))))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Sent",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Network",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "deckbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "schemaVersion": 16,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {},
+            "datasource": "Prometheus",
+            "definition": "label_values(kube_deployment_metadata_generation, namespace)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values(kube_deployment_metadata_generation, namespace)",
+            "refresh": 1,
+            "regex": "/^laa-cla-public-/",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-24h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "browser",
+      "title": {{ include "cla-public.fullname" . }},
+      "version": 1
+    }

--- a/helm_deploy/cla-public/templates/deployment.yaml
+++ b/helm_deploy/cla-public/templates/deployment.yaml
@@ -19,13 +19,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      serviceAccountName: {{ include "cla-public.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
@@ -52,8 +47,6 @@ spec:
             initialDelaySeconds: 5
             timeoutSeconds: 1
             periodSeconds: 10
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: ALLOWED_HOSTS
               value: "{{ .Values.host }}"
@@ -123,15 +116,3 @@ spec:
                   optional: {{ .Values.useDevValues }}
 
             {{- toYaml .Values.envVars | nindent 12 }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}

--- a/helm_deploy/cla-public/templates/deployment.yaml
+++ b/helm_deploy/cla-public/templates/deployment.yaml
@@ -1,0 +1,137 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ include "cla-public.fullname" . }}-app
+  labels:
+    {{- include "cla-public.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "cla-public.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cla-public.selectorLabels" . | nindent 8 }}
+        app: web
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "cla-public.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ping.json
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: "{{ .Values.host }}"
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ping.json
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: "{{ .Values.host }}"
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: ALLOWED_HOSTS
+              value: "{{ .Values.host }}"
+            - name: CLA_ENV
+              value: "{{ .Values.environment }}"
+            - name: BACKEND_BASE_URI
+              value: "{{ .Values.backend_base_uri }}"
+            - name: LAALAA_API_HOST
+              value: "{{ .Values.laalaa_api_host }}"
+            - name: GOOGLE_MAPS_API_KEY
+              value: "{{ .Values.google_maps_api_key }}"
+            - name: LOG_LEVEL
+              value: "{{ .Values.logLevel }}"
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: flask-secret-key
+                  key: SECRET_KEY
+                  optional: {{ .Values.useDevValues }}
+            - name: OS_PLACES_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: os-places
+                  key: apiKey
+                  optional: {{ .Values.useDevValues }}
+            - name: ZENDESK_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: zendesk-api
+                  key: ZENDESK_API_TOKEN
+                  optional: {{ .Values.useDevValues }}
+            - name: ZENDESK_API_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: zendesk-api
+                  key: ZENDESK_API_USERNAME
+                  optional: {{ .Values.useDevValues }}
+            - name: SMTP_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-sendgrid
+                  key: SMTP_HOST
+                  optional: {{ .Values.useDevValues }}
+            - name: SMTP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-sendgrid
+                  key: SMTP_USER
+                  optional: {{ .Values.useDevValues }}
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-sendgrid
+                  key: SMTP_PASSWORD
+                  optional: {{ .Values.useDevValues }}
+            - name: RAVEN_CONFIG_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: raven-config
+                  key: RAVEN_CONFIG_DSN
+                  optional: {{ .Values.useDevValues }}
+            - name: RAVEN_CONFIG_SITE
+              valueFrom:
+                secretKeyRef:
+                  name: raven-config
+                  key: RAVEN_CONFIG_SITE
+                  optional: {{ .Values.useDevValues }}
+
+            {{- toYaml .Values.envVars | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/helm_deploy/cla-public/templates/deployment.yaml
+++ b/helm_deploy/cla-public/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cla-public.fullname" . }}-app

--- a/helm_deploy/cla-public/templates/ingress.yaml
+++ b/helm_deploy/cla-public/templates/ingress.yaml
@@ -9,7 +9,12 @@ metadata:
     {{- include "cla-public.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
+    {{- if .Values.ingress.redirectFrom -}}
+    nginx.ingress.kubernetes.io/proxy-redirect-from: {{ .Values.ingress.redirectFrom }}
+    nginx.ingress.kubernetes.io/proxy-redirect-to: {{ .Values.hostName }}
+    {{- else -}}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   tls:

--- a/helm_deploy/cla-public/templates/ingress.yaml
+++ b/helm_deploy/cla-public/templates/ingress.yaml
@@ -9,12 +9,7 @@ metadata:
     {{- include "cla-public.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- if .Values.ingress.redirectFrom -}}
-    nginx.ingress.kubernetes.io/proxy-redirect-from: https://{{ .Values.ingress.redirectFrom }}
-    nginx.ingress.kubernetes.io/proxy-redirect-to: https://{{ .Values.hostName }}
-    {{- else -}}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
   tls:

--- a/helm_deploy/cla-public/templates/ingress.yaml
+++ b/helm_deploy/cla-public/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cla-public.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm_deploy/cla-public/templates/ingress.yaml
+++ b/helm_deploy/cla-public/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "cla-public.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "cla-public.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  tls:
+    - hosts:
+       - "{{ .Values.host }}"
+      {{- if .Values.ingress.tls }}
+      {{- range .Values.ingress.tls }}
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+      {{- end }}
+      {{- end }}
+  rules:
+    - host: "{{ .Values.host }}"
+      http:
+        paths:
+          - path: "/"
+            backend:
+              serviceName: {{ $fullName }}-app
+              servicePort: {{ $svcPort }}
+{{- end }}

--- a/helm_deploy/cla-public/templates/ingress.yaml
+++ b/helm_deploy/cla-public/templates/ingress.yaml
@@ -10,8 +10,8 @@ metadata:
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- if .Values.ingress.redirectFrom -}}
-    nginx.ingress.kubernetes.io/proxy-redirect-from: {{ .Values.ingress.redirectFrom }}
-    nginx.ingress.kubernetes.io/proxy-redirect-to: {{ .Values.hostName }}
+    nginx.ingress.kubernetes.io/proxy-redirect-from: https://{{ .Values.ingress.redirectFrom }}
+    nginx.ingress.kubernetes.io/proxy-redirect-to: https://{{ .Values.hostName }}
     {{- else -}}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/helm_deploy/cla-public/templates/ingress.yaml
+++ b/helm_deploy/cla-public/templates/ingress.yaml
@@ -15,14 +15,7 @@ spec:
   tls:
     - hosts:
        - "{{ .Values.host }}"
-      {{- if .Values.ingress.tls }}
-      {{- range .Values.ingress.tls }}
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
-      {{- end }}
-      {{- end }}
+      secretName: {{ .Values.ingress.secretName }}
   rules:
     - host: "{{ .Values.host }}"
       http:

--- a/helm_deploy/cla-public/templates/service.yaml
+++ b/helm_deploy/cla-public/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cla-public.fullname" . }}-app
+  labels:
+    {{- include "cla-public.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "cla-public.selectorLabels" . | nindent 4 }}

--- a/helm_deploy/cla-public/templates/tests/test-connection.yaml
+++ b/helm_deploy/cla-public/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "cla-public.fullname" . }}-test-connection"
+  labels:
+    {{- include "cla-public.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "cla-public.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm_deploy/cla-public/values-dev.yaml
+++ b/helm_deploy/cla-public/values-dev.yaml
@@ -1,0 +1,44 @@
+# Default values for cla-public in a dev environment.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: cla_public_local
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: NodePort
+  port: 80
+
+environment: development
+backend_base_uri: https://staging-backend.cla.dsd.io/
+laalaa_api_host: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+google_maps_api_key: AIzaSyBVsZmfkiRFNNMJnPraN_8sBW3Dj-BFFNs
+logLevel: DEBUG
+useDevValues: true
+
+# Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
+envVars:
+- name: MOJ_GA_ID
+  value: UA-37377084-21
+- name: GDS_GA_ID
+  value: UA-145652997-1
+- name: SECRET_KEY
+  value: "secret"
+- name: OS_PLACES_API_KEY
+  value: ""
+- name: ZENDESK_API_TOKEN
+  value: ""
+- name: ZENDESK_API_USERNAME
+  value: ""
+- name: SMTP_HOST
+  value: ""
+- name: SMTP_USER
+  value: ""
+- name: SMTP_PASSWORD
+  value: ""
+- name: RAVEN_CONFIG_DSN
+  value: ""
+- name: RAVEN_CONFIG_SITE
+  value: ""

--- a/helm_deploy/cla-public/values-production.yaml
+++ b/helm_deploy/cla-public/values-production.yaml
@@ -1,0 +1,21 @@
+# Default values for cla-public in a production environment.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  pullPolicy: IfNotPresent
+
+environment: production
+
+ingress:
+  enabled: true
+  # hosts:
+    # - host: laa-cla-public-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+      # paths: ['/']
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
+envVars:

--- a/helm_deploy/cla-public/values-production.yaml
+++ b/helm_deploy/cla-public/values-production.yaml
@@ -19,3 +19,5 @@ ingress:
 
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:
+  - name: DEBUG
+    value: "False"

--- a/helm_deploy/cla-public/values-staging.yaml
+++ b/helm_deploy/cla-public/values-staging.yaml
@@ -14,7 +14,7 @@ replicaCount: 2
 
 ingress:
   enabled: true
-  secretName: tls-certificate
+  secretName: tls-wildcard-certificate
 
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:

--- a/helm_deploy/cla-public/values-staging.yaml
+++ b/helm_deploy/cla-public/values-staging.yaml
@@ -14,13 +14,7 @@ replicaCount: 2
 
 ingress:
   enabled: true
-  hosts:
-    - host: laa-cla-public-staging.apps.live-1.cloud-platform.service.justice.gov.uk
-      paths: ['/']
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+  secretName: tls-certificate
 
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:

--- a/helm_deploy/cla-public/values-staging.yaml
+++ b/helm_deploy/cla-public/values-staging.yaml
@@ -1,0 +1,23 @@
+# Default values for cla-public in a staging environment.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  pullPolicy: IfNotPresent
+
+environment: staging
+
+ingress:
+  enabled: true
+  hosts:
+    - host: laa-cla-public-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+      paths: ['/']
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
+envVars:
+  - name: DEBUG
+    value: "False"

--- a/helm_deploy/cla-public/values-staging.yaml
+++ b/helm_deploy/cla-public/values-staging.yaml
@@ -6,6 +6,11 @@ image:
   pullPolicy: IfNotPresent
 
 environment: staging
+backend_base_uri: https://staging-backend.cla.dsd.io/
+laalaa_api_host: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+google_maps_api_key: AIzaSyBVsZmfkiRFNNMJnPraN_8sBW3Dj-BFFNs
+
+replicaCount: 2
 
 ingress:
   enabled: true

--- a/helm_deploy/cla-public/values-staging.yaml
+++ b/helm_deploy/cla-public/values-staging.yaml
@@ -14,7 +14,7 @@ replicaCount: 2
 
 ingress:
   enabled: true
-  secretName: tls-wildcard-certificate
+  secretName: tls-certificate
 
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:

--- a/helm_deploy/cla-public/values.yaml
+++ b/helm_deploy/cla-public/values.yaml
@@ -1,0 +1,76 @@
+# Default values for cla-public.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: cla_public
+  tag: latest
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+logLevel: INFO
+useDevValues: false
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+host: 'localhost'
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # hosts:
+    # - host: chart-example.local
+      # paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+envVars: []
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/helm_deploy/cla-public/values.yaml
+++ b/helm_deploy/cla-public/values.yaml
@@ -9,32 +9,11 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
-imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
 logLevel: INFO
 useDevValues: false
-
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: false
-  # Annotations to add to the service account
-  annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name:
-
-podSecurityContext: {}
-  # fsGroup: 2000
-
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 service:
   type: ClusterIP
@@ -59,21 +38,3 @@ ingress:
   #      - chart-example.local
 
 envVars: []
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}

--- a/helm_deploy/cla-public/values.yaml
+++ b/helm_deploy/cla-public/values.yaml
@@ -42,6 +42,9 @@ service:
 
 host: 'localhost'
 
+dashboard:
+  enabled: true
+
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
## What does this pull request do?

Creates a Helm chart and uses it when deploying to staging on CircleCI
If the branch is `master`, the release has the name `cla-public`. Otherwise, its name is generated from the branch name and is thus for that branch only.
Leaves the production deploy unchanged

## Any other changes that would benefit highlighting?
The master branch staging deploy does not currently create an `Ingress`, as this would clash with the non-Helm `Ingress`. The existing one can be manually edited to point to the new Helm `service`, and then the deploy modified to define the `Ingress` after that.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
