### PR TITLE
Feature/lga 1363 opening times

### DIFF
--- a/cla_public/django_to_jinja.py
+++ b/cla_public/django_to_jinja.py
@@ -59,7 +59,7 @@ def change_jinja_templates(app):
     # get today's date
     @app.context_processor
     def covid_availability_times():
-        show_covid_availability_times = datetime.date(year=2020, month=9, day=10) > datetime.date.today()
+        show_covid_availability_times = datetime.date(year=2020, month=9, day=30) > datetime.date.today()
         return {"show_covid_availability_times": show_covid_availability_times}
 
     return app

--- a/cla_public/django_to_jinja.py
+++ b/cla_public/django_to_jinja.py
@@ -58,7 +58,8 @@ def change_jinja_templates(app):
 
     # get today's date
     @app.context_processor
-    def inject_today_date():
-        return {"today_date": datetime.date.today()}
+    def covid_availability_times():
+        show_covid_availability_times = datetime.date(year=2020,month=9,day=30) > datetime.date.today()
+        return {"show_covid_availability_times": show_covid_availability_times}
 
     return app

--- a/cla_public/django_to_jinja.py
+++ b/cla_public/django_to_jinja.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import datetime
 
 from flask import Blueprint, url_for
 from flask.ext.markdown import Markdown
@@ -54,5 +55,10 @@ def change_jinja_templates(app):
         except KeyError:
             log.critical("Cannot find APP_SETTINGS group in the configuration file.")
             sys.exit(1)
+
+    # get today's date
+    @app.context_processor
+    def inject_today_date():
+        return {"today_date": datetime.date.today()}
 
     return app

--- a/cla_public/django_to_jinja.py
+++ b/cla_public/django_to_jinja.py
@@ -59,7 +59,7 @@ def change_jinja_templates(app):
     # get today's date
     @app.context_processor
     def covid_availability_times():
-        show_covid_availability_times = datetime.date(year=2020, month=9, day=30) > datetime.date.today()
+        show_covid_availability_times = datetime.date(year=2020, month=9, day=10) > datetime.date.today()
         return {"show_covid_availability_times": show_covid_availability_times}
 
     return app

--- a/cla_public/django_to_jinja.py
+++ b/cla_public/django_to_jinja.py
@@ -59,7 +59,7 @@ def change_jinja_templates(app):
     # get today's date
     @app.context_processor
     def covid_availability_times():
-        show_covid_availability_times = datetime.date(year=2020,month=9,day=30) > datetime.date.today()
+        show_covid_availability_times = datetime.date(year=2020, month=9, day=30) > datetime.date.today()
         return {"show_covid_availability_times": show_covid_availability_times}
 
     return app

--- a/cla_public/static-templates/errors/50x.html
+++ b/cla_public/static-templates/errors/50x.html
@@ -145,7 +145,7 @@
           </p>
           <p class="govuk-body">{% trans %}Opening times:{% endtrans %}<br />
             {% set today_date_string = today_date | replace("-", "") | int %}
-            {% if today_date_string >= 20200930 %}
+            {% if today_date_string <= 20200930 %}
               <strong class="govuk-!-font-weight-bold">{% trans %}Monday to Friday: 9am to 8pm{% endtrans %}<br />{% trans %}Saturday: 9am to 12.30pm{% endtrans %}</strong>
             {% else %}
               <strong class="govuk-!-font-weight-bold">{% trans %}Monday to Friday: 9am to 5pm{% endtrans %}</strong>

--- a/cla_public/static-templates/errors/50x.html
+++ b/cla_public/static-templates/errors/50x.html
@@ -144,11 +144,10 @@
             <a href="https://www.gov.uk/call-charges">{% trans %}Find out about call charges here{% endtrans %}</a>.
           </p>
           <p class="govuk-body">{% trans %}Opening times:{% endtrans %}<br />
