### PR TITLE
LGA-1347 Maintenance page

### DIFF
--- a/cla_public/apps/base/__init__.py
+++ b/cla_public/apps/base/__init__.py
@@ -1,7 +1,7 @@
 "Base app"
 import urllib
 import datetime
-from flask import Blueprint, after_this_request, request, redirect
+from flask import Blueprint, after_this_request, request, redirect, current_app
 
 base = Blueprint("base", __name__)
 
@@ -22,3 +22,9 @@ def detect_user_locale():
             response = redirect(path)
             response.set_cookie("locale", locale, expires=expires)
             return response
+
+
+@base.before_app_request
+def detect_maintenance():
+    if current_app.config.get("MAINTENANCE_MODE", False) and request.path != u"/maintenance":
+        return redirect("/maintenance")

--- a/cla_public/apps/base/__init__.py
+++ b/cla_public/apps/base/__init__.py
@@ -26,5 +26,8 @@ def detect_user_locale():
 
 @base.before_app_request
 def detect_maintenance():
-    if current_app.config.get("MAINTENANCE_MODE", False) and request.path != u"/maintenance":
+    maintenance_mode = current_app.config.get("MAINTENANCE_MODE", False)
+    if maintenance_mode and request.path != u"/maintenance":
         return redirect("/maintenance")
+    if not maintenance_mode and request.path == u"/maintenance":
+        return redirect("/start")

--- a/cla_public/apps/base/__init__.py
+++ b/cla_public/apps/base/__init__.py
@@ -30,4 +30,4 @@ def detect_maintenance():
     if maintenance_mode and request.path != u"/maintenance":
         return redirect("/maintenance")
     if not maintenance_mode and request.path == u"/maintenance":
-        return redirect("/start")
+        return redirect("/")

--- a/cla_public/apps/base/tests/test_extensions.py
+++ b/cla_public/apps/base/tests/test_extensions.py
@@ -74,4 +74,4 @@ class TestMaintenanceModeEnabled(FlaskAppTestCase):
         response = client.get("/maintenance")
         self.assertEqual(302, response.status_code)
         headers = dict(response.headers)
-        self.assertEqual(headers.get("Location"), "http://localhost/start")
+        self.assertEqual(headers.get("Location"), "http://localhost/")

--- a/cla_public/apps/base/tests/test_extensions.py
+++ b/cla_public/apps/base/tests/test_extensions.py
@@ -42,3 +42,36 @@ class TestIsQuickExitEnabled(FlaskAppTestCase):
     def test_partial_code_match(self):
         self.session.set_history(["n1", "n1490"])
         self.assertFalse(is_quick_exit_enabled(self.session))
+
+
+class TestMaintenanceModeEnabled(FlaskAppTestCase):
+    def test_maintenance_mode_enabled_start_page(self):
+        self.app.config["MAINTENANCE_MODE"] = True
+        client = self.app.test_client()
+        response = client.get("/start")
+        self.assertEqual(302, response.status_code)
+        headers = dict(response.headers)
+        self.assertEqual(headers.get("Location"), "http://localhost/maintenance")
+
+    def test_maintenance_mode_disabled_start_page(self):
+        self.app.config["MAINTENANCE_MODE"] = False
+        client = self.app.test_client()
+        response = client.get("/start")
+        self.assertEqual(302, response.status_code)
+        headers = dict(response.headers)
+        self.assertEqual(headers.get("Location"), "http://localhost/scope/diagnosis/")
+
+    def test_maintenance_mode_enabled_maintenance_page(self):
+        self.app.config["MAINTENANCE_MODE"] = True
+        client = self.app.test_client()
+        response = client.get("/maintenance")
+        self.assertEqual(200, response.status_code)
+        self.assertIn("This service is currently down for maintenance", response.data)
+
+    def test_maintenance_mode_disabled_maintenance_page(self):
+        self.app.config["MAINTENANCE_MODE"] = False
+        client = self.app.test_client()
+        response = client.get("/maintenance")
+        self.assertEqual(302, response.status_code)
+        headers = dict(response.headers)
+        self.assertEqual(headers.get("Location"), "http://localhost/start")

--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -259,3 +259,8 @@ def healthcheck():
     result = jsonify(response)
     result.status_code = 200 if ok else 503
     return result
+
+
+@base.route("/maintenance")
+def maintenance_page():
+    return render_template("maintenance.html")

--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -107,6 +107,7 @@ MAIL_PASSWORD = os.environ.get("SMTP_PASSWORD")
 MAIL_DEFAULT_SENDER = ("Civil Legal Advice", "no-reply@civillegaladvice.service.gov.uk")
 
 GOOGLE_MAPS_API_KEY = os.environ.get("GOOGLE_MAPS_API_KEY", "")
+MAINTENANCE_MODE = os.environ.get("MAINTENANCE_MODE", "False").upper() == "TRUE"
 
 
 def current_app_cache_factory(*args, **kwargs):

