### PR TITLE
LGA-1107 Details tag not working in IE & Edge

### DIFF
--- a/cla_public/static-src/javascripts/govuk.main.js
+++ b/cla_public/static-src/javascripts/govuk.main.js
@@ -1,5 +1,8 @@
   'use strict';
   require('govuk_publishing_components/modules.js');
+  var govukFrontend = require('govuk-frontend');
+  window.GOVUKFrontend = govukFrontend;
+
   $(document).ready(function () {
     window.GOVUK.modules.start();
   });

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -241,6 +241,11 @@
       </button>
     </p>
   </script>
+
+  <script src="{{ asset(filename='javascripts/govuk.js') }}"></script>
+  <script>
+    window.GOVUKFrontend.initAll()
+  </script>
 {% endblock %}
 
 {% block footer_support_links %}

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -242,7 +242,6 @@
     </p>
   </script>
 
-  <script src="{{ asset(filename='javascripts/govuk.js') }}"></script>
   <script>
     window.GOVUKFrontend.initAll()
   </script>


### PR DESCRIPTION
## What does this pull request do?

Uses the govuk-frontend polyfill for IE and Edge to fix the details dropdown bug.

Govuk-frontend was already installed, but the javascript part of the package needed to be included in the compiled javascript for it to work.

## Any other changes that would benefit highlighting?

Mentions:
I used var in the 'govuk.main.js' file due to the fact that one of the plugins for webpack doesn't support ES6. The specific plugin is 'UglifyJsWebpackPlugin' and may need another ticket to look into possibly updating it. One of the new versions to look into is called TerserWebpackPlugin.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