-            {% set today_date_string = today_date | replace("-", "") | int %}
-            {% if today_date_string >= 20200930 %}
-              <strong class="govuk-!-font-weight-bold">{% trans %}Monday to Friday: 9am to 8pm{% endtrans %}<br />{% trans %}Saturday: 9am to 12.30pm{% endtrans %}</strong>
-            {% else %}
+            {% if show_covid_availability_times %}
               <strong class="govuk-!-font-weight-bold">{% trans %}Monday to Friday: 9am to 5pm{% endtrans %}</strong>
+            {% else %}
+              <strong class="govuk-!-font-weight-bold">{% trans %}Monday to Friday: 9am to 8pm{% endtrans %}<br />{% trans %}Saturday: 9am to 12.30pm{% endtrans %}</strong>
             {% endif %}
           </p>
           <div class="govuk-inset-text">

--- a/cla_public/static-templates/errors/50x.html
+++ b/cla_public/static-templates/errors/50x.html
@@ -145,7 +145,7 @@
           </p>
           <p class="govuk-body">{% trans %}Opening times:{% endtrans %}<br />
             {% set today_date_string = today_date | replace("-", "") | int %}
-            {% if today_date_string <= 20200930 %}
+            {% if today_date_string >= 20200930 %}
               <strong class="govuk-!-font-weight-bold">{% trans %}Monday to Friday: 9am to 8pm{% endtrans %}<br />{% trans %}Saturday: 9am to 12.30pm{% endtrans %}</strong>
             {% else %}
               <strong class="govuk-!-font-weight-bold">{% trans %}Monday to Friday: 9am to 5pm{% endtrans %}</strong>

--- a/cla_public/static-templates/errors/50x.html
+++ b/cla_public/static-templates/errors/50x.html
@@ -144,8 +144,12 @@
             <a href="https://www.gov.uk/call-charges">{% trans %}Find out about call charges here{% endtrans %}</a>.
           </p>
           <p class="govuk-body">{% trans %}Opening times:{% endtrans %}<br />
-            <!--<strong class="govuk-!-font-weight-bold">{% trans %}Monday to Friday: 9am to 8pm{% endtrans %}<br />{% trans %}Saturday: 9am to 12.30pm{% endtrans %}</strong>-->
-            <strong class="govuk-!-font-weight-bold">{% trans %}Monday to Friday: 9am to 5pm{% endtrans %}</strong>
+            {% set today_date_string = today_date | replace("-", "") | int %}
+            {% if today_date_string >= 20200930 %}
+              <strong class="govuk-!-font-weight-bold">{% trans %}Monday to Friday: 9am to 8pm{% endtrans %}<br />{% trans %}Saturday: 9am to 12.30pm{% endtrans %}</strong>
+            {% else %}
+              <strong class="govuk-!-font-weight-bold">{% trans %}Monday to Friday: 9am to 5pm{% endtrans %}</strong>
+            {% endif %}
           </p>
           <div class="govuk-inset-text">
             {%- trans -%}This service is only available if you are a resident of England or Wales.{% endtrans %}

--- a/cla_public/templates/errors/5xx.html
+++ b/cla_public/templates/errors/5xx.html
@@ -29,7 +29,7 @@
   </div>
   <p class="govuk-body">{{ _('Opening times:') }}<br />
     {% set today_date_string = today_date | replace("-", "") | int %}
-    {% if today_date_string <= 20200930 %}
+    {% if today_date_string >= 20200930 %}
       <strong class="govuk-!-font-weight-bold">{{ _('Monday to Friday: 9am to 8pm') }}<br />{{ _('Saturday: 9am to 12.30pm') }}</strong>
     {% else %}
       <strong class="govuk-!-font-weight-bold">{{ _('Monday to Friday: 9am to 5pm') }}</strong>

--- a/cla_public/templates/errors/5xx.html
+++ b/cla_public/templates/errors/5xx.html
@@ -28,11 +28,10 @@
     </p>
   </div>
   <p class="govuk-body">{{ _('Opening times:') }}<br />
-    {% set today_date_string = today_date | replace("-", "") | int %}
-    {% if today_date_string >= 20200930 %}
-      <strong class="govuk-!-font-weight-bold">{{ _('Monday to Friday: 9am to 8pm') }}<br />{{ _('Saturday: 9am to 12.30pm') }}</strong>
-    {% else %}
+    {% if show_covid_availability_times %}
       <strong class="govuk-!-font-weight-bold">{{ _('Monday to Friday: 9am to 5pm') }}</strong>
