### PR TITLE
LGA-955 - Fix `Unimplemented method POST` errors

### DIFF
--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -58,7 +58,7 @@
         e.stopPropagation();
         $.ajax({
           type: 'POST',
-          url: '',
+          url: this.$form.attr('action'),
           contentType: 'application/x-www-form-urlencoded',
           data: this.$form.serialize()
         })


### PR DESCRIPTION
## What does this pull request do?

Makes the ajax form submission use the form's `action` attribute as its
destination (instead of always just using the empty string)

This should fix forms which are set to POST do a url other than the one
they're currently on (eg /result/eligible posts to /contact)
Having this wrong was causing the ajax to POST to an endpoint that only
serves GET requests, and then the form would fall back to the submit
button's default behaviour of posting to the form action, so the user
was still continuing their journey but we were getting lots of warnings
from our back end.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
