### PR TITLE
LGA-1017 - Non-prod landing page

### DIFF
--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -24,7 +24,9 @@ log = logging.getLogger(__name__)
 @base.route("/")
 def index():
     session.clear()
-    return redirect(current_app.config.get("GOV_UK_START_PAGE"))
+    if current_app.config["CLA_ENV"] == "prod":
+        return redirect(current_app.config.get("GOV_UK_START_PAGE"))
+    return render_template("index.html")
 
 
 @base.route("/cookies")

--- a/cla_public/templates/_resources.html
+++ b/cla_public/templates/_resources.html
@@ -1,9 +1,6 @@
-<h2>{{ _('Resources') }}</h2>
+<h2>{{ _('Related content') }}</h2>
 <nav>
   <ul>
-    <li><a href="https://www.gov.uk/civil-legal-advice">{{ _('Civil Legal Advice') }}</a></li>
     <li><a href="https://www.gov.uk/legal-aid">{{ _('Legal aid') }}</a></li>
-    <li><a href="https://www.gov.uk/legal-aid/how-to-claim">{{ _('Criminal legal aid') }}</a></li>
-    <li><a href="{{ url_for('base.privacy') }}">{{ _('How this service protects your privacy') }}</a></li>
   </ul>
 </nav>

--- a/cla_public/templates/index.html
+++ b/cla_public/templates/index.html
@@ -8,42 +8,34 @@
 {% endblock %}
 
 {% block inner_content %}
-  <h1 class="page-title">Check if you can get legal aid</h1>
-  <p>Legal aid can help pay for legal advice.</p>
-  <p>This service will check that your problem is covered by legal aid.</p>
-  <ul>
-    <li>If it looks like you can get legal aid, you may be able to get help over the phone or we’ll suggest that you speak to an adviser face to face.</li>
-    <li>If it looks like you can’t get legal aid, we’ll point you towards other organisations that offer legal advice, or help you find a solicitor. You will have to pay for the solicitor’s advice.</li>
-  </ul>
+  <h1 class="page-title">{% trans %}Check if you can get legal aid{% endtrans %}</h1>
+  <p>{% trans %}Legal aid can help pay for legal advice.{% endtrans %}</p>
+  <p>{% trans %}You’ll be asked general questions about your legal problem and your income and savings. You’ll be told where you can get legal advice.{% endtrans %}</p>
+
+  {% call Element.alert() %}
+    <p>{{ _('This guide is also available <a href="/locale/cy_GB">in Welsh (Cymraeg)</a>.') }}</p>
+  {% endcall %}
 
   <p>
     <a class="button button-get-started" href="{{ url_for('base.get_started') }}" id="start" role="button">
-      Start now
+      {% trans %}Start now{% endtrans %}
     </a>
   </p>
 
-  {{ Element.staying_safe_online_link() }}
+  <h2 class="govuk-heading-m">{% trans %}Before you start{% endtrans %}</h2>
 
-  {% call Element.alert() %}
-    <p>You’ll only get guidance on whether or not you might qualify for legal aid – you won’t get a final decision until you speak to an adviser.</p>
-  {% endcall %}
+  <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak">
 
-  <p>This service can’t help if you’ve been charged with a crime – ask your solicitor or barrister about criminal legal aid.</p>
+    <p>{% trans %}You can only check for non-criminal (‘civil’) cases. If you’ve been charged with a crime, ask your solicitor or barrister if you’re able to get criminal legal aid.{% endtrans %}</p>
 
-  <p>
-    If you’re looking for family mediation, you can also
-    <a href="http://www.familymediationcouncil.org.uk/find-local-mediator/" rel="external">find a local mediator</a>.
-  </p>
+    <p>{% trans %}You’ll only get guidance on whether or not you can get legal aid - you will not get a final decision until you speak to an adviser.{% endtrans %}</p>
 
-  {% call Element.alert() %}
-    <p>
-      Legal aid is different in <a href="http://www.slab.org.uk/public/advice/index.html" rel="external">Scotland</a>
-      and <a href="http://www.dojni.gov.uk/index/legalservices/legal-services-members-of-the-public.htm" rel="external">Northern Ireland.</a>
-    </p>
-  {% endcall %}
-
-  <div class="meta-data group">
-    <p class="modified-date">Last updated: 17 July 2015</p>
+    {% call Element.alert() %}
+      <p>
+        Legal aid is different in <a href="https://www.mygov.scot/legal-aid/" rel="external">Scotland</a>
+        and <a href="http://www.dojni.gov.uk/index/legalservices/legal-services-members-of-the-public.htm" rel="external">Northern Ireland.</a>
+      </p>
+    {% endcall %}
   </div>
 
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?
Disables the `/` redirect except on production
Updates the template served at `/` on non-production environments to match the gov.uk service landing page

## Any other changes that would benefit highlighting?
Still needs some work on translations, both the translatable strings being marked for a couple of more involved cases, and the translations generated and filled in for everything else. This is being done in another PR, and this one should be fine to release with these limitations.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
