### PR TITLE
LGA-1333 colours etc on map page

### DIFF
--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -307,3 +307,18 @@
     }
   };
 
+  function setMapHeight() {
+    if ($(window).width() > 460 && $("ul.org-list").height() > 460) {
+      var setHeight = $("ul.org-list").height();
+      if (setHeight > $(window).height()) setHeight = $(window).height();
+      $(".search-results-container").height(setHeight);
+      $(".search-results-list").height(setHeight);
+    }
+  }
+  $("document").ready(function(){
+    setMapHeight();
+  });
+
+  $(".search-results-container").click(function(){
+    setMapHeight();
+  });

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -308,19 +308,18 @@
   };
 
   function setMapHeight(setHeight) {
-    console.log(setHeight);
     if ($(window).width() > 640) {
-      let listHeight = $("ul.org-list").height();
+      var listHeight = $("ul.org-list").height();
       if (listHeight > setHeight) setHeight = listHeight;
       $(".search-results-container, .search-results-list").height(setHeight);
     }
   }
 
   $("document").ready(function(){
-    $(".search-results-container").data("originalheight", $(".search-results-container").height());
-    setMapHeight(460);
+    var originalHeight = $(".search-results-container").height();
+    setMapHeight(originalHeight);
     $(".search-results-container").click(function(){
-      setMapHeight(460);
+      setMapHeight(originalHeight);
     });
   });
 

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -1,3 +1,4 @@
+const wideScreen = 641;
  'use strict';
   var _ = require('lodash');
   moj.Modules.FindLegalAdviser = {
@@ -24,7 +25,7 @@
 
     // Handle events which rely on media queries
     _handleMQTest: function() {
-      if(window.Modernizr.mq('(min-width: 641px)')) {
+      if(window.Modernizr.mq('(min-width: ' + wideScreen + 'px)')) {
         if(!this.eventsBound) {
           this.bindEvents();
         }
@@ -308,7 +309,7 @@
   };
 
   function setMapHeight(setHeight) {
-    if ($(window).width() > 640) {
+    if ($(window).width() >= wideScreen) {
       var listHeight = $("ul.org-list").height();
       if (listHeight > setHeight) setHeight = listHeight;
       $(".search-results-container, .search-results-list").height(setHeight);

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -307,19 +307,19 @@
     }
   };
 
-  function setMapHeight(setHeight) {
-    if ($(window).width() > 640) {
-      if ($("ul.org-list").height() > setHeight) setHeight = $("ul.org-list").height();
-      $(".search-results-container").height(setHeight);
-      $(".search-results-list").height(setHeight);
+  function setMapHeight() {
+    if ($(window).width() > 640 && $("ul.org-list").height() > 460) {
+      $(".search-results-container").height($("ul.org-list").height());
+      $(".search-results-list").height($("ul.org-list").height());
     }
   }
   $("document").ready(function(){
     const originalMapHeight = $(".search-results-container").height();
-    setMapHeight(originalMapHeight);
+    setMapHeight();
 
     $(".search-results-container").click(function(){
-      setMapHeight(originalMapHeight);
+      setMapHeight();
     });
 
   });
+

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -307,16 +307,19 @@
     }
   };
 
-  function setMapHeight() {
-    if ($(window).width() > 640 && $("ul.org-list").height() > 460) {
-      $(".search-results-container").height($("ul.org-list").height());
-      $(".search-results-list").height($("ul.org-list").height());
+  function setMapHeight(setHeight) {
+    if ($(window).width() > 640) {
+      if ($("ul.org-list").height() > setHeight) setHeight = $("ul.org-list").height();
+      $(".search-results-container").height(setHeight);
+      $(".search-results-list").height(setHeight);
     }
   }
   $("document").ready(function(){
-    setMapHeight();
-  });
+    const originalMapHeight = $(".search-results-container").height();
+    setMapHeight(originalMapHeight);
 
-  $(".search-results-container").click(function(){
-    setMapHeight();
+    $(".search-results-container").click(function(){
+      setMapHeight(originalMapHeight);
+    });
+
   });

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -307,16 +307,18 @@
     }
   };
 
-  function setMapHeight() {
-    if ($(window).width() > 640 && $("ul.org-list").height() > 460) {
-      $(".search-results-container").height($("ul.org-list").height());
-      $(".search-results-list").height($("ul.org-list").height());
+  function setMapHeight(setHeight) {
+    if ($(window).width() > 640) {
+      if ($("ul.org-list").height() > setHeight) setHeight = $("ul.org-list").height();
+      $(".search-results-container").height(setHeight);
+      $(".search-results-list").height(setHeight);
     }
   }
+
   $("document").ready(function(){
-    setMapHeight();
+    setMapHeight(460);
   });
 
   $(".search-results-container").click(function(){
-    setMapHeight();
+    setMapHeight(460);
   });

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -308,7 +308,7 @@
   };
 
   function setMapHeight() {
-    if ($(window).width() > 460 && $("ul.org-list").height() > 460) {
+    if ($(window).width() > 640 && $("ul.org-list").height() > 460) {
       $(".search-results-container").height($("ul.org-list").height());
       $(".search-results-list").height($("ul.org-list").height());
     }

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -317,7 +317,7 @@ var wideScreen = 641;
   }
 
   $("document").ready(function(){
-    var originalHeight = $(".search-results-container").height();
+    var originalHeight = $("#resultsMap").height();
     setMapHeight(originalHeight);
     $(".search-results-container").click(function(){
       setMapHeight(originalHeight);

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -309,10 +309,8 @@
 
   function setMapHeight() {
     if ($(window).width() > 460 && $("ul.org-list").height() > 460) {
-      var setHeight = $("ul.org-list").height();
-      if (setHeight > $(window).height()) setHeight = $(window).height();
-      $(".search-results-container").height(setHeight);
-      $(".search-results-list").height(setHeight);
+      $(".search-results-container").height($("ul.org-list").height());
+      $(".search-results-list").height($("ul.org-list").height());
     }
   }
   $("document").ready(function(){

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -308,13 +308,16 @@
   };
 
   function setMapHeight(setHeight) {
+    console.log(setHeight);
     if ($(window).width() > 640) {
-      if ($("ul.org-list").height() > setHeight) setHeight = $("ul.org-list").height();
+      let listHeight = $("ul.org-list").height();
+      if (listHeight > setHeight) setHeight = listHeight;
       $(".search-results-container, .search-results-list").height(setHeight);
     }
   }
 
   $("document").ready(function(){
+    $(".search-results-container").data("originalheight", $(".search-results-container").height());
     setMapHeight(460);
     $(".search-results-container").click(function(){
       setMapHeight(460);

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -1,4 +1,4 @@
-const wideScreen = 641;
+var wideScreen = 641;
  'use strict';
   var _ = require('lodash');
   moj.Modules.FindLegalAdviser = {

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -307,17 +307,19 @@
     }
   };
 
-  function setMapHeight() {
-    if ($(window).width() > 640 && $("ul.org-list").height() > 460) {
-      $(".search-results-container").height($("ul.org-list").height());
-      $(".search-results-list").height($("ul.org-list").height());
+  function setMapHeight(setHeight) {
+    if ($(window).width() > 640) {
+      if ($("ul.org-list").height() > setHeight) setHeight = $("ul.org-list").height();
+      $(".search-results-container").height(setHeight);
+      $(".search-results-list").height(setHeight);
     }
   }
+
   $("document").ready(function(){
     const originalMapHeight = $(".search-results-container").height();
-    setMapHeight();
-  });
+    setMapHeight(originalMapHeight);
 
-  $(".search-results-container").click(function(){
-    setMapHeight();
+    $(".search-results-container").click(function(){
+      setMapHeight(originalMapHeight);
+    });
   });

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -307,19 +307,16 @@
     }
   };
 
-  function setMapHeight(setHeight) {
-    if ($(window).width() > 640) {
-      if ($("ul.org-list").height() > setHeight) setHeight = $("ul.org-list").height();
-      $(".search-results-container").height(setHeight);
-      $(".search-results-list").height(setHeight);
+  function setMapHeight() {
+    if ($(window).width() > 640 && $("ul.org-list").height() > 460) {
+      $(".search-results-container").height($("ul.org-list").height());
+      $(".search-results-list").height($("ul.org-list").height());
     }
   }
-
   $("document").ready(function(){
-    const originalMapHeight = $(".search-results-container").height();
-    setMapHeight(originalMapHeight);
+    setMapHeight();
+  });
 
-    $(".search-results-container").click(function(){
-      setMapHeight(originalMapHeight);
-    });
+  $(".search-results-container").click(function(){
+    setMapHeight();
   });

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -316,10 +316,8 @@
   $("document").ready(function(){
     const originalMapHeight = $(".search-results-container").height();
     setMapHeight();
-
-    $(".search-results-container").click(function(){
-      setMapHeight();
-    });
-
   });
 
+  $(".search-results-container").click(function(){
+    setMapHeight();
+  });

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -310,15 +310,14 @@
   function setMapHeight(setHeight) {
     if ($(window).width() > 640) {
       if ($("ul.org-list").height() > setHeight) setHeight = $("ul.org-list").height();
-      $(".search-results-container").height(setHeight);
-      $(".search-results-list").height(setHeight);
+      $(".search-results-container, .search-results-list").height(setHeight);
     }
   }
 
   $("document").ready(function(){
     setMapHeight(460);
+    $(".search-results-container").click(function(){
+      setMapHeight(460);
+    });
   });
 
-  $(".search-results-container").click(function(){
-    setMapHeight(460);
-  });

--- a/cla_public/static-src/stylesheets/_find-legal-adviser.scss
+++ b/cla_public/static-src/stylesheets/_find-legal-adviser.scss
@@ -17,14 +17,6 @@ $map-height: 460px;
     }
   }
 
-  .org-category {
-    font-size: 11px;
-    display: inline-block;
-    padding: 1px 5px;
-    background: $yellow-25;
-    text-transform: uppercase;
-  }
-
   .results-filter {
     cursor: default;
     display: inline-block;

--- a/cla_public/static-src/stylesheets/_find-legal-adviser.scss
+++ b/cla_public/static-src/stylesheets/_find-legal-adviser.scss
@@ -336,6 +336,10 @@ $map-height: 460px;
   }
 }
 
+a.org-summary:focus {
+  background-color: $govuk-focus-colour;
+}
+
 @media print {
   .find-legal-adviser {
     page-break-before: always;

--- a/cla_public/static-src/stylesheets/_find-legal-adviser.scss
+++ b/cla_public/static-src/stylesheets/_find-legal-adviser.scss
@@ -384,7 +384,7 @@ $map-height: 460px;
 @media screen and (min-width:641px) {
   .govuk-grid-column-two-thirds .find-legal-adviser {
     width:150%;
-    max-width: 660px;
+    max-width: 960px;
   }
 }
 

--- a/cla_public/static-src/stylesheets/_find-legal-adviser.scss
+++ b/cla_public/static-src/stylesheets/_find-legal-adviser.scss
@@ -303,7 +303,7 @@ $map-height: 460px;
 
 #resultsMap.map {
   * {
-    font-family:"GDS Transport",Arial,sans-serif!important
+    font-family:"GDS Transport",Arial,sans-serif!important;
   }
 
   .gm-style {

--- a/cla_public/static-src/stylesheets/_find-legal-adviser.scss
+++ b/cla_public/static-src/stylesheets/_find-legal-adviser.scss
@@ -316,7 +316,7 @@ $map-height: 460px;
   .gmnoprint {
     div[role=button] {
       border-bottom:3px #929191 solid!important;
-      border-radius:0!important;
+      border-radius:0.01px!important;
       background-color:govuk-colour("white")!important;
       outline: none;
       color:$govuk-text-colour!important;
@@ -331,14 +331,16 @@ $map-height: 460px;
       }
     }
   }
-  .gm-style-cc a {
+  .gm-style-cc a:focus {
     outline-offset:0;
+    outline: solid 2px $govuk-focus-colour;
   }
 }
 
-a.org-summary:focus {
+.search-results-container a:focus {
   background-color: $govuk-focus-colour;
 }
+
 
 @media print {
   .find-legal-adviser {

--- a/cla_public/static-src/stylesheets/_find-legal-adviser.scss
+++ b/cla_public/static-src/stylesheets/_find-legal-adviser.scss
@@ -48,6 +48,10 @@ $map-height: 460px;
   }
 
   .search-results-list {
+    .org-details {
+      outline:none;
+    }
+
     .org-list {
       margin: 0;
       padding: 0;

--- a/cla_public/static-src/stylesheets/_find-legal-adviser.scss
+++ b/cla_public/static-src/stylesheets/_find-legal-adviser.scss
@@ -383,3 +383,9 @@ $map-height: 460px;
     max-width: 660px;
   }
 }
+
+@media (max-width: 640px) {
+  .search-results-container, .search-results-list {
+    height: auto!important;
+  }
+}

--- a/cla_public/static-src/stylesheets/_find-legal-adviser.scss
+++ b/cla_public/static-src/stylesheets/_find-legal-adviser.scss
@@ -63,7 +63,7 @@ $map-height: 460px;
     }
 
     .org-list-item {
-      border-top: 1px solid $grey-3;
+      border-top: 1px solid $govuk-border-colour;
       padding: 10px;
       margin: 0;
       display: block;
@@ -106,7 +106,7 @@ $map-height: 460px;
     }
 
     .distance {
-      color: $grey-1;
+      color: $govuk-text-colour;
       font-size: .8em;
       float: right;
       margin-right: -80px;
@@ -252,11 +252,11 @@ $map-height: 460px;
         padding: 4px;
 
         &:hover {
-          background: $grey-4;
+          background: govuk-colour("light-grey");
         }
 
         &.s-highlighted {
-          background: $yellow;
+          background: $govuk-focus-colour;
         }
       }
 
@@ -294,6 +294,45 @@ $map-height: 460px;
         margin: 0;
       }
     }
+  }
+}
+
+#resultsMap.map {
+  * {
+    font-family:"GDS Transport",Arial,sans-serif!important
+  }
+
+  .gm-style {
+    button:hover, div[role=button]:hover {
+      background-color: govuk-colour("light-grey") !important;
+      outline: govuk-colour("light-grey") 0px solid;
+    }
+    button:focus, div[role=button]:focus {
+      background-color: $govuk-focus-colour !important;
+      outline: $govuk-focus-colour 0px solid;
+    }
+  }
+
+  .gmnoprint {
+    div[role=button] {
+      border-bottom:3px #929191 solid!important;
+      border-radius:0!important;
+      background-color:govuk-colour("white")!important;
+      outline: none;
+      color:$govuk-text-colour!important;
+      border:1px solid govuk-colour("light-grey");
+
+      &:hover {
+        background-color:govuk-colour("light-grey")!important;
+      }
+      &:focus {
+        background-color: $govuk-focus-colour !important;
+        border-bottom-color:govuk-colour("black")!important;
+      }
+    }
+  }
+  .gm-style-cc a {
+    outline-offset:0;
   }
 }
 

--- a/cla_public/static-src/stylesheets/_find-legal-adviser.scss
+++ b/cla_public/static-src/stylesheets/_find-legal-adviser.scss
@@ -187,7 +187,6 @@ $map-height: 460px;
 
   .map {
     display: block;
-    height: $map-height;
     margin-bottom: 1em;
 
     @include media(mobile) {
@@ -224,6 +223,10 @@ $map-height: 460px;
         &:focus .fn {
           color: $govuk-text-colour;
         }
+      }
+
+      .postal-code {
+        text-transform:uppercase;
       }
 
       .org-details {

--- a/cla_public/static-src/stylesheets/_find-legal-adviser.scss
+++ b/cla_public/static-src/stylesheets/_find-legal-adviser.scss
@@ -217,8 +217,13 @@ $map-height: 460px;
       border-left: 1px solid $grey-2;
       margin-left: -1px;
 
-      .fn {
-        color: $link-colour;
+      a {
+        .fn {
+          color: $govuk-link-colour;
+        }
+        &:focus .fn {
+          color: $govuk-text-colour;
+        }
       }
 
       .org-details {

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -86,7 +86,7 @@
                   </div>
                 </header>
                 <div class="org-details">
-                  <p>
+                  <p class="govuk-body-s">
                     <span class="sr-only">{{ _('Address') }}:</span>
                     <span class="adr">
                       <span class="street-address">{{ item.location.address }}</span>
@@ -94,25 +94,23 @@
                       <span class="postal-code">{{ item.location.postcode }}</span>
                     </span>
                   </p>
-                  <p>
+                  <p class="govuk-body-s">
                     <span>{{ _('Helpline') }}:</span>
                     <span class="tel">{{ item.telephone }}</span>
                   </p>
                   {% if item.organisation.website %}
-                    <p>
+                    <p class="govuk-body-s">
                       <span>{{ _('Website') }}:</span>
                       {{ Element.link_same_window(item.organisation.website|human_to_url, item.organisation.website|url_to_human, is_external=True, **{'class': 'url'}) }}
                     </p>
                   {% endif %}
                   {% if item.categories|length %}
-                    <div class="org-categories" role="list">
-                      <h4 class="govuk-heading-s govuk-!-font-size-16 govuk-!-margin-bottom-2">{{ _('Categories of law') }}</h4>
-                      <ul class="govuk-list govuk-list--bullet govuk-!-font-size-14" role="list">
-                        {% for cat in item.categories if cat %}
-                          <li class="govuk-!-margin-0" role="listitem">{{ cat }}</li>
-                        {% endfor %}
-                      </ul>
-                    </div>
+                    <h4 class="govuk-heading-s govuk-!-font-size-16 govuk-!-margin-bottom-2">{{ _('Categories of law') }}</h4>
+                    <ul class="govuk-list govuk-list--bullet govuk-!-font-size-14" role="list">
+                      {% for cat in item.categories if cat %}
+                        <li class="govuk-!-margin-0" role="listitem">{{ cat }}</li>
+                      {% endfor %}
+                    </ul>
                   {% endif %}
                 </div>
               </li>

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -117,38 +117,6 @@
             {% endfor %}
           </ul>
         </div>
-        <nav class="search-results-pagination" style="display:none; /*reason:this-is-dormant*/">
-          <ul>
-            {% if data.previous %}
-              {% set prev_page = data.previous|query_to_dict('page') %}
-              <li class="results-nav results-nav-prev">
-                <a
-                  href="{{ url_for(request.url_rule.endpoint,
-                    postcode=request.args['postcode'],
-                    page=prev_page,
-                    category=category) }}"
-                  data-page="{{prev_page}}"
-                >
-                  {{ _('Previous') }}
-                </a>
-              </li>
-            {% endif %}
-            {% if data.next %}
-              {% set next_page = data.next|query_to_dict('page')|first %}
-              <li class="results-nav results-nav-next">
-                <a
-                  href="{{ url_for(request.url_rule.endpoint,
-                    postcode=request.args['postcode'],
-                    page=next_page,
-                    category=category) }}"
-                  data-page="{{next_page}}"
-                >
-                  {{ _('Next') }}
-                </a>
-              </li>
-            {% endif %}
-          </ul>
-        </nav>
       </div>
     </div>
   {% elif 'count' in data and data.count == 0 %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -117,7 +117,7 @@
             {% endfor %}
           </ul>
         </div>
-        <nav class="search-results-pagination" style="display:none /*reason:this-is-dormant*/">
+        <nav class="search-results-pagination" style="display:none; /*reason:this-is-dormant*/">
           <ul>
             {% if data.previous %}
               {% set prev_page = data.previous|query_to_dict('page') %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -117,7 +117,7 @@
             {% endfor %}
           </ul>
         </div>
-        <nav class="search-results-pagination">
+        <nav class="search-results-pagination" style="display:none /*reason:this-is-dormant*/">
           <ul>
             {% if data.previous %}
               {% set prev_page = data.previous|query_to_dict('page') %}
@@ -164,6 +164,21 @@
     window.LABELS = {
       loading: "{{ _('Loading…') }}"
     };
+    function setMapHeight() {
+      if ($(window).width() > 460 && $("ul.org-list").height() > 460) {
+        var setHeight = $("ul.org-list").height();
+        if (setHeight > $(window).height()) setHeight = $(window).height();
+        $(".search-results-container").height(setHeight);
+        $(".search-results-list").height(setHeight);
+      }
+    }
+    $("document").ready(function(){
+      setMapHeight();
+    });
+
+    $(".search-results-container").click(function(){
+      setMapHeight();
+    });
   </script>
 
 </section>

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -164,21 +164,6 @@
     window.LABELS = {
       loading: "{{ _('Loading…') }}"
     };
-    function setMapHeight() {
-      if ($(window).width() > 460 && $("ul.org-list").height() > 460) {
-        var setHeight = $("ul.org-list").height();
-        if (setHeight > $(window).height()) setHeight = $(window).height();
-        $(".search-results-container").height(setHeight);
-        $(".search-results-list").height(setHeight);
-      }
-    }
-    $("document").ready(function(){
-      setMapHeight();
-    });
-
-    $(".search-results-container").click(function(){
-      setMapHeight();
-    });
   </script>
 
 </section>

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -86,14 +86,6 @@
                   </div>
                 </header>
                 <div class="org-details">
-                  {% if item.categories|length %}
-                    <div class="org-categories" role="list">
-                      <div class="sr-only">{{ _('Categories of law') }}</div>
-                      {% for cat in item.categories if cat %}
-                        <span class="org-category" role="listitem">{{ cat }}</span>
-                      {% endfor %}
-                    </div>
-                  {% endif %}
                   <p>
                     <span class="sr-only">{{ _('Address') }}:</span>
                     <span class="adr">
@@ -111,6 +103,16 @@
                       <span>{{ _('Website') }}:</span>
                       {{ Element.link_same_window(item.organisation.website|human_to_url, item.organisation.website|url_to_human, is_external=True, **{'class': 'url'}) }}
                     </p>
+                  {% endif %}
+                  {% if item.categories|length %}
+                    <div class="org-categories" role="list">
+                      <h4 class="govuk-heading-s govuk-!-font-size-16 govuk-!-margin-bottom-2">{{ _('Categories of law') }}</h4>
+                      <ul class="govuk-list govuk-list--bullet govuk-!-font-size-14" role="list">
+                        {% for cat in item.categories if cat %}
+                          <li class="govuk-!-margin-0" role="listitem">{{ cat }}</li>
+                        {% endfor %}
+                      </ul>
+                    </div>
                   {% endif %}
                 </div>
               </li>


### PR DESCRIPTION
## What does this pull request do?

Distance colour changed to black
Focus colour updated list of solicitors
Focus colour updated for the map controls and links
Map and Satellite buttons updated to mimic govuk buttons (not exactly the same colours to maintain suitable contrast with map)
Cat of law tags changed to a list at the bottom of the details bit
New JS to expand the size of the map to be more suitable to the list (avoiding double-scrolling).
Unused pagination controls bit hidden (dormant, can be resurrected if/when needed)

## Any other changes that would benefit highlighting?

Max-width increased from 660 px to 960 px

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
