### PR TITLE
LGA-1119 Change GA language field on Welsh site from en-gb to en-cy

### DIFF
--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -183,7 +183,7 @@
         ga(values["name"] + '.linker:autoLink', ['www.gov.uk']);
       }
       if(localeLanguage === 'cy') {
-        ga(values["name"] + '.set', 'language', 'cy')
+        ga(values["name"] + '.set', 'language', 'en_cy')
       }
     });
 

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -171,6 +171,8 @@
       }
     {% endif %}
 
+    const localeLanguage = "{{ request.cookies.get('locale', 'en')[:2] }}"
+
     _.forEach(window.ga_trackers, function(values, id){
       ga('create', values["id"], values["domain"], values["name"], values["options"]);
       ga(values["name"] + '.set', 'anonymizeIp', true);
@@ -179,6 +181,9 @@
         ga(values["name"] + '.require', 'linker');
         ga(values["name"] + '.linker.set', 'anonymizeIp', true);
         ga(values["name"] + '.linker:autoLink', ['www.gov.uk']);
+      }
+      if(localeLanguage === 'cy') {
+        ga(values["name"] + '.set', 'language', 'cy')
       }
     });
 

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -183,7 +183,7 @@
         ga(values["name"] + '.linker:autoLink', ['www.gov.uk']);
       }
       if(localeLanguage === 'cy') {
-        ga(values["name"] + '.set', 'language', 'en-cy')
+        ga(values["name"] + '.set', 'language', 'cy')
       } else {
         ga(values["name"] + '.set', 'language', 'en-gb')
       }

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -171,7 +171,7 @@
       }
     {% endif %}
 
-    const localeLanguage = "{{ request.cookies.get('locale', 'en')[:2] }}"
+    const localeLanguage = "{{ request.cookies.get('locale', 'en_GB') }}"
 
     _.forEach(window.ga_trackers, function(values, id){
       ga('create', values["id"], values["domain"], values["name"], values["options"]);
@@ -182,11 +182,7 @@
         ga(values["name"] + '.linker.set', 'anonymizeIp', true);
         ga(values["name"] + '.linker:autoLink', ['www.gov.uk']);
       }
-      if(localeLanguage === 'cy') {
-        ga(values["name"] + '.set', 'language', 'cy')
-      } else {
-        ga(values["name"] + '.set', 'language', 'en-gb')
-      }
+      ga(values["name"] + '.set', 'language', localeLanguage)
     });
 
     {% block ga_pageview -%}

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -183,7 +183,9 @@
         ga(values["name"] + '.linker:autoLink', ['www.gov.uk']);
       }
       if(localeLanguage === 'cy') {
-        ga(values["name"] + '.set', 'language', 'en_cy')
+        ga(values["name"] + '.set', 'language', 'en-cy')
+      } else {
+        ga(values["name"] + '.set', 'language', 'en-gb')
       }
     });
 

--- a/helm_deploy/cla-public/values-production.yaml
+++ b/helm_deploy/cla-public/values-production.yaml
@@ -20,3 +20,7 @@ ingress:
 envVars:
   - name: DEBUG
     value: "False"
+  - name: MOJ_GA_ID
+    value: UA-37377084-21
+  - name: GDS_GA_ID
+    value: UA-145652997-1

--- a/helm_deploy/cla-public/values-staging.yaml
+++ b/helm_deploy/cla-public/values-staging.yaml
@@ -21,4 +21,4 @@ envVars:
   - name: DEBUG
     value: "False"
   - name: MOJ_GA_ID
-    value: UA-37377084-21
+    value: UA-37377084-13

--- a/helm_deploy/cla-public/values-staging.yaml
+++ b/helm_deploy/cla-public/values-staging.yaml
@@ -20,3 +20,5 @@ ingress:
 envVars:
   - name: DEBUG
     value: "False"
+  - name: MOJ_GA_ID
+    value: UA-37377084-21


### PR DESCRIPTION
## What does this pull request do?

After switching to the welsh language, when navigating welsh pages, each page will send 'cy_GB' as the language code.

Adds Google Analytics credentials to Kubernetes to enable testing on production and staging. This was outside the scope of the ticket, but it was necessary in order to test my changes which is why it was included.

Sets the fallback English language code as 'en_GB' instead of en'.

## Any other changes that would benefit highlighting?

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
