### PR TITLE
LGA-1213 Move Circle CI Staging Approval earlier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,6 +263,7 @@ workflows:
                 - master
       - staging_deploy:
           requires:
+            - build
             - staging_deploy_approval
           context: laa-cla-public-live-1
           multideploy: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,10 +250,9 @@ workflows:
           context: laa-cla-public-live-1
       - staging_deploy_approval:
           type: approval
-          requires:
-            - build
       - staging_deploy:
           requires:
+            - build
             - staging_deploy_approval
           context: laa-cla-public-live-1
           name: staging_deploy_master


### PR DESCRIPTION
## What does this pull request do?

Rearranges Circle CI flow so approval for staging deploy can be done immediately.
It also makes staging deploy require a successful build as well as the approval.
(Essentially, the requirement for Build is moved from the approval to the actual staging deploy.)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
