### PR TITLE
LGA-455 Simplify cyclomatic complexity of the 'get_cait_params' function

### DIFF
--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -51,7 +51,7 @@ class CreateCaitParams:
     def __init__(self):
         self.params = {}
 
-    def create_cait_survey_options(self, survey_config, choices, nodes_config):
+    def create_cait_survey_params(self, survey_config, choices, nodes_config):
         if survey_config.get("run") is True:
             self.params["info_tools"] = True
             survey_urls = survey_config["urls"]
@@ -75,7 +75,7 @@ class CreateCaitParams:
 
             self.params["cait_survey"] = {"heading": survey_config.get("heading"), "body": survey_body}
 
-    def create_cait_link_options(self, intervention_config, links_config, organisations, truncate, choices):
+    def create_cait_link_params(self, intervention_config, links_config, organisations, truncate, choices):
         if intervention_config.get("run") is True:
             self.params["info_tools"] = True
             intervention_quota = intervention_config.get("quota")
@@ -98,7 +98,7 @@ class CreateCaitParams:
                         journey.update({"nodes": "/".join(choices), "last_node": choices[-1]})
                     self.params["cait_journey"] = journey
 
-    def create_css_and_js_options(self, css_config, js_config):
+    def create_css_and_js_params(self, css_config, js_config):
         if self.params.get("info_tools"):
             self.params["cait_css"] = css_config
             self.params["cait_js"] = js_config
@@ -123,13 +123,13 @@ def get_cait_params(category_name, organisations, choices=[], truncate=5):
         js_config = cait_intervention_config.get("js", "")
 
         # Survey
-        params_class.create_cait_survey_options(survey_config, choices, nodes_config)
+        params_class.create_cait_survey_params(survey_config, choices, nodes_config)
 
         # CAIT link
-        params_class.create_cait_link_options(intervention_config, links_config, organisations, truncate, choices)
+        params_class.create_cait_link_params(intervention_config, links_config, organisations, truncate, choices)
 
         # Additional CSS injection
-        params_class.create_css_and_js_options(css_config, js_config)
+        params_class.create_css_and_js_params(css_config, js_config)
 
     except ConfigException:
         return params

--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -48,9 +48,23 @@ def get_uuid():
 
 
 class CreateCaitParams(dict):
-    def __init__(self, *args, **kwargs):
-        super(CreateCaitParams, self).__init__(*args, **kwargs)
+    def __init__(
+        self,
+        survey_config,
+        intervention_config,
+        nodes_config,
+        links_config,
+        css_config,
+        js_config,
+        organisations,
+        choices,
+        truncate,
+    ):
+        self.create_cait_survey_params(survey_config, choices, nodes_config)
+        self.create_cait_link_params(intervention_config, links_config, organisations, truncate, choices)
+        self.create_css_and_js_params(css_config, js_config)
 
+    # Survey
     def create_cait_survey_params(self, survey_config, choices, nodes_config):
         if survey_config.get("run") is True:
             self["info_tools"] = True
@@ -75,6 +89,7 @@ class CreateCaitParams(dict):
 
             self["cait_survey"] = {"heading": survey_config.get("heading"), "body": survey_body}
 
+    # CAIT link
     def create_cait_link_params(self, intervention_config, links_config, organisations, truncate, choices):
         if intervention_config.get("run") is True:
             self["info_tools"] = True
@@ -98,6 +113,7 @@ class CreateCaitParams(dict):
                         journey.update({"nodes": "/".join(choices), "last_node": choices[-1]})
                     self["cait_journey"] = journey
 
+    # Additional CSS injection
     def create_css_and_js_params(self, css_config, js_config):
         if self.get("info_tools"):
             self["cait_css"] = css_config
@@ -105,7 +121,7 @@ class CreateCaitParams(dict):
 
 
 def get_cait_params(category_name, organisations, choices=[], truncate=5):
-    params = CreateCaitParams()
+    params = {}
     if category_name != "Family" or request.path != "/scope/refer/family":
         return params
 
@@ -128,13 +144,16 @@ def get_cait_params(category_name, organisations, choices=[], truncate=5):
         css_config = cait_intervention_config.get("css", "")
         js_config = cait_intervention_config.get("js", "")
 
