### PR TITLE
LGA-1315 - Fix checks for CLA_ENV on production

### DIFF
--- a/cla_public/apps/base/forms.py
+++ b/cla_public/apps/base/forms.py
@@ -57,7 +57,7 @@ class FeedbackForm(Honeypot, BabelTranslationsFormMixin, Form):
 
         environment = current_app.config["CLA_ENV"]
         subject = "CLA Public Feedback"
-        if environment != "prod":
+        if environment != "production":
             subject = "[TEST] - " + subject
 
         ticket = {

--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 @base.route("/")
 def index():
     session.clear()
-    if current_app.config["CLA_ENV"] == "prod":
+    if current_app.config["CLA_ENV"] == "production":
         return redirect(current_app.config.get("GOV_UK_START_PAGE"))
     return render_template("index.html")
 

--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -25,7 +25,7 @@ def get_config():
 
 def grt_config_url():
     config_branch = "master"
-    if os.environ.get("CLA_ENV") != "prod":
+    if os.environ.get("CLA_ENV") != "production":
         config_branch = "develop"
 
     return (

--- a/cla_public/config/deployment.py
+++ b/cla_public/config/deployment.py
@@ -21,7 +21,7 @@ for key in settings_required:
 
 DEBUG = os.environ.get("SET_DEBUG", False) == "True"
 
-SESSION_COOKIE_SECURE = os.environ.get("CLA_ENV", "") in ["prod", "staging"]
+SESSION_COOKIE_SECURE = os.environ.get("CLA_ENV", "") in ["production", "staging"]
 
 HOST_NAME = os.environ.get("HOST_NAME") or os.environ.get("HOSTNAME")
 


### PR DESCRIPTION
## What does this pull request do?
Fixes multiple checks that the `CLA_ENV` setting is the production setting

The value of the env var on kubernetes is "production" not "prod". This
was the case even before the recent changes to the kubernetes config

The homepage redirection was recently changed to check this setting, and
was incorrectly set based on the other uses, which appear to have been
wrong for a while.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
