### PR TITLE
LGA-1283 - Partner error messages

### DIFF
--- a/cla_public/apps/checker/forms.py
+++ b/cla_public/apps/checker/forms.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 "Checker forms"
 
+import copy
 import logging
 
 from flask import session, request
@@ -406,6 +407,12 @@ class IncomeFieldForm(BaseNoCsrfForm):
         for field in self_employed_fields:
             field.set_self_employed_details(self.is_partner)
 
+        money_interval_fields = [field for field in self if isinstance(field, MoneyIntervalField)]
+        for field in money_interval_fields:
+            field.validators = [copy.copy(validator) for validator in field.validators]
+            for validator in field.validators:
+                validator.is_partner = self.is_partner
+
     earnings = SelfEmployedMoneyIntervalField(
         label=_(u"Wages before tax"),
         self_employed_descriptions={
@@ -478,6 +485,13 @@ class IncomeFieldForm(BaseNoCsrfForm):
                 freq_message=_(u"Tell us how often you receive this other income"),
                 amount_message=_(
                     u"Tell us how much other income you receive"
+                ),  # this is followed by the time period, e.g. "... each week"
+                partner_message=_(
+                    u"Enter the total amount of other income your partner receives, or 0 if this doesn’t apply to them"
+                ),
+                partner_freq_message=_(u"Tell us how often your partner receives this other income"),
+                partner_amount_message=_(
+                    u"Tell us how much other income your partner receives"
                 ),  # this is followed by the time period, e.g. "... each week"
             )
         ],

--- a/cla_public/apps/checker/forms.py
+++ b/cla_public/apps/checker/forms.py
@@ -486,13 +486,13 @@ class IncomeFieldForm(BaseNoCsrfForm):
                 amount_message=_(
                     u"Tell us how much other income you receive"
                 ),  # this is followed by the time period, e.g. "... each week"
-                partner_message=_(
-                    u"Enter the total amount of other income your partner receives, or 0 if this doesn’t apply to them"
-                ),
-                partner_freq_message=_(u"Tell us how often your partner receives this other income"),
-                partner_amount_message=_(
-                    u"Tell us how much other income your partner receives"
-                ),  # this is followed by the time period, e.g. "... each week"
+                # partner_message=_(
+                # u"Enter the total amount of other income your partner receives, or 0 if this doesn’t apply to them"
+                # ),
+                # partner_freq_message=_(u"Tell us how often your partner receives this other income"),
+                # partner_amount_message=_(
+                # u"Tell us how much other income your partner receives"
+                # ),  # this is followed by the time period, e.g. "... each week"
             )
         ],
     )

--- a/cla_public/apps/checker/validators.py
+++ b/cla_public/apps/checker/validators.py
@@ -88,8 +88,6 @@ class MoneyIntervalAmountRequired(object):
     is_partner = None
 
     def __init__(self, message=None, freq_message=None, amount_message=None, **kwargs):
-        self.args = [message, freq_message, amount_message]
-        self.kwargs = kwargs
         self.messages = {"message": message, "freq_message": freq_message, "amount_message": amount_message}
         self.partner_messages = {
             "message": kwargs.get("partner_message", message),

--- a/cla_public/apps/checker/validators.py
+++ b/cla_public/apps/checker/validators.py
@@ -85,27 +85,35 @@ class MoneyIntervalAmountRequired(object):
         "per_month": u"each month",
         "per_year": u"each year",
     }
+    is_partner = None
 
-    def __init__(self, message=None, freq_message=None, amount_message=None):
-        self.message = message
-        self.freq_message = freq_message
-        self.amount_message = amount_message
+    def __init__(self, message=None, freq_message=None, amount_message=None, **kwargs):
+        self.args = [message, freq_message, amount_message]
+        self.kwargs = kwargs
+        self.messages = {"message": message, "freq_message": freq_message, "amount_message": amount_message}
+        self.partner_messages = {
+            "message": kwargs.get("partner_message", message),
+            "freq_message": kwargs.get("partner_freq_message", freq_message),
+            "amount_message": kwargs.get("partner_amount_message", amount_message),
+        }
 
     def __call__(self, form, field):
+        messages = self.partner_messages if self.is_partner else self.messages
+
         amount = field.form.per_interval_value
         interval = field.form.interval_period
         amount_field_is_blank = not amount.errors and amount.data is None
-        specific_period_error_message = interval.data != "" and self.amount_message
+        specific_period_error_message = interval.data != "" and messages["amount_message"]
 
         if amount_field_is_blank:
             if specific_period_error_message:
-                message = self.amount_message + " " + field.gettext(self.interval_texts[interval.data])
+                message = messages["amount_message"] + " " + field.gettext(self.interval_texts[interval.data])
             else:
-                message = self.message or field.gettext(u"Type in a number")
+                message = messages["message"] or field.gettext(u"Type in a number")
             raise StopValidation(message)
 
-        if interval.data == "" and amount.data > 0 and self.freq_message:
-            raise StopValidation(self.freq_message)
+        if interval.data == "" and amount.data > 0 and messages["freq_message"]:
+            raise StopValidation(messages["freq_message"])
 
 
 class ValidMoneyInterval(object):


### PR DESCRIPTION
## What does this pull request do?
Allows `MoneyIntervalField` instances to be configured with different error messages for when they refer to the user's partner, and then to choose which messages to use when the sub-form is initiated.
Includes a sample set of `partner_` error messages, commented out.

## Any other changes that would benefit highlighting?
Manually makes copies of the validators, as by default the validators will be the same instances even on different instances of the field (presumably due to the way they are copied when the form library initialises the form), so changing instance variables on them would affect the form instances in both halves of the form.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
