### PR TITLE
LGA-1230 - Fix always-passing-tests bug

### DIFF
--- a/cla_public/apps/contact/tests/test_availability.py
+++ b/cla_public/apps/contact/tests/test_availability.py
@@ -172,12 +172,12 @@ class TestDayTimeChoices(unittest.TestCase):
             field = DayChoiceField()
             field = field.bind(form, "day")
             choices = field.day_time_choices
-            # half day on saturday
-            self.assertEqual(7, len(choices["20150214"]))
+            # no availability on saturday
+            self.assertNotIn("20150214", choices.keys())
             # can book before 11am on monday. Monday morning call back capping removed.
-            self.assertEqual(22, len(choices["20150216"]))
+            self.assertEqual(16, len(choices["20150216"]))
             # can book any slot on tuesday
-            self.assertEqual(22, len(choices["20150217"]))
+            self.assertEqual(16, len(choices["20150217"]))
 
     def test_monday_available_before_11_on_saturday(self):
         with override_current_time(datetime.datetime(2015, 5, 9, 10, 30)):

--- a/cla_public/apps/contact/tests/test_mail.py
+++ b/cla_public/apps/contact/tests/test_mail.py
@@ -21,7 +21,7 @@ def submit(**kwargs):
         "callback-contact_number": "0123456789",
     }
 
-    if datetime.datetime.now().time() > datetime.time(hour=17, minute=30):
+    if datetime.datetime.now().time() > datetime.time(hour=14, minute=30):
         # use tomorrow because no more callbacks available today
         another_day = datetime.date.today() + datetime.timedelta(days=1)
         if another_day.weekday() in (5, 6):

--- a/manage.py
+++ b/manage.py
@@ -34,7 +34,10 @@ def test():
     import xmlrunner
     import unittest
 
-    xmlrunner.XMLTestRunner(output="test-reports", verbosity=3).run(unittest.TestLoader().discover("cla_public"))
+    result = xmlrunner.XMLTestRunner(output="test-reports", verbosity=3).run(
+        unittest.TestLoader().discover("cla_public")
+    )
+    return sys.exit(not result.wasSuccessful())
 
 
 def add_msgctxt(**format_kwargs):


### PR DESCRIPTION
## What does this pull request do?
The new test runner wasn't exiting with a non-zero exit code even when tests failed, so this makes it do so.
It also fixes the tests which broke when cla_common was upgraded to reflect the new operator hours

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
