### PR TITLE
LGA-1319 CSS fix for Firefox bug

### DIFF
--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -203,6 +203,16 @@ hr {
   padding: 10px 11px 0 13px;
   box-sizing: border-box;
 }
+@supports (-moz-appearance:none) {
+  /*for fixing firefox only bug where currency prefix was off.*/
+  .laa-currency-prefix {
+    top:-10px;
+  }
+  .govuk-input {
+    outline: govuk-colour("white");
+  }
+}
+
 @media only screen and (max-width: 640px) {
   .laa-currency .govuk-input{
     padding-left:2.3em;

--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -206,10 +206,10 @@ hr {
 @supports (-moz-appearance:none) {
   /*for fixing firefox only bug where currency prefix was off.*/
   .laa-currency-prefix {
-    top:-10px;
+    top:-9px;
   }
   .govuk-input {
-    outline: govuk-colour("white");
+    outline: govuk-colour("white") solid;
   }
 }
 


### PR DESCRIPTION
## What does this pull request do?

The bug is a firefox-specific layout issue where the currency prefix is mis-aligned (vertically) with the input field.  The absolute positioning in Firefox is done after the padding, rather than ignoring padding as in other browsers.  

Added some Firefox-specific CSS to:
- position the currency correctly using a top value.
- add a white outline to the input box to catch any slight overflow from the positioning.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
