### PR TITLE
LGA-1273 internal start page

### DIFF
--- a/cla_public/templates/index.html
+++ b/cla_public/templates/index.html
@@ -2,7 +2,7 @@
 {% import "macros/element.html" as Element %}
 
 {% block before_content %}
-  <!-- no phase banner -->
+  <!-- no phase banner for pseudo start page -->
 {% endblock %}
 
 {% block sidebar %}
@@ -39,8 +39,12 @@
 
   <div role="note" aria-label="Information" class="govuk-inset-text">
     <p class="govuk-body">
-      {{ _('Legal aid is different in <a href="https://www.mygov.scot/legal-aid/" rel="external">Scotland</a> and <a href="http://www.dojni.gov.uk/index/legalservices/legal-services-members-of-the-public.htm" rel="external">Northern Ireland</a>.') }}
+      {% trans
+        Scotland_legal_aid_link=Element.link_same_window('https://www.mygov.scot/legal-aid/', _('Scotland'), True),
+        Ulster_legal_aid_link=Element.link_same_window('http://www.dojni.gov.uk/index/legalservices/legal-services-members-of-the-public.htm', _('Northern Ireland'), True)
+      %}Legal aid is different in {{ Scotland_legal_aid_link }} and {{ Ulster_legal_aid_link }}.{% endtrans %}
     </p>
+
   </div>
 
 

--- a/cla_public/templates/index.html
+++ b/cla_public/templates/index.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 {% import "macros/element.html" as Element %}
 
+{% block before_content %}
+  <!-- no phase banner -->
+{% endblock %}
+
 {% block sidebar %}
   <aside class="sidebar">
     {% include '_resources.html' %}
@@ -8,34 +12,36 @@
 {% endblock %}
 
 {% block inner_content %}
-  <h1 class="page-title">{% trans %}Check if you can get legal aid{% endtrans %}</h1>
-  <p>{% trans %}Legal aid can help pay for legal advice.{% endtrans %}</p>
-  <p>{% trans %}You’ll be asked general questions about your legal problem and your income and savings. You’ll be told where you can get legal advice.{% endtrans %}</p>
+  <h1 class="govuk-heading-xl">{% trans %}Check if you can get legal aid{% endtrans %}</h1>
+  <p class="govuk-body">{% trans %}Legal aid can help pay for legal advice.{% endtrans %}</p>
+  <p class="govuk-body">{% trans %}You’ll be asked general questions about your legal problem and your income and savings. You’ll be told where you can get legal advice.{% endtrans %}</p>
 
-  {% call Element.alert() %}
-    <p>{{ _('This guide is also available <a href="/locale/cy_GB">in Welsh (Cymraeg)</a>.') }}</p>
-  {% endcall %}
+  <div role="note" aria-label="Information" class="govuk-inset-text">
+    <p>
+      {{ _('This guide is also available <a class="govuk-link" lang="cy" href="/locale/cy_GB" data-ga="event:locale/switch/welsh">in Welsh (Cymraeg)</a>') }}.
+    </p>
+  </div>
 
-  <p>
-    <a class="button button-get-started" href="{{ url_for('base.get_started') }}" id="start" role="button">
+  <p class="govuk-body">
+    <a role="button" draggable="false" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" data-module="govuk-button" href="{{ url_for('base.get_started') }}" id="start">
       {% trans %}Start now{% endtrans %}
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+      </svg>
     </a>
   </p>
 
   <h2 class="govuk-heading-m">{% trans %}Before you start{% endtrans %}</h2>
 
-  <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak">
+  <p class="govuk-body">{% trans %}You can only check for non-criminal (‘civil’) cases. If you’ve been charged with a crime, ask your solicitor or barrister if you’re able to get criminal legal aid.{% endtrans %}</p>
 
-    <p>{% trans %}You can only check for non-criminal (‘civil’) cases. If you’ve been charged with a crime, ask your solicitor or barrister if you’re able to get criminal legal aid.{% endtrans %}</p>
+  <p class="govuk-body">{% trans %}You’ll only get guidance on whether or not you can get legal aid - you will not get a final decision until you speak to an adviser.{% endtrans %}</p>
 
