### PR TITLE
LGA-1304 Add an ID to the green buttons

### DIFF
--- a/cla_public/templates/checker/about.html
+++ b/cla_public/templates/checker/about.html
@@ -39,7 +39,7 @@
     {% include '_valuables-info.html' %}
 
     {{ Form.honeypot(form) }}
-    {{ Form.actions(_('Continue')) }}
+    {{ Form.actions(_('Continue'),"submit-button") }}
   </form>
   {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/checker/additional-benefits.html
+++ b/cla_public/templates/checker/additional-benefits.html
@@ -23,7 +23,7 @@
     {% endcall %}
 
     {{ Form.honeypot(form) }}
-    {{ Form.actions(_('Continue')) }}
+    {{ Form.actions(_('Continue'),"submit-button") }}
   </form>
   {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/checker/benefits.html
+++ b/cla_public/templates/checker/benefits.html
@@ -26,7 +26,7 @@
       </fieldset>
     </div>
     {{ Form.honeypot(form) }}
-    {{ Form.actions(_('Continue')) }}
+    {{ Form.actions(_('Continue'),"submit-button") }}
   </form>
   {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/checker/income.html
+++ b/cla_public/templates/checker/income.html
@@ -54,7 +54,7 @@
     {% endif %}
 
     {{ Form.honeypot(form) }}
-    {{ Form.actions(_('Continue')) }}
+    {{ Form.actions(_('Continue'),"submit-button") }}
   </form>
   {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/checker/outgoings.html
+++ b/cla_public/templates/checker/outgoings.html
@@ -16,7 +16,7 @@
     {% endif %}
 
     {{ Form.honeypot(form) }}
-    {{ Form.actions(_('Review your answers')) }}
+    {{ Form.actions(_('Review your answers'),"submit-button") }}
   </form>
   {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/checker/property.html
+++ b/cla_public/templates/checker/property.html
@@ -54,7 +54,7 @@
     {% endif %}
 
     {{ Form.honeypot(form) }}
-    {{ Form.actions(_('Continue')) }}
+    {{ Form.actions(_('Continue'),"submit-button") }}
   </form>
   {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/checker/review.html
+++ b/cla_public/templates/checker/review.html
@@ -48,7 +48,7 @@
 
     {{ form.csrf_token }}
     {{ Form.honeypot(form) }}
-    {{ Form.actions(_('Confirm')) }}
+    {{ Form.actions(_('Confirm'),"submit-button") }}
 
   </form>
   {% include "checker/time-out-warning.html" %}

--- a/cla_public/templates/checker/savings.html
+++ b/cla_public/templates/checker/savings.html
@@ -31,7 +31,7 @@
     {% endwith %}
 
     {{ Form.honeypot(form) }}
-    {{ Form.actions(_('Continue')) }}
+    {{ Form.actions(_('Continue'),"submit-button") }}
   </form>
     {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -112,7 +112,7 @@
       {{ Subform.adaptations(form.adaptations) }}
     </div>
     {{ Form.honeypot(form) }}
-    {{ Form.actions(_('Submit details')) }}
+    {{ Form.actions(_('Submit details'),"submit-button") }}
   </form>
   {% include "checker/time-out-warning.html" %}
   {% block notice %}

--- a/cla_public/templates/feedback.html
+++ b/cla_public/templates/feedback.html
@@ -32,7 +32,7 @@
     {{ Form.group(form.ideas, field_attrs={'class': 'm-full', 'rows': 6}) }}
 
     {{ Form.honeypot(form) }}
-    {{ Form.actions(_('Continue to contact CLA')) }}
+    {{ Form.actions(_('Continue to contact CLA'),"submit-button") }}
   </form>
   {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -558,8 +558,8 @@
     - button_label <string>
         Button label
 #}
-{% macro actions(button_label) %}
-  <button class="govuk-button" data-module="govuk-button">
+{% macro actions(button_label,id) %}
+  <button class="govuk-button" id="{{ id }}" data-module="govuk-button">
     {{ button_label }}
   </button>
 {% endmacro %}

--- a/cla_public/templates/reasons-for-contacting.html
+++ b/cla_public/templates/reasons-for-contacting.html
@@ -26,7 +26,7 @@
       </fieldset>
     </div>
     {{ Form.honeypot(form) }}
-    {{ Form.actions(_('Continue to contact CLA')) }}
+    {{ Form.actions(_('Continue to contact CLA'),"submit-button") }}
   </form>
   {% include "checker/time-out-warning.html" %}
 {% endblock %}


### PR DESCRIPTION
## What does this pull request do?

Amends the `actions()` function to allow an ID parameter, so the green button can be given an ID.  

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
