### PR TITLE
LGA-1231 - Use cla_backend kubernetes staging deployment

### DIFF
--- a/helm_deploy/cla-public/values-dev.yaml
+++ b/helm_deploy/cla-public/values-dev.yaml
@@ -12,7 +12,7 @@ service:
   port: 80
 
 environment: development
-backend_base_uri: https://staging-backend.cla.dsd.io/
+backend_base_uri: https://lga-959-kubernetes-laa-cla-backend-staging.apps.live-1.cloud-platform.service.justice.gov.uk
 laalaa_api_host: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
 google_maps_api_key: AIzaSyBVsZmfkiRFNNMJnPraN_8sBW3Dj-BFFNs
 logLevel: DEBUG

--- a/helm_deploy/cla-public/values-staging.yaml
+++ b/helm_deploy/cla-public/values-staging.yaml
@@ -6,7 +6,7 @@ image:
   pullPolicy: IfNotPresent
 
 environment: staging
-backend_base_uri: https://staging-backend.cla.dsd.io/
+backend_base_uri: https://lga-959-kubernetes-laa-cla-backend-staging.apps.live-1.cloud-platform.service.justice.gov.uk
 laalaa_api_host: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
 google_maps_api_key: AIzaSyBVsZmfkiRFNNMJnPraN_8sBW3Dj-BFFNs
 


### PR DESCRIPTION
## What does this pull request do?

Use cla_backend kubernetes staging deployment

## Any other changes that would benefit highlighting?

backend_base_uri previosuly had the the trailing slash, the paths are passed with the leading slash this will results in the url becoming scheme://domain.tld//uri  which django will see it as a non-existing path and return a 404.

This is not happening on the current deployment system because nginx is sitting in front of uswgi and reconstructing the url.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
