### PR TITLE
LGA-1327 quick exit tab order

### DIFF
--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -377,9 +377,12 @@ dl.govuk-list.govuk-list--bullet {
       display:none;
     }
     
-    .laa-quick-exit-info{
-      display:none;
-    }
+  }
+}
+
+@media only screen and (hover: none) {
+  .laa-quick-exit-info{
+    display:none;
   }
 }
 

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -59,7 +59,7 @@
     {% endif %}
     ">
     <div class="laa-flee-button-position">
-      <a href="https://www.google.com" id="quick-exit" class="govuk-button govuk-button--warning laa-flee-button">
+      <a href="https://www.google.com" id="quick-exit" tabindex="-1" class="govuk-button govuk-button--warning laa-flee-button">
         <strong>{{ _('Hide this page') }}</strong>
         <span class="govuk-visually-hidden">{{ _('Or press escape key to hide this page') }}</span>
       </a>


### PR DESCRIPTION
## What does this pull request do?

- removes the QE button from the tab order

## Any other changes that would benefit highlighting?

- applies a CSS fix to make the QE info note (press escape) only appear when on non-mobile devices.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
