### PR TITLE
LGA-1252 - Restore Google Analytics on production

### DIFF
--- a/helm_deploy/cla-public/values-production.yaml
+++ b/helm_deploy/cla-public/values-production.yaml
@@ -24,5 +24,5 @@ envVars:
     value: UA-37377084-21
   - name: GDS_GA_ID
     value: UA-145652997-1
-  - name: MOJ_GA_ID
+  - name: MOJ_GTM_ID
     value: GTM-MWL77F6


### PR DESCRIPTION
## What does this pull request do?
The new env var was intended to switch on Google Tag Manager but there
was a typo so it actually overrode (and therefore broke) the GA
implementation. This should restore both GA and GTM

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
