### PR TITLE
Revert "LGA-1231 - Use cla_backend kubernetes staging deployment"

### DIFF
--- a/helm_deploy/cla-public/values-dev.yaml
+++ b/helm_deploy/cla-public/values-dev.yaml
@@ -12,7 +12,7 @@ service:
   port: 80
 
 environment: development
-backend_base_uri: https://lga-959-kubernetes-laa-cla-backend-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+backend_base_uri: https://staging-backend.cla.dsd.io/
 laalaa_api_host: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
 google_maps_api_key: AIzaSyBVsZmfkiRFNNMJnPraN_8sBW3Dj-BFFNs
 logLevel: DEBUG

--- a/helm_deploy/cla-public/values-staging.yaml
+++ b/helm_deploy/cla-public/values-staging.yaml
@@ -6,7 +6,7 @@ image:
   pullPolicy: IfNotPresent
 
 environment: staging
-backend_base_uri: https://lga-959-kubernetes-laa-cla-backend-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+backend_base_uri: https://staging-backend.cla.dsd.io/
 laalaa_api_host: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
 google_maps_api_key: AIzaSyBVsZmfkiRFNNMJnPraN_8sBW3Dj-BFFNs
 


### PR DESCRIPTION
Reverts ministryofjustice/cla_public#955

Seems to have broken translation. Need to investigate why this happens