### PR TITLE
LGA-1163 - Enable production ingress

### DIFF
--- a/bin/production_deploy.sh
+++ b/bin/production_deploy.sh
@@ -9,7 +9,6 @@ helm upgrade cla-public \
   --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} \
   --values ${HELM_DIR}/values-production.yaml \
   --set host=$PRODUCTION_HOST \
-  --set ingress.enabled=false \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --force \


### PR DESCRIPTION
## What does this pull request do?
Enables the Helm ingress

## Any other changes that would benefit highlighting?

Currently based on the branch that introduces the production Helm deploy, for simpler diff. That will merge and then this will follow it into `master`

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