-        # Survey
-        params.create_cait_survey_params(survey_config, choices, nodes_config)
-
-        # CAIT link
-        params.create_cait_link_params(intervention_config, links_config, organisations, truncate, choices)
-
-        # Additional CSS injection
-        params.create_css_and_js_params(css_config, js_config)
+        params = CreateCaitParams(
+            survey_config,
+            intervention_config,
+            nodes_config,
+            links_config,
+            css_config,
+            js_config,
+            organisations,
+            choices,
+            truncate,
+        )
 
     return params

--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -62,7 +62,11 @@ class CreateCaitParams(dict):
     ):
         self.create_cait_survey_params(survey_config, choices, nodes_config)
         self.create_cait_link_params(intervention_config, links_config, organisations, truncate, choices)
-        self.create_css_and_js_params(css_config, js_config)
+
+        # Additional CSS injection
+        if self.get("info_tools"):
+            self["cait_css"] = css_config
+            self["cait_js"] = js_config
 
     # Survey
     def create_cait_survey_params(self, survey_config, choices, nodes_config):
@@ -112,12 +116,6 @@ class CreateCaitParams(dict):
                     if len(choices) > 0:
                         journey.update({"nodes": "/".join(choices), "last_node": choices[-1]})
                     self["cait_journey"] = journey
-
-    # Additional CSS injection
-    def create_css_and_js_params(self, css_config, js_config):
-        if self.get("info_tools"):
-            self["cait_css"] = css_config
-            self["cait_js"] = js_config
 
 
 def get_cait_params(category_name, organisations, choices=[], truncate=5):

--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -48,25 +48,17 @@ def get_uuid():
 
 
 class CreateCaitParams(dict):
-    def __init__(
-        self,
-        survey_config,
-        intervention_config,
-        nodes_config,
-        links_config,
-        css_config,
-        js_config,
-        organisations,
-        choices,
-        truncate,
-    ):
-        self.create_cait_survey_params(survey_config, choices, nodes_config)
-        self.create_cait_link_params(intervention_config, links_config, organisations, truncate, choices)
+    def __init__(self, *args, **kwargs):
+        organisations, choices, truncate = args
+        self.create_cait_survey_params(kwargs["survey_config"], choices, kwargs["nodes_config"])
+        self.create_cait_link_params(
+            kwargs["intervention_config"], kwargs["links_config"], organisations, truncate, choices
+        )
 
         # Additional CSS injection
         if self.get("info_tools"):
-            self["cait_css"] = css_config
-            self["cait_js"] = js_config
+            self["cait_css"] = kwargs["css_config"]
+            self["cait_js"] = kwargs["js_config"]
 
     # Survey
     def create_cait_survey_params(self, survey_config, choices, nodes_config):
@@ -143,15 +135,15 @@ def get_cait_params(category_name, organisations, choices=[], truncate=5):
         js_config = cait_intervention_config.get("js", "")
 
         params = CreateCaitParams(
-            survey_config,
-            intervention_config,
-            nodes_config,
-            links_config,
-            css_config,
-            js_config,
             organisations,
             choices,
             truncate,
+            survey_config=survey_config,
+            intervention_config=intervention_config,
+            nodes_config=nodes_config,
+            links_config=links_config,
+            css_config=css_config,
+            js_config=js_config,
         )
 
     return params

--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -47,7 +47,7 @@ def get_uuid():
     return uuid.uuid1()
 
 
-class CreateCaitParams(dict):
+class CaitParams(dict):
     def __init__(self, *args, **kwargs):
         organisations, choices, truncate = args
         self.create_cait_survey_params(kwargs["survey_config"], choices, kwargs["nodes_config"])
@@ -134,7 +134,7 @@ def get_cait_params(category_name, organisations, choices=[], truncate=5):
         css_config = cait_intervention_config.get("css", "")
         js_config = cait_intervention_config.get("js", "")
 
