### PR TITLE
LGA-1342 property prefixes

### DIFF
--- a/cla_public/templates/checker/_progress.html
+++ b/cla_public/templates/checker/_progress.html
@@ -58,7 +58,6 @@
       and not (session.checker.AboutYouForm and session.checker.AboutYouForm.is_completed)
     %}
       <li class="progress-step m-collapsed">
-        <span class="govuk-visually-hidden">_('Several future pages')</span>
         {% for n in range(3) %}
           <div class="step-name"></div>
         {% endfor %}

--- a/cla_public/templates/checker/property.html
+++ b/cla_public/templates/checker/property.html
@@ -27,19 +27,19 @@
           {% endif %}
         {% endif %}
 
-          {{ Form.fieldset(property.is_main_home, hidden_legend_prefix='Property ' + loop.index) }}
-          {{ Form.fieldset(property.other_shareholders) }}
-          {{ Form.group(property.property_value, field_attrs={'prefix': '£', 'class_': ''}) }}
-          {{ Form.group(property.mortgage_remaining, field_attrs={'prefix': '£', 'class_': ''}) }}
-          {{ Form.group(property.mortgage_payments, field_attrs={'prefix': '£', 'class_': ''}) }}
+        {{ Form.fieldset(property.is_main_home, hidden_legend_prefix='Property ' ~ loop.index) }}
+        {{ Form.fieldset(property.other_shareholders) }}
+        {{ Form.group(property.property_value, field_attrs={'prefix': '£', 'class_': ''}) }}
+        {{ Form.group(property.mortgage_remaining, field_attrs={'prefix': '£', 'class_': ''}) }}
+        {{ Form.group(property.mortgage_payments, field_attrs={'prefix': '£', 'class_': ''}) }}
 
-          {% call Form.fieldset(property.is_rented) %}
-            <div class="govuk-radios__conditional">
-              {{ Form.currency_fieldset(property.rent_amount, '', controlled_by=property.is_rented) }}
-            </div>
-          {% endcall %}
+        {% call Form.fieldset(property.is_rented) %}
+          <div class="govuk-radios__conditional">
+            {{ Form.currency_fieldset(property.rent_amount, '', controlled_by=property.is_rented) }}
+          </div>
+        {% endcall %}
 
-          {{ Form.fieldset(property.in_dispute) }}
+        {{ Form.fieldset(property.in_dispute) }}
       {% endcall %}
     {% endfor %}
 

--- a/cla_public/templates/checker/property.html
+++ b/cla_public/templates/checker/property.html
@@ -27,7 +27,7 @@
           {% endif %}
         {% endif %}
 
-          {{ Form.fieldset(property.is_main_home) }}
+          {{ Form.fieldset(property.is_main_home, hidden_legend_prefix='Property ' + loop.index) }}
           {{ Form.fieldset(property.other_shareholders) }}
           {{ Form.group(property.property_value, field_attrs={'prefix': '£', 'class_': ''}) }}
           {{ Form.group(property.mortgage_remaining, field_attrs={'prefix': '£', 'class_': ''}) }}

--- a/cla_public/templates/checker/property.html
+++ b/cla_public/templates/checker/property.html
@@ -25,21 +25,22 @@
                    type="submit"
                    value="{{ _('Remove property') }} {{ loop.index }}"/>
           {% endif %}
+          {% set property_prefix = 'Property ' ~ loop.index%}
         {% endif %}
 
-        {{ Form.fieldset(property.is_main_home, hidden_legend_prefix='Property ' ~ loop.index) }}
-        {{ Form.fieldset(property.other_shareholders, hidden_legend_prefix='Property ' ~ loop.index) }}
+        {{ Form.fieldset(property.is_main_home, hidden_legend_prefix=property_prefix) }}
+        {{ Form.fieldset(property.other_shareholders, hidden_legend_prefix=property_prefix) }}
         {{ Form.group(property.property_value, field_attrs={'prefix': '£', 'class_': ''}) }}
         {{ Form.group(property.mortgage_remaining, field_attrs={'prefix': '£', 'class_': ''}) }}
         {{ Form.group(property.mortgage_payments, field_attrs={'prefix': '£', 'class_': ''}) }}
 
-        {% call Form.fieldset(property.is_rented, hidden_legend_prefix='Property ' ~ loop.index) %}
+        {% call Form.fieldset(property.is_rented, hidden_legend_prefix=property_prefix) %}
           <div class="govuk-radios__conditional">
             {{ Form.currency_fieldset(property.rent_amount, '', controlled_by=property.is_rented) }}
           </div>
         {% endcall %}
 
-        {{ Form.fieldset(property.in_dispute, hidden_legend_prefix='Property ' ~ loop.index) }}
+        {{ Form.fieldset(property.in_dispute, hidden_legend_prefix=property_prefix) }}
       {% endcall %}
     {% endfor %}
 

