### PR TITLE
LGA-1181 COVID-19 opening times changed by JS function

### DIFF
--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -121,8 +121,8 @@
       $("#thirdparty-time-time_in_day, #thirdparty-time-time_today, #callback-time-time_in_day, #callback-time-time_today")
         .find("option:contains(7:30 PM), option:contains(6:30 PM), option:contains(5:30 PM)")
         .remove();
-      var d = new Date();
-      var n = d.getDay();
+      const d = new Date();
+      const n = d.getDay();
       if (n == 6 || n === 0) {
         /*if we are currently in a weekend*/
         $("#thirdparty-time-specific_day-0, #callback-time-specific_day-0").attr('disabled', 'disabled');

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -123,7 +123,7 @@
         .remove();
       var d = new Date();
       var n = d.getDay();
-      if (n > 5) {
+      if (n == 6 || n === 0) {
         /*if we are currently in a weekend*/
         $("#thirdparty-time-specific_day-0, #callback-time-specific_day-0").attr('disabled', 'disabled');
         $("#thirdparty-time-specific_day-1, #callback-time-specific_day-1").prop('checked', true);

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -114,7 +114,7 @@
   <script>
 
     $(document).ready(function(){
-      /*COVID-19: This function is a stopgap for emergency plague-time opening times*/
+      /*COVID-19: This function is a stopgap for emergency opening times*/
       $("#field-thirdparty-time-day, #field-callback-time-day")
         .find("option:contains(Saturday), option:contains(Sunday)")
         .remove();

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -113,6 +113,23 @@
 {% block javascripts %}
   <script>
 
+    $(document).ready(function(){
+      /*COVID-19: This function is a stopgap for emergency plague-time opening times*/
+      $("#field-thirdparty-time-day, #field-callback-time-day")
+        .find("option:contains(Saturday), option:contains(Sunday)")
+        .remove();
+      $("#thirdparty-time-time_in_day, #thirdparty-time-time_today, #callback-time-time_in_day, #callback-time-time_today")
+        .find("option:contains(7:30 PM), option:contains(6:30 PM), option:contains(5:30 PM)")
+        .remove();
+      var d = new Date();
+      var n = d.getDay();
+      if (n > 5) {
+        /*if we are currently in a weekend*/
+        $("#thirdparty-time-specific_day-0, #callback-time-specific_day-0").attr('disabled', 'disabled');
+        $("#thirdparty-time-specific_day-1, #callback-time-specific_day-1").prop('checked', true);
+      }
+    });
+
     function fleeFromPage(fleeMethod) {
       $("body").hide();
       ga('moj.send', 'event', 'Quick-exit', 'Quick exit by '+fleeMethod, 'Quick exit from '+stripPII(window.location.href));


### PR DESCRIPTION
## What does this pull request do?

New JS to hide unwanted days and times.  Done by matching the text in the options.  
Also function to disable "call today" on a weekend.  
To be reversed once LGA-1053 is complete

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
