### PR TITLE
LGA-1325 fieldset added to scope options

### DIFF
--- a/cla_public/templates/scope/diagnosis.html
+++ b/cla_public/templates/scope/diagnosis.html
@@ -13,24 +13,27 @@
 {% block page_title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <h1 class="govuk-heading-xl">{{ title }}</h1>
+  <fieldset>
+    <legend>
+      <h1 class="govuk-heading-xl">{{ title }}</h1>
+    </legend>
+    {% if not nodes|length or nodes and nodes[-1].data_safety %}
+      {{ Element.staying_safe_online_link() }}
+    {% endif %}
 
-  {% if not nodes|length or nodes and nodes[-1].data_safety %}
-    {{ Element.staying_safe_online_link() }}
-  {% endif %}
-
-  <ul class="cla-scope-options-list">
-    {% for choice in choices %}
-      <li class="cla-scope-options-list-item">
-        <a class="cla-scope-options-list-item-link" title="{{ choice.label|safe|striptags }}" href="{{ choice.url }}"{% if not nodes|length %} data-ga="event:category-of-law/{{ choice.label|striptags }}"{% endif %} role="button">
-          <h2 class="govuk-heading-m govuk-!-margin-2">{{ choice.label|safe|striptags }}</h2>
-          {% if choice.help_text %}
-            <p class="govuk-body govuk-!-margin-2">{{ choice.help_text|safe|striptags }}</p>
-          {% endif %}
-        </a>
-      </li>
-    {% endfor %}
-  </ul>
+    <ul class="cla-scope-options-list">
+      {% for choice in choices %}
+        <li class="cla-scope-options-list-item">
+          <a class="cla-scope-options-list-item-link" title="{{ choice.label|safe|striptags }}" href="{{ choice.url }}"{% if not nodes|length %} data-ga="event:category-of-law/{{ choice.label|striptags }}"{% endif %} role="button">
+            <h2 class="govuk-heading-m govuk-!-margin-2">{{ choice.label|safe|striptags }}</h2>
+            {% if choice.help_text %}
+              <p class="govuk-body govuk-!-margin-2">{{ choice.help_text|safe|striptags }}</p>
+            {% endif %}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </fieldset>
   {% include "checker/time-out-warning.html" %}
   {{ Element.get_in_touch_link() }}
   

--- a/cla_public/templates/scope/diagnosis.html
+++ b/cla_public/templates/scope/diagnosis.html
@@ -13,8 +13,8 @@
 {% block page_title %}{{ title }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
-  <fieldset>
-    <legend>
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend">
       <h1 class="govuk-heading-xl">{{ title }}</h1>
     </legend>
     {% if not nodes|length or nodes and nodes[-1].data_safety %}


### PR DESCRIPTION
## What does this pull request do?

Surrounds the merits choices with `<fieldset>` and the title is in a `<legend>`

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
