### PR TITLE
LGA-1264 - Make production use the correct GTM environment

### DIFF
--- a/helm_deploy/cla-public/values-production.yaml
+++ b/helm_deploy/cla-public/values-production.yaml
@@ -27,4 +27,4 @@ envVars:
   - name: MOJ_GTM_ID
     value: GTM-MWL77F6
   - name: MOJ_GTM_AUTH
-    value: "4KOuCU7aXv3Owhcs7U0ORw"
+    value: "pXnyHhiNQwB3LpZ4-zTZYg"


### PR DESCRIPTION
## What does this pull request do?
Correctly sets up the Google Tag Manager snippet on production.
Surprisingly, the ID is the same across environments but the auth value
is what should differ.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
