### PR TITLE
LGA-1158 Escape key activates quick exit only when quick exit visible

### DIFF
--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -126,10 +126,8 @@
       fleeFromPage("mouse click");
     });
     $(document).keyup(function(e) {
-      if ($('.laa-flee-button-enabled').length) {
-        if (e.keyCode == 27) { // escape key
-          fleeFromPage("escape key");
-        }
+      if ($('.laa-flee-button-enabled').length && e.keyCode == 27) { // 27 = escape key
+        fleeFromPage("escape key");
       }
     });
 

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -126,8 +126,10 @@
       fleeFromPage("mouse click");
     });
     $(document).keyup(function(e) {
-      if (e.keyCode == 27) { // escape key
-        fleeFromPage("escape key");
+      if ($('.laa-flee-button-enabled').length) {
+        if (e.keyCode == 27) { // escape key
+          fleeFromPage("escape key");
+        }
       }
     });
 


### PR DESCRIPTION
## What does this pull request do?

Added condition so quick exit only fires when quick exit enabled (checks for class)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