-    <p>{% trans %}You’ll only get guidance on whether or not you can get legal aid - you will not get a final decision until you speak to an adviser.{% endtrans %}</p>
-
-    {% call Element.alert() %}
-      <p>
-        Legal aid is different in <a href="https://www.mygov.scot/legal-aid/" rel="external">Scotland</a>
-        and <a href="http://www.dojni.gov.uk/index/legalservices/legal-services-members-of-the-public.htm" rel="external">Northern Ireland.</a>
-      </p>
-    {% endcall %}
+  <div role="note" aria-label="Information" class="govuk-inset-text">
+    <p class="govuk-body">
+      {{ _('Legal aid is different in <a href="https://www.mygov.scot/legal-aid/" rel="external">Scotland</a> and <a href="http://www.dojni.gov.uk/index/legalservices/legal-services-members-of-the-public.htm" rel="external">Northern Ireland</a>.') }}
+    </p>
   </div>
+
 
 {% endblock %}

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -1201,9 +1201,54 @@ msgstr "Roedd gwall wrth anfon eich e-bost. Gwiriwch a cheisiwch eto, neu rhowch
 msgid "What do you need help with?"
 msgstr "Ar gyfer beth y mae arnoch chi angen cymorth?"
 
-#: cla_public/config/common.py:48 cla_public/config/common.py:49
+#: cla_public/config/common.py:48 cla_public/config/common.py:49 cla_public/templates/index.html:15
 msgid "Check if you can get legal aid"
 msgstr "Gwirio os y gallwch chi gael cymorth cyfreithiol"