--- a/cla_public/templates/errors/5xx.html
+++ b/cla_public/templates/errors/5xx.html
@@ -5,7 +5,9 @@
 {% block page_title %}{{ _('Sorry, there is a problem with the service')}} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
+  {% block heading %}
   <h1 class="govuk-heading-xl">{{ _('Sorry, there is a problem with the service') }}</h1>
+  {% endblock %}
   <p class="govuk-body">{{ _('Try again later.') }}</p>
   <p class="govuk-body">{{ _('We have not saved any information you have entered. When the service is available, you will have to start again.') }}</p>
   <p class="govuk-body">{{ _('Contact the Civil Legal Advice Helpline if you need urgent information or advice.') }}</p>

--- a/cla_public/templates/errors/5xx.html
+++ b/cla_public/templates/errors/5xx.html
@@ -9,7 +9,9 @@
   <h1 class="govuk-heading-xl">{{ _('Sorry, there is a problem with the service') }}</h1>
   {% endblock %}
   <p class="govuk-body">{{ _('Try again later.') }}</p>
+  {% block description %}
   <p class="govuk-body">{{ _('We have not saved any information you have entered. When the service is available, you will have to start again.') }}</p>
+  {% endblock %}
   <p class="govuk-body">{{ _('Contact the Civil Legal Advice Helpline if you need urgent information or advice.') }}</p>
   <p class="govuk-body">{{ _('Telephone:') }}<br />
     <strong class="govuk-!-font-weight-bold">{{ _('0345 345 4345') }}</strong>

--- a/cla_public/templates/maintenance.html
+++ b/cla_public/templates/maintenance.html
@@ -1,0 +1,11 @@
+{% extends "errors/5xx.html" %}
+
+
+{% set title = _('Maintenance') %}
+{% block page_title %}{{ title }} - {{ super() }}{% endblock %}
+
+  {% block heading %}
+  <h1 class="govuk-heading-xl">{{ _('Sorry, we are currently down for maintenance') }}</h1>
+  {% endblock %}
+
+

--- a/cla_public/templates/maintenance.html
+++ b/cla_public/templates/maintenance.html
@@ -1,11 +1,15 @@
 {% extends "errors/5xx.html" %}
 
 
-{% set title = _('Maintenance') %}
-{% block page_title %}{{ title }} - {{ super() }}{% endblock %}
+{% set title = _('This service is currently down for maintenance') %}
+{% block page_title %}{{ title }} {% endblock %}
 
-  {% block heading %}
-  <h1 class="govuk-heading-xl">{{ _('Sorry, we are currently down for maintenance') }}</h1>
-  {% endblock %}
+{% block before_content %} {% endblock %}
 
+{% block heading %}
+<h1 class="govuk-heading-xl">{{ _('This service is currently down for maintenance') }}</h1>
+{% endblock %}
 
+{% block description %}
+<p class="govuk-body">{{ _('If you were part way through the service, you will have to start again when the service becomes available') }}</p>
+{% endblock %}

--- a/helm_deploy/cla-public/templates/deployment.yaml
+++ b/helm_deploy/cla-public/templates/deployment.yaml
@@ -60,6 +60,8 @@ spec:
               value: "{{ .Values.google_maps_api_key }}"
             - name: LOG_LEVEL
               value: "{{ .Values.logLevel }}"
+            - name: MAINTENANCE_MODE
+              value: "{{ .Values.maintenanceMode }}"
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/helm_deploy/cla-public/values-dev.yaml
+++ b/helm_deploy/cla-public/values-dev.yaml
@@ -17,7 +17,6 @@ laalaa_api_host: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platfor
 google_maps_api_key: AIzaSyBVsZmfkiRFNNMJnPraN_8sBW3Dj-BFFNs
 logLevel: DEBUG
 useDevValues: true
-maintenanceMode: false
 
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:

--- a/helm_deploy/cla-public/values-dev.yaml
+++ b/helm_deploy/cla-public/values-dev.yaml
@@ -17,6 +17,7 @@ laalaa_api_host: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platfor
 google_maps_api_key: AIzaSyBVsZmfkiRFNNMJnPraN_8sBW3Dj-BFFNs
 logLevel: DEBUG
 useDevValues: true
+maintenanceMode: false
 
 # Lists don't deep merge, so this list of envVars overrides anything defined in an earlier values file
 envVars:

--- a/helm_deploy/cla-public/values.yaml
+++ b/helm_deploy/cla-public/values.yaml
@@ -37,4 +37,6 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+maintenanceMode: false
+
 envVars: []


### PR DESCRIPTION
## What does this pull request do?

- Adds maintenance mode environment variable
- Adds a before_request action that when maintenance mode is enabled redirects **ALL traffic** to the /maintenance page.

## Any other changes that would benefit highlighting?

When not in maintenance mode if someone goes to /maintenance then they will be redirected to /start

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