-        params = CreateCaitParams(
+        params = CaitParams(
             organisations,
             choices,
             truncate,

--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -120,7 +120,7 @@ def get_cait_params(category_name, organisations, choices=[], truncate=5):
         pass
 
     else:
-        # Make sure any errors with the json/config do not effect the site
+        # Make sure any errors with the json/config do not affect the site
 
         survey_config = cait_intervention_config.get("survey", {})
         intervention_config = cait_intervention_config.get("intervention", {})

--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -121,10 +121,7 @@ def get_cait_params(category_name, organisations, choices=[], truncate=5):
     except ConfigException:
         return params
 
-    except Exception:
-        pass
-
-    else:
+    try:
         # Make sure any errors with the json/config do not affect the site
 
         survey_config = cait_intervention_config.get("survey", {})
@@ -145,5 +142,8 @@ def get_cait_params(category_name, organisations, choices=[], truncate=5):
             css_config=css_config,
             js_config=js_config,
         )
+
+    except Exception:
+        pass
 
     return params

--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -98,6 +98,11 @@ class CreateCaitParams:
                         journey.update({"nodes": "/".join(choices), "last_node": choices[-1]})
                     self.params["cait_journey"] = journey
 
+    def create_css_and_js_options(self, css_config, js_config):
+        if self.params.get("info_tools"):
+            self.params["cait_css"] = css_config
+            self.params["cait_js"] = js_config
+
 
 def get_cait_params(category_name, organisations, choices=[], truncate=5):  # noqa: C901
     params_class = CreateCaitParams()
@@ -124,9 +129,7 @@ def get_cait_params(category_name, organisations, choices=[], truncate=5):  # no
         params_class.create_cait_link_options(intervention_config, links_config, organisations, truncate, choices)
 
         # Additional CSS injection
-        if params.get("info_tools"):
-            params["cait_css"] = css_config
-            params["cait_js"] = js_config
+        params_class.create_css_and_js_options(css_config, js_config)
 
     except ConfigException:
         return params

--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -47,8 +47,17 @@ def get_uuid():
     return uuid.uuid1()
 
 
+class CreateCaitParams:
+    def __init__(self):
+        self.params = {}
+
+    def create_cait_survey_params(self):
+        pass
+
+
 def get_cait_params(category_name, organisations, choices=[], truncate=5):  # noqa: C901
-    params = {}
+    params_class = CreateCaitParams()
+    params = params_class.params
     if category_name != "Family" or request.path != "/scope/refer/family":
         return params
 

--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -54,10 +54,7 @@ def get_cait_params(category_name, organisations, choices=[], truncate=5):  # no
 
     try:
         cait_intervention_config = get_config()
-    except ConfigException:
-        return params
 
-    try:
         # Make sure any errors with the json/config do not effect the site
 
         survey_config = cait_intervention_config.get("survey", {})
@@ -118,6 +115,10 @@ def get_cait_params(category_name, organisations, choices=[], truncate=5):  # no
         if params.get("info_tools"):
             params["cait_css"] = css_config
             params["cait_js"] = js_config
+
+    except ConfigException:
+        return params
+
     except Exception:
         pass
 

--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -113,6 +113,13 @@ def get_cait_params(category_name, organisations, choices=[], truncate=5):
     try:
         cait_intervention_config = get_config()
 
+    except ConfigException:
+        return params
+
+    except Exception:
+        pass
+
+    else:
         # Make sure any errors with the json/config do not effect the site
 
         survey_config = cait_intervention_config.get("survey", {})
@@ -130,11 +137,5 @@ def get_cait_params(category_name, organisations, choices=[], truncate=5):
 
         # Additional CSS injection
         params_class.create_css_and_js_params(css_config, js_config)
-
-    except ConfigException:
-        return params
-
-    except Exception:
-        pass
 
     return params

--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -104,7 +104,7 @@ class CreateCaitParams:
             self.params["cait_js"] = js_config
 
 
-def get_cait_params(category_name, organisations, choices=[], truncate=5):  # noqa: C901
+def get_cait_params(category_name, organisations, choices=[], truncate=5):
     params_class = CreateCaitParams()
     params = params_class.params
     if category_name != "Family" or request.path != "/scope/refer/family":

--- a/cla_public/apps/checker/cait_intervention.py
+++ b/cla_public/apps/checker/cait_intervention.py
@@ -69,11 +69,11 @@ class CaitParams(dict):
 
             if len(choices) > 1:
                 entrypoint = nodes_config.get(choices[1], {})
-                survey = entrypoint.get("survey")
 
                 if entrypoint:
                     nested = entrypoint.get("nested", [])
                     if not nested or (len(choices) > 2 and choices[2] in nested):
+                        survey = entrypoint.get("survey")
                         survey_url = survey_urls.get(survey)
 
             if not survey_url:


### PR DESCRIPTION
## What does this pull request do?

- Create a class called `CaitParams` and separate out the functionality of the `get_cait_params` function into methods on the class

## Any other changes that would benefit highlighting?

The `CaitParams` class has been made into a dict-like object using dict as a base class. The methods on the class set key, value pairs upon itself. It is assigned to the `params` variable and eventually returned when it has been fully configured

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