+
+#cla_public/templates/index.html:16
+msgid "Legal aid can help pay for legal advice."
+msgstr "Gall cymorth cyfreithiol helpu i dalu am gyngor cyfreithiol."
+
+#cla_public/templates/index.html:17
+msgid "You’ll be asked general questions about your legal problem and your income and savings. You’ll be told where you can get legal advice."
+msgstr "Byddwch yn cael eich holi’n gyffredinol am eich problem gyfreithiol, eich incwm â’ch cynilion. Byddwch yn cael gwybod ble gallwch gael cyngor cyfreithiol."
+
+#!!!This translation offers the site in English - so it is not a literal translation of the English
+#cla_public/templates/index.html:21
+msgid "This guide is also available <a class=\"govuk-link\" lang=\"cy\" href=\"/locale/cy_GB\" data-ga=\"event:locale/switch/welsh\">in Welsh (Cymraeg)</a>"
+msgstr "Mae’r canllaw hwn hefyd ar gael <a class=\"govuk-link" lang=\"en\" href=\"/locale/en_GB\" data-ga=\"event:locale/switch/english\">yn Saesneg (English)</a>"
+
+#cla_public/templates/index.html:27
+msgid "Start now"
+msgstr "Dechrau nawr"
+
+#cla_public/templates/index.html:36
+msgid "You can only check for non-criminal (‘civil’) cases. If you’ve been charged with a crime, ask your solicitor or barrister if you’re able to get criminal legal aid."
+msgstr "Gallwch wirio ar gyfer achosion sydd ddim yn droseddol yn unig (‘sifil’). Os ydych chi wedi cael eich cyhuddo o drosedd, gofynnwch i’ch cyfreithiwr neu fargyfreithiwr os oes modd i chi gael cymorth cyfreithiol troseddol."
+
+#cla_public/templates/index.html:38
+msgid "You’ll only get guidance on whether or not you can get legal aid - you will not get a final decision until you speak to an adviser."
+msgstr "Byddwch yn cael arweiniad ynghylch p’un a ydych yn gallu cael cymorth cyfreithiol ai peidio yn unig – ni fyddwch yn cael penderfyniad terfynol nes eich bod yn siarad â chynghorydd."
+
+#cla_public/templates/index.html:42
+msgid "Legal aid is different in <a href=\"https://www.mygov.scot/legal-aid/" rel=\"external\">Scotland</a> and <a href=\"http://www.dojni.gov.uk/index/legalservices/legal-services-members-of-the-public.htm\" rel=\"external\">Northern Ireland</a>."
+msgstr "Mae cymorth cyfreithiol yn wahanol yn yr <a href=\"https://www.mygov.scot/legal-aid/\" rel=\"external\">Alban</a> a <a href=\"http://www.dojni.gov.uk/index/legalservices/legal-services-members-of-the-public.htm\" rel=\"external\">Gogledd Iwerddon</a>."
+
+#cla_public/templates/index.html:42
+msgid "Scotland"
+msgstr "Alban"
+
+#cla_public/templates/index.html:42
+msgid "Northern Ireland"
+msgstr "Gogledd Iwerddon"
+
+#cla_public/templates/index.html:42
+msgid "Legal aid is different in <a href=\"%(anchorScot)\" rel=\"external\">Scotland</a> and <a href=\"%(anchorUlster)\" rel=\"external\">Northern Ireland</a>."
+msgstr "Mae cymorth cyfreithiol yn wahanol yn yr <a href=\"%(anchorScot)\" rel=\"external\">Alban</a> a <a href=\"%(anchorUlster)\" rel=\"external\">Gogledd Iwerddon</a>."
+
+#cla_public/templates/index.html:42
+msgid "Legal aid is different in %(Scotland_legal_aid_link)s and %(Ulster_legal_aid_link)s."
+msgstr "Mae cymorth cyfreithiol yn wahanol yn yr %(Scotland_legal_aid_link)s a %(Ulster_legal_aid_link)s."
 
 #: cla_public/libs/honeypot.py:23
 msgid "This field must be left empty"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -1231,20 +1231,12 @@ msgid "You’ll only get guidance on whether or not you can get legal aid - you 
 msgstr "Byddwch yn cael arweiniad ynghylch p’un a ydych yn gallu cael cymorth cyfreithiol ai peidio yn unig – ni fyddwch yn cael penderfyniad terfynol nes eich bod yn siarad â chynghorydd."
 
 #cla_public/templates/index.html:42
-msgid "Legal aid is different in <a href=\"https://www.mygov.scot/legal-aid/" rel=\"external\">Scotland</a> and <a href=\"http://www.dojni.gov.uk/index/legalservices/legal-services-members-of-the-public.htm\" rel=\"external\">Northern Ireland</a>."
-msgstr "Mae cymorth cyfreithiol yn wahanol yn yr <a href=\"https://www.mygov.scot/legal-aid/\" rel=\"external\">Alban</a> a <a href=\"http://www.dojni.gov.uk/index/legalservices/legal-services-members-of-the-public.htm\" rel=\"external\">Gogledd Iwerddon</a>."
-
-#cla_public/templates/index.html:42
 msgid "Scotland"
 msgstr "Alban"
 
 #cla_public/templates/index.html:42
 msgid "Northern Ireland"
 msgstr "Gogledd Iwerddon"
-
-#cla_public/templates/index.html:42
-msgid "Legal aid is different in <a href=\"%(anchorScot)\" rel=\"external\">Scotland</a> and <a href=\"%(anchorUlster)\" rel=\"external\">Northern Ireland</a>."
-msgstr "Mae cymorth cyfreithiol yn wahanol yn yr <a href=\"%(anchorScot)\" rel=\"external\">Alban</a> a <a href=\"%(anchorUlster)\" rel=\"external\">Gogledd Iwerddon</a>."
 
 #cla_public/templates/index.html:42
 msgid "Legal aid is different in %(Scotland_legal_aid_link)s and %(Ulster_legal_aid_link)s."


### PR DESCRIPTION
## What does this pull request do?

Styles the internal start page similar to the start page on gov.uk
Adds in Welsh translations for the start page (taken from the main page on gov.uk)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
