### PR TITLE
LGA-1296 & 1297 QE accessibility

### DIFF
--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -291,7 +291,7 @@ dl.govuk-list.govuk-list--bullet {
     display:block;
   }
 
-  .js-enabled .laa-flee-button-container.laa-flee-button-enabled {
+  .laa-flee-button-container.laa-flee-button-enabled {
     display:block;
     float: right;
     position: -webkit-sticky;
@@ -305,6 +305,7 @@ dl.govuk-list.govuk-list--bullet {
 
       .laa-flee-button {
         width:100%;
+        margin-bottom:0;
       }
 
       .laa-quick-exit-info {
@@ -312,8 +313,7 @@ dl.govuk-list.govuk-list--bullet {
       }
     }
 
-    .laa-flee-button-sizing,
-    .exit-info-sizing {
+    .laa-flee-button-sizing{
       visibility:hidden;
     }
   }
@@ -332,6 +332,11 @@ dl.govuk-list.govuk-list--bullet {
 }
 
 @media only screen and (max-width: 640px) {
+
+  .laa-flee-button-sizing{
+    display:none;
+  }
+
   .js-enabled .laa-flee-button-container.govuk-visually-hidden {
     display:block;
 
@@ -344,7 +349,7 @@ dl.govuk-list.govuk-list--bullet {
     }
   }
 
-  .js-enabled .laa-flee-button-container.laa-flee-button-enabled {
+  .laa-flee-button-container.laa-flee-button-enabled {
     float: none;
 
     .laa-flee-button-position {
@@ -354,25 +359,14 @@ dl.govuk-list.govuk-list--bullet {
       background: govuk-colour("light-grey");
     }
 
-    .laa-flee-button-sizing,
-    .exit-info-sizing {
+    .laa-flee-button-sizing{
       display:none;
     }
     
-    .laa-explanation-long,
-    .laa-quick-exit-info,
-    .exit-info-sizing {
+    .laa-quick-exit-info{
       display:none;
     }
-
-    .laa-explanation-short {
-      display:inline;
-    }
   }
-}
-
-.laa-explanation-short {
-  display:none;
 }
 
 .laa-flee-button-container {

--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -287,12 +287,19 @@ dl.govuk-list.govuk-list--bullet {
 }
 
 @media only screen {
+  .js-enabled .laa-flee-button-container.govuk-visually-hidden {
+    display:block;
+  }
+
   .js-enabled .laa-flee-button-container.laa-flee-button-enabled {
     display:block;
     float: right;
+    position: -webkit-sticky;
+    position: sticky;
+    top:0;
+    z-index:1000;
 
     .laa-flee-button-position {
-      position: fixed;
       z-index:1000;
       background-color:govuk-colour("white");
 
@@ -312,15 +319,36 @@ dl.govuk-list.govuk-list--bullet {
   }
 }
 
-@media only screen and (max-width: 640px) {
-  footer.govuk-footer {
-    padding-bottom: 95px;
+.laa-flee-button-position {
+  position:fixed;
+}
+@media only screen and (min-width: 641px) {
+  @supports (position:sticky) {
+    .laa-flee-button-position {
+      position:sticky;
+      top:0;
+    }
   }
+}
+
+@media only screen and (max-width: 640px) {
+  .js-enabled .laa-flee-button-container.govuk-visually-hidden {
+    display:block;
+
+    ~.gem-c-cookie-banner__confirmation,.gem-c-cookie-banner {
+      padding-top:40px;
+    }
+
+    ~ #skiplink-container {
+      padding-top:40px;
+    }
+  }
+
   .js-enabled .laa-flee-button-container.laa-flee-button-enabled {
     float: none;
 
     .laa-flee-button-position {
-      bottom: 0;
+      top: 0;
       width: 100vw;
       left: 0;
       background: govuk-colour("light-grey");

--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -309,7 +309,11 @@ dl.govuk-list.govuk-list--bullet {
       }
 
       .laa-quick-exit-info {
-        text-align:center;
+        text-align: center;
+        padding: 10px 0;
+        border: 1px $govuk-border-colour solid;
+        border-top-style: none;
+        margin: 0;
       }
     }
 

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -59,7 +59,7 @@
     {% endif %}
     ">
     <div class="laa-flee-button-position">
-      <a href="https://www.google.com" id="quick-exit" class="govuk-button govuk-button--warning govuk-!-margin-bottom-0 laa-flee-button">
+      <a href="https://www.google.com" id="quick-exit" class="govuk-button govuk-button--warning laa-flee-button">
         <strong>{{ _('Hide this page') }}</strong>
         <span class="govuk-visually-hidden">{{ _('Or press escape key to hide this page') }}</span>
       </a>
@@ -67,6 +67,9 @@
         ({{ _('Or press Esc key') }})
       </p>
     </div>
+    <p class="govuk-button laa-flee-button-sizing">
+      <strong>{{ _('Hide this page') }}</strong>
+    </p>
   </div>
   <main class="govuk-main-wrapper " id="main-content" role="main" lang="{{ request.cookies.get('locale', 'en')[:2] }}">
     <div class="govuk-grid-row">

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -59,18 +59,18 @@
     {% endif %}
     ">
     <div class="laa-flee-button-position">
-      <button id="quick-exit" class="govuk-button govuk-button--warning govuk-!-margin-bottom-2 laa-flee-button">
+      <button id="quick-exit" class="govuk-button govuk-button--warning govuk-!-margin-bottom-0 laa-flee-button">
         <strong>{{ _('Hide this page') }}</strong>
         <span class="govuk-visually-hidden">{{ _('Or press escape key to hide this page') }}</span>
       </button>
-      <p class="laa-quick-exit-info govuk-body-s govuk-!-font-size-14">
+      <p class="laa-quick-exit-info govuk-body-s govuk-!-font-size-14 govuk-!-margin-top-2">
         ({{ _('Or press Esc key') }})
       </p>
     </div>
-    <button class="govuk-button govuk-button--warning govuk-!-margin-bottom-2 laa-flee-button-sizing" style="visibility: hidden;">
+    <button class="govuk-button govuk-button--warning govuk-!-margin-bottom-0 laa-flee-button-sizing" style="visibility: hidden;">
       <strong>{{ _('Hide this page') }}</strong>
     </button>
-    <p class="govuk-body-s govuk-!-font-size-14 exit-info-sizing" style="visibility: hidden;">
+    <p class="govuk-body-s govuk-!-font-size-14 exit-info-sizing govuk-!-margin-top-2" style="visibility: hidden;">
       {{ _('Or press Esc key') }}
     </p>
     <!-- identical with above to space out.-->

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -63,7 +63,7 @@
         <strong>{{ _('Hide this page') }}</strong>
         <span class="govuk-visually-hidden">{{ _('Or press escape key to hide this page') }}</span>
       </a>
-      <p class="laa-quick-exit-info govuk-body-s govuk-!-font-size-14 govuk-!-margin-top-2">
+      <p class="laa-quick-exit-info govuk-!-font-size-14">
         ({{ _('Or press Esc key') }})
       </p>
     </div>

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -59,22 +59,14 @@
     {% endif %}
     ">
     <div class="laa-flee-button-position">
-      <button id="quick-exit" class="govuk-button govuk-button--warning govuk-!-margin-bottom-0 laa-flee-button">
+      <a href="https://www.google.com" id="quick-exit" class="govuk-button govuk-button--warning govuk-!-margin-bottom-0 laa-flee-button">
         <strong>{{ _('Hide this page') }}</strong>
         <span class="govuk-visually-hidden">{{ _('Or press escape key to hide this page') }}</span>
-      </button>
+      </a>
       <p class="laa-quick-exit-info govuk-body-s govuk-!-font-size-14 govuk-!-margin-top-2">
         ({{ _('Or press Esc key') }})
       </p>
     </div>
-    <button class="govuk-button govuk-button--warning govuk-!-margin-bottom-0 laa-flee-button-sizing" style="visibility: hidden;">
-      <strong>{{ _('Hide this page') }}</strong>
-    </button>
-    <p class="govuk-body-s govuk-!-font-size-14 exit-info-sizing govuk-!-margin-top-2" style="visibility: hidden;">
-      {{ _('Or press Esc key') }}
-    </p>
-    <!-- identical with above to space out.-->
-
   </div>
   <main class="govuk-main-wrapper " id="main-content" role="main" lang="{{ request.cookies.get('locale', 'en')[:2] }}">
     <div class="govuk-grid-row">
@@ -134,8 +126,10 @@
       window.open("http://bbc.co.uk/weather", "_newtab");
       window.location.replace("http://www.google.co.uk");
     }
-    $("#quick-exit").on("click", function() {
+    $("#quick-exit").on("click", function(e) {
       fleeFromPage("mouse click");
+      e.preventDefault();
+      e.stopPropagation();
     });
     $(document).keyup(function(e) {
       if ($('.laa-flee-button-enabled').length && e.keyCode == 27) { // 27 = escape key

--- a/cla_public/templates/moj_template_base.jinja
+++ b/cla_public/templates/moj_template_base.jinja
@@ -76,6 +76,15 @@
   <body class="govuk-template__body {% block body_classes %}{{ product_type }} {{ phase }}{% endblock %}">
     <script type="text/javascript">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
+    <div class="laa-flee-button-container
+      {% if is_quick_exit_enabled(session) %}
+        govuk-visually-hidden
+      {% endif %}
+      ">
+      <p class="govuk-body">
+        ({{ _('This page has a quick exit facility, if you need to hide the page quickly, press the escape key.') }})
+      </p>
+    </div>
     <div id="skiplink-container">
       <div>
         <a href="#main-content" class="govuk-skip-link">Skip to main content</a>

--- a/cla_public/templates/moj_template_base.jinja
+++ b/cla_public/templates/moj_template_base.jinja
@@ -82,7 +82,7 @@
       {% endif %}
       ">
       <p class="govuk-body">
-        ({{ _('This page has a quick exit facility, if you need to hide the page quickly, press the escape key.') }})
+        ({{ _('To leave the page quickly, press the escape key.') }})
       </p>
     </div>
     <div id="skiplink-container">


### PR DESCRIPTION
## What does this pull request do?

Added sticky behaviour.
Adds in a non-visual element to the QE button for screen readers.
Moves the mobile button from the bottom to the top.
Adds a fallback for non-JS users.
Adds a border to the info bit.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
