### PR TITLE
Use Kubernetes CLA Backend staging as the backend for staging cla

### DIFF
--- a/helm_deploy/cla-public/values-staging.yaml
+++ b/helm_deploy/cla-public/values-staging.yaml
@@ -6,7 +6,7 @@ image:
   pullPolicy: IfNotPresent
 
 environment: staging
-backend_base_uri: https://staging-backend.cla.dsd.io/
+backend_base_uri: https://laa-cla-backend-staging.apps.live-1.cloud-platform.service.justice.gov.uk
 laalaa_api_host: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
 google_maps_api_key: AIzaSyBVsZmfkiRFNNMJnPraN_8sBW3Dj-BFFNs
 


### PR DESCRIPTION
## What does this pull request do?

Use cla_backend kubernetes staging deployment

## Any other changes that would benefit highlighting?

backend_base_uri previosuly had the the trailing slash, the paths are passed with the leading slash this will results in the url becoming scheme://domain.tld//uri which django will see it as a non-existing path and return a 404.

This is not happening on the current deployment system because nginx is sitting in front of uswgi and reconstructing the url.

Previously done at https://github.com/ministryofjustice/cla_public/pull/955 but then reverted out at https://github.com/ministryofjustice/cla_public/pull/959 due issues with translation (The staging environment was previously unstable as it wasn't using a persistent database backend)

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
