### PR TITLE
LGA-1170 no options bug

### DIFF
--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -105,7 +105,7 @@
     {% if zeroOptions %}
       // this is set in diagnosis.html
       $( document ).ready(function(){
-        ga('moj.send', 'event', 'Zero-options', 'Zero options instance', 'No options instance: '+stripPII(window.location.href));
+        ga('moj.send', 'event', 'Zero-options', 'Zero options (page reload)', 'No options instance: '+stripPII(window.location.href));
         location.reload();
       })
     {% endif %}

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -106,6 +106,7 @@
       // this is set in diagnosis.html
       $( document ).ready(function(){
         ga('moj.send', 'event', 'Zero-options', 'Zero options instance', 'No options instance: '+stripPII(window.location.href));
+        location.reload();
       })
     {% endif %}
 

--- a/cla_public/templates/checker/time-out-warning.html
+++ b/cla_public/templates/checker/time-out-warning.html
@@ -1,5 +1,7 @@
 <div class="govuk-inset-text">
-  {% trans %}
-    Your session will time out after 30 minutes of inactivity. We do this for your security.
-  {% endtrans %}
+  {% if zeroOptions %}
+    {% trans %}If you are on this page for more than a few seconds, please refresh your browser{% endtrans %}
+  {% else %}
+    {% trans %}Your session will time out after 30 minutes of inactivity. We do this for your security.{% endtrans %}
+  {% endif %}
 </div>

--- a/cla_public/templates/scope/diagnosis.html
+++ b/cla_public/templates/scope/diagnosis.html
@@ -4,7 +4,7 @@
 {% if nodes|length %}
   {% set title = _(nodes[-1].heading) %}
 {% elif not choices|length %}
-  {% set title = _('Loading...') %}
+  {% set title = _('Loading…') %}
   {% set zeroOptions = true %}
 {% else %}
   {% set title = _('Choose the area you most need help with') %}

--- a/cla_public/templates/scope/diagnosis.html
+++ b/cla_public/templates/scope/diagnosis.html
@@ -4,7 +4,7 @@
 {% if nodes|length %}
   {% set title = _(nodes[-1].heading) %}
 {% elif not choices|length %}
-  {% set title = _('Select which area you most need help with') %}
+  {% set title = _('Loading...') %}
   {% set zeroOptions = true %}
 {% else %}
   {% set title = _('Choose the area you most need help with') %}


### PR DESCRIPTION
## What does this pull request do?

Added JS page reload for no-option instances.
Changed wording of no-options page to say "Loading..."
Added comment about reloading page for non-JS situations.
Changed GA naming so reports can be distinguished.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
