### PR TITLE
LGA-1384 Error prefix for <title>

### DIFF
--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -258,6 +258,11 @@
 
       if(this.$form.data('error-banner') !== false) {
         this.$form.closest('main').prepend(this.mainFormError({ errors: this.createErrorSummary(unattachedErrors)}));
+        if (GOVUK.getCookie("locale") == "cy_GB") {
+          $("title").prepend("Gwall: ");
+        } else {
+          $("title").prepend("Error: ");
+        }
       }
 
       // Report to GA about form errors
@@ -278,6 +283,11 @@
     },
 
     clearErrors: function() {
+      $("title").text(
+        $("title").text()
+          .replace("Error: ", "")
+          .replace("Gwall: ", "")
+      );
       $('.govuk-error-message').remove();
       $('.form-row.field-error').remove();
       $('form>.alert.alert-error').remove();

--- a/cla_public/static-src/stylesheets/_progress.scss
+++ b/cla_public/static-src/stylesheets/_progress.scss
@@ -217,16 +217,16 @@ div.progress {
       .step-name {
         padding: 2px 0 3px;
 
-        &:nth-child(2) {
+        &:nth-child(1) {
           z-index: 3;
         }
 
         &:before,
-        &:nth-child(3) {
+        &:nth-child(2) {
           z-index: 2;
         }
 
-        &:nth-child(4) {
+        &:nth-child(3) {
           z-index: 1;
         }
       }

--- a/cla_public/templates/checker/base.html
+++ b/cla_public/templates/checker/base.html
@@ -6,7 +6,16 @@
 {% if form.title %}
   {% set title = form.title %}
 {% endif %}
-{% block page_title %}{{ title }} - {{ super() }}{% endblock %}
+{% block page_title %}
+  {% if form.errors %}
+    {% if request.cookies.get('locale') == 'cy_GB' %}
+      Gwall:
+    {% else %}
+      Error:
+    {% endif %}
+  {% endif %}
+  {{ title }} - {{ super() }}
+{% endblock %}
 
 {% block sidebar %}
   <aside class="sidebar">


### PR DESCRIPTION
## What does this pull request do?

Added "Error: " to the `<title>` tag when an error is thrown.  
JS and non-JS.

## Any other changes that would benefit highlighting?

CSS tweak

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