--- a/cla_public/templates/checker/property.html
+++ b/cla_public/templates/checker/property.html
@@ -28,18 +28,18 @@
         {% endif %}
 
         {{ Form.fieldset(property.is_main_home, hidden_legend_prefix='Property ' ~ loop.index) }}
-        {{ Form.fieldset(property.other_shareholders) }}
+        {{ Form.fieldset(property.other_shareholders, hidden_legend_prefix='Property ' ~ loop.index) }}
         {{ Form.group(property.property_value, field_attrs={'prefix': '£', 'class_': ''}) }}
         {{ Form.group(property.mortgage_remaining, field_attrs={'prefix': '£', 'class_': ''}) }}
         {{ Form.group(property.mortgage_payments, field_attrs={'prefix': '£', 'class_': ''}) }}
 
-        {% call Form.fieldset(property.is_rented) %}
+        {% call Form.fieldset(property.is_rented, hidden_legend_prefix='Property ' ~ loop.index) %}
           <div class="govuk-radios__conditional">
             {{ Form.currency_fieldset(property.rent_amount, '', controlled_by=property.is_rented) }}
           </div>
         {% endcall %}
 
-        {{ Form.fieldset(property.in_dispute) }}
+        {{ Form.fieldset(property.in_dispute, hidden_legend_prefix='Property ' ~ loop.index) }}
       {% endcall %}
     {% endfor %}
 

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -15,9 +15,6 @@
 #}
 {% macro fieldset(field=None, class_='govuk-fieldset ', legend=None, field_attrs={}, hidden_legend_prefix=None) %}
   {% set legend_ = field.label.text if field else legend %}
-  {% if hidden_legend_prefix %}
-    {% set legend_ = '<span class="govuk-visually-hidden">' + hidden_legend_prefix + '</span>' + legend_ | safe %}
-  {% endif %}
   {% set controlled_by = kwargs.controlled_by %}
   {% set control_value = kwargs.control_value if kwargs.control_value else '1' %}
   {% set legend_size = kwargs.legend_size if kwargs.legend_size else 's' %}
@@ -35,6 +32,9 @@
     >
       {% if legend_ %}
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--{{ legend_size }}" {% if field %} id="field-label-{{ field.id }}"{% endif %}>
+          {% if hidden_legend_prefix %}
+            <span class="govuk-visually-hidden">{{ hidden_legend_prefix }}</span>
+          {% endif %}
           {{ legend_ }}
         </legend>
       {% endif %}

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -33,7 +33,7 @@
       {% if legend_ %}
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--{{ legend_size }}" {% if field %} id="field-label-{{ field.id }}"{% endif %}>
           {% if hidden_legend_prefix %}
-            <span class="govuk-visually-hidden">{{ hidden_legend_prefix }}</span>
+            <span class="govuk-visually-hidden">{{ hidden_legend_prefix }} </span>
           {% endif %}
           {{ legend_ }}
         </legend>

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -13,8 +13,11 @@
     - attrs <object> (default: None)
         Custom HTML attributes for fieldset element
 #}
-{% macro fieldset(field=None, class_='govuk-fieldset ', legend=None, field_attrs={}) %}
+{% macro fieldset(field=None, class_='govuk-fieldset ', legend=None, field_attrs={}, hidden_legend_prefix=None) %}
   {% set legend_ = field.label.text if field else legend %}
+  {% if hidden_legend_prefix %}
+    {% set legend_ = '<span class="govuk-visually-hidden">' + hidden_legend_prefix + '</span>' + legend_ %}
+  {% endif %}
   {% set controlled_by = kwargs.controlled_by %}
   {% set control_value = kwargs.control_value if kwargs.control_value else '1' %}
   {% set legend_size = kwargs.legend_size if kwargs.legend_size else 's' %}

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -16,7 +16,7 @@
 {% macro fieldset(field=None, class_='govuk-fieldset ', legend=None, field_attrs={}, hidden_legend_prefix=None) %}
   {% set legend_ = field.label.text if field else legend %}
   {% if hidden_legend_prefix %}
-    {% set legend_ = '<span class="govuk-visually-hidden">' + hidden_legend_prefix + '</span>' + legend_ %}
+    {% set legend_ = '<span class="govuk-visually-hidden">' + hidden_legend_prefix + '</span>' + legend_ | safe %}
   {% endif %}
   {% set controlled_by = kwargs.controlled_by %}
   {% set control_value = kwargs.control_value if kwargs.control_value else '1' %}


### PR DESCRIPTION
## What does this pull request do?

Adds a property prefix so screen readers know that they are dealing with property number 1
- Sets a variable if property count > 1.
- Feeds variable into fieldset for all relevant fields.
- Radio buttons only, the currency fields pick up the fieldset legend.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