+    {% else %}
+      <strong class="govuk-!-font-weight-bold">{{ _('Monday to Friday: 9am to 8pm') }}<br />{{ _('Saturday: 9am to 12.30pm') }}</strong>
     {% endif %}
   </p>
 {% endblock %}

--- a/cla_public/templates/errors/5xx.html
+++ b/cla_public/templates/errors/5xx.html
@@ -29,7 +29,7 @@
   </div>
   <p class="govuk-body">{{ _('Opening times:') }}<br />
     {% set today_date_string = today_date | replace("-", "") | int %}
-    {% if today_date_string >= 20200930 %}
+    {% if today_date_string <= 20200930 %}
       <strong class="govuk-!-font-weight-bold">{{ _('Monday to Friday: 9am to 8pm') }}<br />{{ _('Saturday: 9am to 12.30pm') }}</strong>
     {% else %}
       <strong class="govuk-!-font-weight-bold">{{ _('Monday to Friday: 9am to 5pm') }}</strong>

--- a/cla_public/templates/errors/5xx.html
+++ b/cla_public/templates/errors/5xx.html
@@ -28,8 +28,12 @@
     </p>
   </div>
   <p class="govuk-body">{{ _('Opening times:') }}<br />
-    <!--<strong class="govuk-!-font-weight-bold">{{ _('Monday to Friday: 9am to 8pm') }}<br />{{ _('Saturday: 9am to 12.30pm') }}</strong>-->
-    <strong class="govuk-!-font-weight-bold">{{ _('Monday to Friday: 9am to 5pm') }}</strong>
+    {% set today_date_string = today_date | replace("-", "") | int %}
+    {% if today_date_string >= 20200930 %}
+      <strong class="govuk-!-font-weight-bold">{{ _('Monday to Friday: 9am to 8pm') }}<br />{{ _('Saturday: 9am to 12.30pm') }}</strong>
+    {% else %}
+      <strong class="govuk-!-font-weight-bold">{{ _('Monday to Friday: 9am to 5pm') }}</strong>
+    {% endif %}
   </p>
 {% endblock %}
 

--- a/cla_public/templates/macros/element.html
+++ b/cla_public/templates/macros/element.html
@@ -78,7 +78,7 @@
     - completed <Number>
 #}
 
-{%  macro progress_bar(completed, offset=-5) %}
+{% macro progress_bar(completed, offset=-5) %}
   {% if completed is number %}
     <div class="progress-bar">
       {% if completed %}

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -1,6 +1,6 @@
-{{ extends "base.html" }}
+{% extends "base.html" %}
 
-{% block page_title %}{{ _('Privacy Statement') }} - {{ super() }}{% endblock %}
+{% block page_title %}{% _('Privacy Statement') %} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
   <h1 class="govuk-heading-xl">{{ _('Terms and conditions and privacy') }}</h1>

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block page_title %}{{ _('Privacy Statement') }} - {{ super() }}{% endblock %}
+{% block page_title %}{% _('Privacy Statement') %} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
   <h1 class="govuk-heading-xl">{{ _('Terms and conditions and privacy') }}</h1>

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block page_title %}{% _('Privacy Statement') %} - {{ super() }}{% endblock %}
+{% block page_title %}{{ _('Privacy Statement') }} - {{ super() }}{% endblock %}
 
 {% block inner_content %}
   <h1 class="govuk-heading-xl">{{ _('Terms and conditions and privacy') }}</h1>

--- a/cla_public/templates/privacy.html
+++ b/cla_public/templates/privacy.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{{ extends "base.html" }}
 
 {% block page_title %}{{ _('Privacy Statement') }} - {{ super() }}{% endblock %}
 


### PR DESCRIPTION
## What does this pull request do?

Reverts the 500 error page contact hours to their pre-Covid times
- Change will happen on September 30th
- September 30th will use pre-Covid times
- Prior to Sept 30th, the current times will remain in use

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
