### PR TITLE
LGA-1339 LARP page changes

### DIFF
--- a/cla_public/apps/checker/forms.py
+++ b/cla_public/apps/checker/forms.py
@@ -699,4 +699,4 @@ class ReviewForm(BaseForm):
 
 
 class FindLegalAdviserForm(Honeypot, BabelTranslationsFormMixin, Form):
-    postcode = StringField(_(u"Enter postcode"), validators=[InputRequired()])
+    postcode = StringField(_(u"Enter postcode"), validators=[InputRequired(_(u"Enter a postcode"))])

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -129,6 +129,7 @@ var wideScreen = 641;
     _prepareMarkers: function() {
       var organisations = $.map(this.$organisationListItems, function(item) {
         var $item = $(item);
+        console.log('Dæta: '+$item)
         return {
           id: $item.data('id'),
           position: {

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -129,7 +129,6 @@ var wideScreen = 641;
     _prepareMarkers: function() {
       var organisations = $.map(this.$organisationListItems, function(item) {
         var $item = $(item);
-        console.log('Dæta: '+JSON.stringify($item));
         return {
           id: $item.data('id'),
           position: {

--- a/cla_public/static-src/javascripts/modules/find-legal-adviser.js
+++ b/cla_public/static-src/javascripts/modules/find-legal-adviser.js
@@ -129,7 +129,7 @@ var wideScreen = 641;
     _prepareMarkers: function() {
       var organisations = $.map(this.$organisationListItems, function(item) {
         var $item = $(item);
-        console.log('Dæta: '+$item)
+        console.log('Dæta: '+JSON.stringify($item));
         return {
           id: $item.data('id'),
           position: {

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -125,7 +125,8 @@
     </p>
   {% endcall %}
 
-  {% Form.postcode.error.append( "Postcode not found" ) %}
+  Postcode: {{ Form.postcode }}
+  Postcode Error: {{ Form.postcode.error }}
 
   {% set find_legal_advisor_subtitle = _('Try again') %}
 

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -109,9 +109,13 @@
       </div>
     </div>
   </section>
-  {% if not hide_subtitle %}
-    <h2 class="govuk-heading-m">{{ _('Search again') }}</h2>
-  {% endif %}
+
+  <p class="govuk-body">
+    <a class="govuk-link" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">
+      {% trans %}What did you think of this service?{% endtrans %}</a> {% trans %}(takes 30 seconds){% endtrans %}
+  </p>
+
+  {% set find_legal_advisor_subtitle = _('Search again') %}
 
 {% elif 'count' in data and data.count == 0 %}
   {% call Element.alert('error', title=_('No results')) %}
@@ -121,9 +125,7 @@
     </p>
   {% endcall %}
 
-  {% if not hide_subtitle %}
-    <h2 class="govuk-heading-m">{{ _('Try again') }}</h2>
-  {% endif %}
+  {% set find_legal_advisor_subtitle = _('Try again') %}
 
 {% else %}
 
@@ -131,83 +133,85 @@
     <h1 class="govuk-heading-xl">
       {{ _('A legal adviser may be able to help you') }}
     </h1>
-    <p class="govuk-body">
-      {% trans %}You will usually only get legal aid for advice about
-        clinical negligence if your child has suffered a brain injury during pregnancy,
-        birth or in the first 8 weeks of life.{% endtrans %}
-    </p>
-    <h2 class="govuk-heading-m">{% trans %}What happens next{% endtrans %}</h2>
-    <p class="govuk-body">
-      {% trans %}You should contact a legal aid adviser in your area,
-          who may be able to help.{% endtrans %}
-    </p>
-
   {% elif category == 'pi' %}
     <h1 class="govuk-heading-xl">
       {{ _('Legal aid is not usually available for advice about personal injury') }}
     </h1>
-    <p class="govuk-body">
-      {% trans %}You may be able to get legal aid in exceptional cases. You
-        could seek advice from a legal adviser about whether an application
-        might succeed in your case and how to apply.{% endtrans %}
-    </p>
-    <h2 class="govuk-heading-m">What happens next</h2>
   {% elif category == 'debt' or category == 'housing' %}
     <h1 class="govuk-heading-xl">
       {{ _('A legal adviser may be able to help you') }}
     </h1>
-    <h2 class="govuk-heading-m">What happens next</h2>
   {% else %}
     <h1 class="govuk-heading-xl">
       {{ _('A legal adviser may be able to help you') }}
     </h1>
-    <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
   {% endif %}
 
-  <p class="govuk-body">
-    {% trans %}
-      Your adviser will check whether you qualify for legal aid <strong>at
-      no cost to you</strong> by asking about your problem and your finances.
-    {% endtrans %}
-    {% trans %}In some cases you may need to pay a contribution towards your legal aid.{% endtrans %}
-  </p>
-
-  <p class="govuk-body">
-      <a class="govuk-link" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">
-        {% trans %}What did you think of this service?{% endtrans %}</a> {% trans %}(takes 30 seconds){% endtrans %}
-
-  </p>
-
-  {% if category == 'mentalhealth' %}
-    <p class="govuk-body">
-      {% trans %}If you’re applying for legal aid for a mental health issue,
-        the requirements for the financial assessment are less rigorous than
-        for other legal aid problems.{% endtrans %}
-    </p>
-
-  {% endif %}
-
-  {% if not hide_subtitle %}
-    <h2 class="govuk-heading-m">{{ _('Find a legal adviser') }}</h2>
-  {% endif %}
+  {% set find_legal_advisor_subtitle = _('Find a legal adviser') %}
 
 {% endif %}
 
-  <form method="GET">
-    {{ Form.postcode_input(form.postcode) }}
-    {% if category %}
-      <div class="govuk-form-group">
-        <input class="govuk-input govuk-input--width-10" id="category" type="hidden" name="category" value="{{ category }}" />
-      </div>
-    {% endif %}
-    <button class="govuk-button" type="submit">
-      {{ _('Search') }}
-    </button>
-  </form>
+
+{% if category == 'clinneg' %}
+  <p class="govuk-body">
+    {% trans %}You will usually only get legal aid for advice about
+      clinical negligence if your child has suffered a brain injury during pregnancy,
+      birth or in the first 8 weeks of life.{% endtrans %}
+  </p>
+  <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
+  <p class="govuk-body">
+    {% trans %}You should contact a legal aid adviser in your area,
+        who may be able to help.{% endtrans %}
+  </p>
+
+{% elif category == 'pi' %}
+  <p class="govuk-body">
+    {% trans %}You may be able to get legal aid in exceptional cases. You
+      could seek advice from a legal adviser about whether an application
+      might succeed in your case and how to apply.{% endtrans %}
+  </p>
+  <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
+{% elif category == 'debt' or category == 'housing' %}
+  <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
+{% else %}
+  <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
+{% endif %}
+
+<p class="govuk-body">
+  {% trans %}
+    Your adviser will check whether you qualify for legal aid <strong>at
+    no cost to you</strong> by asking about your problem and your finances.
+  {% endtrans %}
+  {% trans %}In some cases you may need to pay a contribution towards your legal aid.{% endtrans %}
+</p>
+
+{% if category == 'mentalhealth' %}
+  <p class="govuk-body">
+    {% trans %}If you’re applying for legal aid for a mental health issue,
+      the requirements for the financial assessment are less rigorous than
+      for other legal aid problems.{% endtrans %}
+  </p>
+{% endif %}
+
+{% if not hide_subtitle %}
+  <h2 class="govuk-heading-m">{{ find_legal_advisor_subtitle }}</h2>
+{% endif %}
+
+<form method="GET">
+  {{ Form.postcode_input(form.postcode) }}
+  {% if category %}
+    <div class="govuk-form-group">
+      <input class="govuk-input govuk-input--width-10" id="category" type="hidden" name="category" value="{{ category }}" />
+    </div>
+  {% endif %}
+  <button class="govuk-button" type="submit">
+    {{ _('Search') }}
+  </button>
+</form>
 
 
-  <script>
-    window.LABELS = {
-      loading: "{{ _('Loading…') }}"
-    };
-  </script>
+<script>
+  window.LABELS = {
+    loading: "{{ _('Loading…') }}"
+  };
+</script>

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -129,7 +129,6 @@
 
     {% set postcode_error = true %}
 
-    {% set find_legal_advisor_subtitle = _('Try again') %}
   {% endif %}
 
   {% if form.postcode and form.postcode.errors %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -113,6 +113,66 @@
     {% endcall %}
   {% else %}
 
+    {% if category == 'clinneg' %}
+      <h1 class="govuk-heading-xl">
+        {{ _('A legal adviser may be able to help you') }}
+      </h1>
+      <p class="govuk-body">
+        {% trans %}You will usually only get legal aid for advice about
+          clinical negligence if your child has suffered a brain injury during pregnancy,
+          birth or in the first 8 weeks of life.{% endtrans %}
+      </p>
+      <h2 class="govuk-heading-m">{% trans %}What happens next{% endtrans %}</h2>
+      <p class="govuk-body">
+        {% trans %}You should contact a legal aid adviser in your area,
+            who may be able to help.{% endtrans %}
+      </p>
+
+    {% elif category == 'pi' %}
+      <h1 class="govuk-heading-xl">
+        {{ _('Legal aid is not usually available for advice about personal injury') }}
+      </h1>
+      <p class="govuk-body">
+        {% trans %}You may be able to get legal aid in exceptional cases. You
+          could seek advice from a legal adviser about whether an application
+          might succeed in your case and how to apply.{% endtrans %}
+      </p>
+      <h2 class="govuk-heading-m">What happens next</h2>
+    {% elif category == 'debt' or category == 'housing' %}
+      <h1 class="govuk-heading-xl">
+        {{ _('A legal adviser may be able to help you') }}
+      </h1>
+      <h2 class="govuk-heading-m">What happens next</h2>
+    {% else %}
+      <h1 class="govuk-heading-xl">
+        {{ _('A legal adviser may be able to help you') }}
+      </h1>
+      <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
+    {% endif %}
+
+    <p class="govuk-body">
+      {% trans %}
+        Your adviser will check whether you qualify for legal aid <strong>at
+        no cost to you</strong> by asking about your problem and your finances.
+      {% endtrans %}
+      {% trans %}In some cases you may need to pay a contribution towards your legal aid.{% endtrans %}
+    </p>
+
+    <p class="govuk-body">
+        <a class="govuk-link" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">
+          {% trans %}What did you think of this service?{% endtrans %}</a> {% trans %}(takes 30 seconds){% endtrans %}
+
+    </p>
+
+    {% if category == 'mentalhealth' %}
+      <p class="govuk-body">
+        {% trans %}If you’re applying for legal aid for a mental health issue,
+          the requirements for the financial assessment are less rigorous than
+          for other legal aid problems.{% endtrans %}
+      </p>
+
+    {% endif %}
+
     {% if not hide_subtitle %}
       <h2 class="govuk-heading-m">{{ _('Find a legal adviser') }}</h2>
     {% endif %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -200,7 +200,7 @@
 {% endif %}
 
 <form method="GET">
-  {% if postcode_error = true %}
+  {% if postcode_error == true %}
     {{ Form.postcode_input(form.postcode, class_="govuk-form-group--error") }}
   {% else %}
     {{ Form.postcode_input(form.postcode) }}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -125,6 +125,8 @@
     </p>
   {% endcall %}
 
+  {% set postcode_error = true %}
+
   {% set find_legal_advisor_subtitle = _('Try again') %}
 
 {% else %}
@@ -198,6 +200,9 @@
 {% endif %}
 
 <form method="GET">
+  {% if postcode_error = true %}
+    {% set form.postcode.error[0] = "Postcode not found" %}
+  {% endif %}
   {{ Form.postcode_input(form.postcode) }}
   {% if category %}
     <div class="govuk-form-group ">

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -117,23 +117,24 @@
 
   {% set find_legal_advisor_subtitle = _('Search again') %}
 
-{% elif 'count' in data and data.count == 0 %}
-  {% call Element.alert('error', title=_('No results')) %}
-    <div class="govuk-error-summary__body">
-    <ul class="govuk-list govuk-error-summary__list">
-      <li>
-        <a href="#postcode">{% trans %}We couldn’t find any results for your search.
-      We are constantly updating our records so please try again later.{% endtrans %}</a>
-      </li>
-    </ul>
-  </div>
-  {% endcall %}
-
-  {% set postcode_error = true %}
-
-  {% set find_legal_advisor_subtitle = _('Try again') %}
-
 {% else %}
+
+  {% if 'count' in data and data.count == 0 %}
+    {% call Element.alert('error', title=_('No results')) %}
+      <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li>
+          <a href="#postcode">{% trans %}We couldn’t find any results for your search.
+        We are constantly updating our records so please try again later.{% endtrans %}</a>
+        </li>
+      </ul>
+    </div>
+    {% endcall %}
+
+    {% set postcode_error = true %}
+
+    {% set find_legal_advisor_subtitle = _('Try again') %}
+  {% endif %}
 
   {% if category == 'clinneg' %}
     <h1 class="govuk-heading-xl">

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -148,17 +148,9 @@
     {% endcall %}
   {% endif %}
 
-  {% if category == 'clinneg' %}
-    <h1 class="govuk-heading-xl">
-      {{ _('A legal adviser may be able to help you') }}
-    </h1>
-  {% elif category == 'pi' %}
+  {% if category == 'pi' %}
     <h1 class="govuk-heading-xl">
       {{ _('Legal aid is not usually available for advice about personal injury') }}
-    </h1>
-  {% elif category == 'debt' or category == 'housing' %}
-    <h1 class="govuk-heading-xl">
-      {{ _('A legal adviser may be able to help you') }}
     </h1>
   {% else %}
     <h1 class="govuk-heading-xl">

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -110,11 +110,6 @@
     </div>
   </section>
 
-  <p class="govuk-body">
-    <a class="govuk-link" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">
-      {% trans %}What did you think of this service?{% endtrans %}</a> {% trans %}(takes 30 seconds){% endtrans %}
-  </p>
-
   {% set find_legal_advisor_subtitle = _('Search again') %}
 
 {% else %}
@@ -180,8 +175,7 @@
   </p>
   <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
   <p class="govuk-body">
-    {% trans %}You should contact a legal aid adviser in your area,
-        who may be able to help.{% endtrans %}
+    {% trans %}You should contact a legal aid adviser in your area, who may be able to help.{% endtrans %}
   </p>
 
 {% elif category == 'pi' %}
@@ -208,6 +202,13 @@
     {% trans %}If you’re applying for legal aid for a mental health issue,
       the requirements for the financial assessment are less rigorous than
       for other legal aid problems.{% endtrans %}
+  </p>
+{% endif %}
+
+{% if find_legal_advisor_subtitle == _('Search again') %}
+  <p class="govuk-body">
+    <a class="govuk-link" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">
+      {% trans %}What did you think of this service?{% endtrans %}</a> {% trans %}(takes 30 seconds){% endtrans %}
   </p>
 {% endif %}
 

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -225,6 +225,7 @@
   {% endif %}
   {% if category %}
     <div class="govuk-form-group ">
+    {{ error_text }}
       <input class="govuk-input govuk-input--width-10 " id="category" type="hidden" name="category" value="{{ category }}" />
     </div>
   {% endif %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -218,14 +218,13 @@
 <form method="GET">
   {% if postcode_error == true %}
     {{ Form.postcode_input(form.postcode, custom_error=_('Postcode not found')) }}
-  {% elif error_text|length > 1 %}
+  {% elif error_text %}
     {{ Form.postcode_input(form.postcode, custom_error=error_text) }}
   {% else %}
     {{ Form.postcode_input(form.postcode) }}
   {% endif %}
   {% if category %}
     <div class="govuk-form-group ">
-    {{ error_text }}
       <input class="govuk-input govuk-input--width-10 " id="category" type="hidden" name="category" value="{{ category }}" />
     </div>
   {% endif %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -191,8 +191,6 @@
       might succeed in your case and how to apply.{% endtrans %}
   </p>
   <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
-{% elif category == 'debt' or category == 'housing' %}
-  <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
 {% else %}
   <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
 {% endif %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -125,7 +125,7 @@
     </p>
   {% endcall %}
 
-  {% Form.postcode.append( "Postcode not found" ) %}
+  {% Form.postcode.error.append( "Postcode not found" ) %}
 
   {% set find_legal_advisor_subtitle = _('Try again') %}
 

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -136,7 +136,7 @@
     {% set find_legal_advisor_subtitle = _('Try again') %}
   {% endif %}
 
-  {% if field and field.errors %}
+  {% if form.postcode and form.postcode.errors %}
     <h2> Error error error </h2>
   {% endif %}
 

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -119,14 +119,8 @@
 
 {% elif 'count' in data and data.count == 0 %}
   {% call Element.alert('error', title=_('No results')) %}
-    <p class="govuk-body">
-      {% trans %}We couldn’t find any results for your search.
-      We are constantly updating our records so please try again later.{% endtrans %}
-    </p>
     <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list">
-      <li>
-
       <li>
         <a href="#postcode">{% trans %}We couldn’t find any results for your search.
       We are constantly updating our records so please try again later.{% endtrans %}</a>

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -2,65 +2,50 @@
 {% import "macros/element.html" as Element %}
 
 <section class="find-legal-adviser">
-  {% if not hide_subtitle %}
-    <h2 class="govuk-heading-m">{{ _('Find a legal adviser') }}</h2>
-  {% endif %}
-
-  <form method="GET">
-    {{ Form.postcode_input(form.postcode) }}
-    {% if category %}
-      <div class="govuk-form-group">
-        <input class="govuk-input govuk-input--width-10" id="category" type="hidden" name="category" value="{{ category }}" />
-      </div>
-    {% endif %}
-    <button class="govuk-button" type="submit">
-      {{ _('Search') }}
-    </button>
-  </form>
-    {% if postcode_info.is_scottish_postcode
-    or postcode_info.is_ni_postcode
-    or postcode_info.is_mann_postcode
-    or postcode_info.is_jersey_postcode
-    or postcode_info.is_guernsey_postcode
-    %}
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning </span>
-        {% if postcode_info.is_scottish_postcode %}
-          {% trans
-            link=Element.link_same_window('https://www.mygov.scot/legal-aid/', _('mygov.scot'), True)
-          %}Legal Aid is different in Scotland. Visit {{ link }} for more information.{% endtrans %}
-        {% elif postcode_info.is_ni_postcode %}
-          {% trans
-            link=Element.link_same_window('https://www.nidirect.gov.uk/articles/legal-aid-schemes', _('nidirect.gov.uk'), True)
-          %}Legal Aid is different in Northern Ireland. Visit {{ link }} for more information.{% endtrans %}
-        {% elif postcode_info.is_mann_postcode %}
-          {% trans
-            link=Element.link_same_window('https://www.gov.im/categories/benefits-and-financial-support/legal-aid/', _('gov.im'), True)
-          %}Legal Aid is different on the Isle of Man. Visit {{ link }} for more information.{% endtrans %}
-        {% elif postcode_info.is_jersey_postcode  %}
-          {% trans
-            link=Element.link_same_window('https://www.legalaid.je/', _('legalaid.je'), True)
-          %}Legal Aid is different in Jersey. Visit {{ link }} for more information.{% endtrans %}
-        {% elif postcode_info.is_guernsey_postcode %}
-          {% trans
-            link=Element.link_same_window('https://www.gov.gg/legalaid', _('gov.gg'), True)
-          %}Legal Aid is different in Guernsey. Visit {{ link }} for more information.{% endtrans %}
-        {% endif %}
-      </strong>
-    </div>
-  {% endif %}
-
   {% if data and data.count and data.count > 0 %}
-    <p id="larp-results" class="govuk-body">
+    <h1 id="larp-results" class="govuk-heading-xl">
       {% trans count=data.results|length %}Showing {{ count }} results around{% endtrans %}
       <strong class="govuk-!-font-weight-bold">{{ data.origin.postcode }}</strong>
       {% if category_name %}
         {{ _('for') }}
           <strong class="govuk-!-font-weight-bold">{{ category_name|lower }}</strong>.
       {% endif %}
-    </p>
+    </h1>
+
+    {% if postcode_info.is_scottish_postcode
+      or postcode_info.is_ni_postcode
+      or postcode_info.is_mann_postcode
+      or postcode_info.is_jersey_postcode
+      or postcode_info.is_guernsey_postcode
+      %}
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning </span>
+          {% if postcode_info.is_scottish_postcode %}
+            {% trans
+              link=Element.link_same_window('https://www.mygov.scot/legal-aid/', _('mygov.scot'), True)
+            %}Legal Aid is different in Scotland. Visit {{ link }} for more information.{% endtrans %}
+          {% elif postcode_info.is_ni_postcode %}
+            {% trans
+              link=Element.link_same_window('https://www.nidirect.gov.uk/articles/legal-aid-schemes', _('nidirect.gov.uk'), True)
+            %}Legal Aid is different in Northern Ireland. Visit {{ link }} for more information.{% endtrans %}
+          {% elif postcode_info.is_mann_postcode %}
+            {% trans
+              link=Element.link_same_window('https://www.gov.im/categories/benefits-and-financial-support/legal-aid/', _('gov.im'), True)
+            %}Legal Aid is different on the Isle of Man. Visit {{ link }} for more information.{% endtrans %}
+          {% elif postcode_info.is_jersey_postcode  %}
+            {% trans
+              link=Element.link_same_window('https://www.legalaid.je/', _('legalaid.je'), True)
+            %}Legal Aid is different in Jersey. Visit {{ link }} for more information.{% endtrans %}
+          {% elif postcode_info.is_guernsey_postcode %}
+            {% trans
+              link=Element.link_same_window('https://www.gov.gg/legalaid', _('gov.gg'), True)
+            %}Legal Aid is different in Guernsey. Visit {{ link }} for more information.{% endtrans %}
+          {% endif %}
+        </strong>
+      </div>
+    {% endif %}
 
     <div class="search-results-container">
       {% if data.origin %}
@@ -126,6 +111,24 @@
         We are constantly updating our records so please try again later.{% endtrans %}
       </p>
     {% endcall %}
+  {% else %}
+
+    {% if not hide_subtitle %}
+      <h2 class="govuk-heading-m">{{ _('Find a legal adviser') }}</h2>
+    {% endif %}
+
+    <form method="GET">
+      {{ Form.postcode_input(form.postcode) }}
+      {% if category %}
+        <div class="govuk-form-group">
+          <input class="govuk-input govuk-input--width-10" id="category" type="hidden" name="category" value="{{ category }}" />
+        </div>
+      {% endif %}
+      <button class="govuk-button" type="submit">
+        {{ _('Search') }}
+      </button>
+    </form>
+
   {% endif %}
 
   <script>

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -141,7 +141,7 @@
       <div class="govuk-error-summary__body">
         <ul class="govuk-list govuk-error-summary__list">
           <li>
-            <a href="#postcode">{{ form.postcode.errors[0] }}</a>
+            <a href="#postcode">{{ form.postcode.errors[0] }}</a> {{ request.args.get('postcode') }}
           </li>
         </ul>
       </div>

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -125,8 +125,12 @@
     </p>
   {% endcall %}
 
-  Postcode: {{ Form.postcode }}
-  Postcode Error: {{ Form.postcode.error }}
+  {% if Form.postcode %}
+    Postcode: {{ Form.postcode }}
+    {% if Form.postcode.error %}
+      Postcode Error: {{ Form.postcode.error }}
+    {% endif %}
+  {% endif %}
 
   {% set find_legal_advisor_subtitle = _('Try again') %}
 

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -119,8 +119,9 @@
       <div class="govuk-error-summary__body">
         <ul class="govuk-list govuk-error-summary__list">
           <li>
-            <a href="#postcode">{% trans %}We couldn’t find any results for your search.
-          We are constantly updating our records so please try again later.{% endtrans %}</a>
+            <a href="#postcode">
+              {% trans %}We couldn’t find any results for your search. We are constantly updating our records so please try again later.{% endtrans %}
+            </a>
           </li>
         </ul>
       </div>
@@ -190,10 +191,7 @@
 {% endif %}
 
 <p class="govuk-body">
-  {% trans %}
-    Your adviser will check whether you qualify for legal aid <strong>at
-    no cost to you</strong> by asking about your problem and your finances.
-  {% endtrans %}
+  {% trans %}Your adviser will check whether you qualify for legal aid <strong>at no cost to you</strong> by asking about your problem and your finances.{% endtrans %}
   {% trans %}In some cases you may need to pay a contribution towards your legal aid.{% endtrans %}
 </p>
 

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -137,11 +137,20 @@
   {% endif %}
 
   {% if form.postcode and form.postcode.errors %}
+    {% if postcode_info.is_mann_postcode %}
+      {% set error_text = _('No results returned for the Isle of Man, try a postcode in England or Wales') %}
+    {% elif postcode_info.is_jersey_postcode %}
+      {% set error_text = _('No results returned for Jersey, try a postcode in England or Wales') %}
+    {% elif postcode_info.is_guernsey_postcode %}
+      {% set error_text = _('No results returned for Guernsey, try a postcode in England or Wales') %}
+    {% else %}
+      {% set error_text = form.postcode.errors[0] %}
+    {% endif %}
     {% call Element.alert('error') %}
       <div class="govuk-error-summary__body">
         <ul class="govuk-list govuk-error-summary__list">
           <li>
-            <a href="#postcode">{{ form.postcode.errors[0] }}</a> {{ request.args.get('postcode') }}
+            <a href="#postcode">{{ error_text }}</a>
           </li>
         </ul>
       </div>

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -125,13 +125,6 @@
     </p>
   {% endcall %}
 
-  {% if Form.postcode %}
-    Postcode: {{ Form.postcode }}
-    {% if Form.postcode.error %}
-      Postcode Error: {{ Form.postcode.error }}
-    {% endif %}
-  {% endif %}
-
   {% set find_legal_advisor_subtitle = _('Try again') %}
 
 {% else %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -49,7 +49,7 @@
     </div>
   {% endif %}
 
-  <section class="find-legal-adviser">
+  <section class="find-legal-adviser govuk-!-margin-bottom-7">
 
     <div class="search-results-container">
       {% if data.origin %}
@@ -124,6 +124,8 @@
       We are constantly updating our records so please try again later.{% endtrans %}
     </p>
   {% endcall %}
+
+  {% set postcode_error %}
 
   {% set find_legal_advisor_subtitle = _('Try again') %}
 
@@ -200,8 +202,11 @@
 <form method="GET">
   {{ Form.postcode_input(form.postcode) }}
   {% if category %}
-    <div class="govuk-form-group">
-      <input class="govuk-input govuk-input--width-10" id="category" type="hidden" name="category" value="{{ category }}" />
+    <div class="govuk-form-group {{ 'govuk-form-group--error' if postcode_error }}">
+      {% if postcode_error %}
+        {{ _('Postcode not found') }}
+      {% endif %}
+      <input class="govuk-input govuk-input--width-10 {{ 'govuk-input--error' if postcode_error }}" id="category" type="hidden" name="category" value="{{ category }}" />
     </div>
   {% endif %}
   <button class="govuk-button" type="submit">

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -126,6 +126,7 @@
   {% endcall %}
 
   {% set postcode_error = true %}
+  {% set form.postcode.error[0] = "Postcode not found" %}
 
   {% set find_legal_advisor_subtitle = _('Try again') %}
 
@@ -201,9 +202,10 @@
 
 <form method="GET">
   {% if postcode_error = true %}
-    {% set form.postcode.error[0] = "Postcode not found" %}
+    {{ Form.postcode_input(form.postcode, class_="govuk-form-group--error") }}
+  {% else %}
+    {{ Form.postcode_input(form.postcode) }}
   {% endif %}
-  {{ Form.postcode_input(form.postcode) }}
   {% if category %}
     <div class="govuk-form-group ">
       <input class="govuk-input govuk-input--width-10 " id="category" type="hidden" name="category" value="{{ category }}" />

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -220,6 +220,8 @@
 <form method="GET">
   {% if postcode_error == true %}
     {{ Form.postcode_input(form.postcode, custom_error=_('Postcode not found')) }}
+  {% elif error_text %}
+    {{ Form.postcode_input(form.postcode, custom_error=error_text) }}
   {% else %}
     {{ Form.postcode_input(form.postcode) }}
   {% endif %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -125,7 +125,7 @@
     </p>
   {% endcall %}
 
-  {% set postcode_error = true %}
+  {% Form.postcode.append( "Postcode not found" ) %}
 
   {% set find_legal_advisor_subtitle = _('Try again') %}
 
@@ -202,11 +202,8 @@
 <form method="GET">
   {{ Form.postcode_input(form.postcode) }}
   {% if category %}
-    <div class="govuk-form-group {{ 'govuk-form-group--error' if postcode_error == true }}">
-      {% if postcode_error == true %}
-        {{ _('Postcode not found') }}
-      {% endif %}
-      <input class="govuk-input govuk-input--width-10 {{ 'govuk-input--error' if postcode_error == true }}" id="category" type="hidden" name="category" value="{{ category }}" />
+    <div class="govuk-form-group ">
+      <input class="govuk-input govuk-input--width-10 " id="category" type="hidden" name="category" value="{{ category }}" />
     </div>
   {% endif %}
   <button class="govuk-button" type="submit">

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -126,7 +126,6 @@
   {% endcall %}
 
   {% set postcode_error = true %}
-  {% set form.postcode.error[0] = "Postcode not found" %}
 
   {% set find_legal_advisor_subtitle = _('Try again') %}
 

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -122,13 +122,13 @@
   {% if 'count' in data and data.count == 0 %}
     {% call Element.alert('error', title=_('No results')) %}
       <div class="govuk-error-summary__body">
-      <ul class="govuk-list govuk-error-summary__list">
-        <li>
-          <a href="#postcode">{% trans %}We couldn’t find any results for your search.
-        We are constantly updating our records so please try again later.{% endtrans %}</a>
-        </li>
-      </ul>
-    </div>
+        <ul class="govuk-list govuk-error-summary__list">
+          <li>
+            <a href="#postcode">{% trans %}We couldn’t find any results for your search.
+          We are constantly updating our records so please try again later.{% endtrans %}</a>
+          </li>
+        </ul>
+      </div>
     {% endcall %}
 
     {% set postcode_error = true %}
@@ -137,7 +137,15 @@
   {% endif %}
 
   {% if form.postcode and form.postcode.errors %}
-    <h2> Error error error </h2>
+    {% call Element.alert('error') %}
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          <li>
+            <a href="#postcode">{{ form.postcode.errors[0] }}</a>
+          </li>
+        </ul>
+      </div>
+    {% endcall %}
   {% endif %}
 
   {% if category == 'clinneg' %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -125,7 +125,7 @@
     </p>
   {% endcall %}
 
-  {% set postcode_error %}
+  {% set postcode_error = true %}
 
   {% set find_legal_advisor_subtitle = _('Try again') %}
 
@@ -202,11 +202,11 @@
 <form method="GET">
   {{ Form.postcode_input(form.postcode) }}
   {% if category %}
-    <div class="govuk-form-group {{ 'govuk-form-group--error' if postcode_error }}">
-      {% if postcode_error %}
+    <div class="govuk-form-group {{ 'govuk-form-group--error' if postcode_error == true }}">
+      {% if postcode_error == true %}
         {{ _('Postcode not found') }}
       {% endif %}
-      <input class="govuk-input govuk-input--width-10 {{ 'govuk-input--error' if postcode_error }}" id="category" type="hidden" name="category" value="{{ category }}" />
+      <input class="govuk-input govuk-input--width-10 {{ 'govuk-input--error' if postcode_error == true }}" id="category" type="hidden" name="category" value="{{ category }}" />
     </div>
   {% endif %}
   <button class="govuk-button" type="submit">

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -123,6 +123,16 @@
       {% trans %}We couldn’t find any results for your search.
       We are constantly updating our records so please try again later.{% endtrans %}
     </p>
+    <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+      <li>
+
+      <li>
+        <a href="#postcode">{% trans %}We couldn’t find any results for your search.
+      We are constantly updating our records so please try again later.{% endtrans %}</a>
+      </li>
+    </ul>
+  </div>
   {% endcall %}
 
   {% set postcode_error = true %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -136,6 +136,10 @@
     {% set find_legal_advisor_subtitle = _('Try again') %}
   {% endif %}
 
+  {% if field and field.errors %}
+    <h2> Error error error </h2>
+  {% endif %}
+
   {% if category == 'clinneg' %}
     <h1 class="govuk-heading-xl">
       {{ _('A legal adviser may be able to help you') }}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -201,7 +201,7 @@
 
 <form method="GET">
   {% if postcode_error == true %}
-    {{ Form.postcode_input(form.postcode, class_="govuk-form-group--error") }}
+    {{ Form.postcode_input(form.postcode, custom_error=_('Postcode not found')) }}
   {% else %}
     {{ Form.postcode_input(form.postcode) }}
   {% endif %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -218,7 +218,7 @@
 <form method="GET">
   {% if postcode_error == true %}
     {{ Form.postcode_input(form.postcode, custom_error=_('Postcode not found')) }}
-  {% elif error_text %}
+  {% elif error_text|length > 1 %}
     {{ Form.postcode_input(form.postcode, custom_error=error_text) }}
   {% else %}
     {{ Form.postcode_input(form.postcode) }}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -1,51 +1,55 @@
 {% import "macros/form.html" as Form %}
 {% import "macros/element.html" as Element %}
 
-<section class="find-legal-adviser">
-  {% if data and data.count and data.count > 0 %}
-    <h1 id="larp-results" class="govuk-heading-xl">
-      {% trans count=data.results|length %}Showing {{ count }} results around{% endtrans %}
-      <strong class="govuk-!-font-weight-bold">{{ data.origin.postcode }}</strong>
-      {% if category_name %}
-        {{ _('for') }}
-          <strong class="govuk-!-font-weight-bold">{{ category_name|lower }}</strong>.
-      {% endif %}
-    </h1>
-
-    {% if postcode_info.is_scottish_postcode
-      or postcode_info.is_ni_postcode
-      or postcode_info.is_mann_postcode
-      or postcode_info.is_jersey_postcode
-      or postcode_info.is_guernsey_postcode
-      %}
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive">Warning </span>
-          {% if postcode_info.is_scottish_postcode %}
-            {% trans
-              link=Element.link_same_window('https://www.mygov.scot/legal-aid/', _('mygov.scot'), True)
-            %}Legal Aid is different in Scotland. Visit {{ link }} for more information.{% endtrans %}
-          {% elif postcode_info.is_ni_postcode %}
-            {% trans
-              link=Element.link_same_window('https://www.nidirect.gov.uk/articles/legal-aid-schemes', _('nidirect.gov.uk'), True)
-            %}Legal Aid is different in Northern Ireland. Visit {{ link }} for more information.{% endtrans %}
-          {% elif postcode_info.is_mann_postcode %}
-            {% trans
-              link=Element.link_same_window('https://www.gov.im/categories/benefits-and-financial-support/legal-aid/', _('gov.im'), True)
-            %}Legal Aid is different on the Isle of Man. Visit {{ link }} for more information.{% endtrans %}
-          {% elif postcode_info.is_jersey_postcode  %}
-            {% trans
-              link=Element.link_same_window('https://www.legalaid.je/', _('legalaid.je'), True)
-            %}Legal Aid is different in Jersey. Visit {{ link }} for more information.{% endtrans %}
-          {% elif postcode_info.is_guernsey_postcode %}
-            {% trans
-              link=Element.link_same_window('https://www.gov.gg/legalaid', _('gov.gg'), True)
-            %}Legal Aid is different in Guernsey. Visit {{ link }} for more information.{% endtrans %}
-          {% endif %}
-        </strong>
-      </div>
+{% if data and data.count and data.count > 0 %}
+  <h1 class="govuk-heading-xl">
+    {{ _('Legal Adviser Search Results') }}
+  </h1>
+  <p id="larp-results" class="govuk-body">
+    {% trans count=data.results|length %}Showing {{ count }} results around{% endtrans %}
+    <strong class="govuk-!-font-weight-bold">{{ data.origin.postcode }}</strong>
+    {% if category_name %}
+      {{ _('for') }}
+        <strong class="govuk-!-font-weight-bold">{{ category_name|lower }}</strong>.
     {% endif %}
+  </p>
+
+  {% if postcode_info.is_scottish_postcode
+    or postcode_info.is_ni_postcode
+    or postcode_info.is_mann_postcode
+    or postcode_info.is_jersey_postcode
+    or postcode_info.is_guernsey_postcode
+    %}
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning </span>
+        {% if postcode_info.is_scottish_postcode %}
+          {% trans
+            link=Element.link_same_window('https://www.mygov.scot/legal-aid/', _('mygov.scot'), True)
+          %}Legal Aid is different in Scotland. Visit {{ link }} for more information.{% endtrans %}
+        {% elif postcode_info.is_ni_postcode %}
+          {% trans
+            link=Element.link_same_window('https://www.nidirect.gov.uk/articles/legal-aid-schemes', _('nidirect.gov.uk'), True)
+          %}Legal Aid is different in Northern Ireland. Visit {{ link }} for more information.{% endtrans %}
+        {% elif postcode_info.is_mann_postcode %}
+          {% trans
+            link=Element.link_same_window('https://www.gov.im/categories/benefits-and-financial-support/legal-aid/', _('gov.im'), True)
+          %}Legal Aid is different on the Isle of Man. Visit {{ link }} for more information.{% endtrans %}
+        {% elif postcode_info.is_jersey_postcode  %}
+          {% trans
+            link=Element.link_same_window('https://www.legalaid.je/', _('legalaid.je'), True)
+          %}Legal Aid is different in Jersey. Visit {{ link }} for more information.{% endtrans %}
+        {% elif postcode_info.is_guernsey_postcode %}
+          {% trans
+            link=Element.link_same_window('https://www.gov.gg/legalaid', _('gov.gg'), True)
+          %}Legal Aid is different in Guernsey. Visit {{ link }} for more information.{% endtrans %}
+        {% endif %}
+      </strong>
+    </div>
+  {% endif %}
+
+  <section class="find-legal-adviser">
 
     <div class="search-results-container">
       {% if data.origin %}
@@ -104,97 +108,106 @@
         </div>
       </div>
     </div>
-  {% elif 'count' in data and data.count == 0 %}
-    {% call Element.alert('error', title=_('No results')) %}
-      <p class="govuk-body">
-        {% trans %}We couldn’t find any results for your search.
-        We are constantly updating our records so please try again later.{% endtrans %}
-      </p>
-    {% endcall %}
+  </section>
+  {% if not hide_subtitle %}
+    <h2 class="govuk-heading-m">{{ _('Search again') }}</h2>
+  {% endif %}
+
+{% elif 'count' in data and data.count == 0 %}
+  {% call Element.alert('error', title=_('No results')) %}
+    <p class="govuk-body">
+      {% trans %}We couldn’t find any results for your search.
+      We are constantly updating our records so please try again later.{% endtrans %}
+    </p>
+  {% endcall %}
+
+  {% if not hide_subtitle %}
+    <h2 class="govuk-heading-m">{{ _('Try again') }}</h2>
+  {% endif %}
+
+{% else %}
+
+  {% if category == 'clinneg' %}
+    <h1 class="govuk-heading-xl">
+      {{ _('A legal adviser may be able to help you') }}
+    </h1>
+    <p class="govuk-body">
+      {% trans %}You will usually only get legal aid for advice about
+        clinical negligence if your child has suffered a brain injury during pregnancy,
+        birth or in the first 8 weeks of life.{% endtrans %}
+    </p>
+    <h2 class="govuk-heading-m">{% trans %}What happens next{% endtrans %}</h2>
+    <p class="govuk-body">
+      {% trans %}You should contact a legal aid adviser in your area,
+          who may be able to help.{% endtrans %}
+    </p>
+
+  {% elif category == 'pi' %}
+    <h1 class="govuk-heading-xl">
+      {{ _('Legal aid is not usually available for advice about personal injury') }}
+    </h1>
+    <p class="govuk-body">
+      {% trans %}You may be able to get legal aid in exceptional cases. You
+        could seek advice from a legal adviser about whether an application
+        might succeed in your case and how to apply.{% endtrans %}
+    </p>
+    <h2 class="govuk-heading-m">What happens next</h2>
+  {% elif category == 'debt' or category == 'housing' %}
+    <h1 class="govuk-heading-xl">
+      {{ _('A legal adviser may be able to help you') }}
+    </h1>
+    <h2 class="govuk-heading-m">What happens next</h2>
   {% else %}
+    <h1 class="govuk-heading-xl">
+      {{ _('A legal adviser may be able to help you') }}
+    </h1>
+    <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
+  {% endif %}
 
-    {% if category == 'clinneg' %}
-      <h1 class="govuk-heading-xl">
-        {{ _('A legal adviser may be able to help you') }}
-      </h1>
-      <p class="govuk-body">
-        {% trans %}You will usually only get legal aid for advice about
-          clinical negligence if your child has suffered a brain injury during pregnancy,
-          birth or in the first 8 weeks of life.{% endtrans %}
-      </p>
-      <h2 class="govuk-heading-m">{% trans %}What happens next{% endtrans %}</h2>
-      <p class="govuk-body">
-        {% trans %}You should contact a legal aid adviser in your area,
-            who may be able to help.{% endtrans %}
-      </p>
+  <p class="govuk-body">
+    {% trans %}
+      Your adviser will check whether you qualify for legal aid <strong>at
+      no cost to you</strong> by asking about your problem and your finances.
+    {% endtrans %}
+    {% trans %}In some cases you may need to pay a contribution towards your legal aid.{% endtrans %}
+  </p>
 
-    {% elif category == 'pi' %}
-      <h1 class="govuk-heading-xl">
-        {{ _('Legal aid is not usually available for advice about personal injury') }}
-      </h1>
-      <p class="govuk-body">
-        {% trans %}You may be able to get legal aid in exceptional cases. You
-          could seek advice from a legal adviser about whether an application
-          might succeed in your case and how to apply.{% endtrans %}
-      </p>
-      <h2 class="govuk-heading-m">What happens next</h2>
-    {% elif category == 'debt' or category == 'housing' %}
-      <h1 class="govuk-heading-xl">
-        {{ _('A legal adviser may be able to help you') }}
-      </h1>
-      <h2 class="govuk-heading-m">What happens next</h2>
-    {% else %}
-      <h1 class="govuk-heading-xl">
-        {{ _('A legal adviser may be able to help you') }}
-      </h1>
-      <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
-    {% endif %}
+  <p class="govuk-body">
+      <a class="govuk-link" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">
+        {% trans %}What did you think of this service?{% endtrans %}</a> {% trans %}(takes 30 seconds){% endtrans %}
 
+  </p>
+
+  {% if category == 'mentalhealth' %}
     <p class="govuk-body">
-      {% trans %}
-        Your adviser will check whether you qualify for legal aid <strong>at
-        no cost to you</strong> by asking about your problem and your finances.
-      {% endtrans %}
-      {% trans %}In some cases you may need to pay a contribution towards your legal aid.{% endtrans %}
+      {% trans %}If you’re applying for legal aid for a mental health issue,
+        the requirements for the financial assessment are less rigorous than
+        for other legal aid problems.{% endtrans %}
     </p>
-
-    <p class="govuk-body">
-        <a class="govuk-link" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">
-          {% trans %}What did you think of this service?{% endtrans %}</a> {% trans %}(takes 30 seconds){% endtrans %}
-
-    </p>
-
-    {% if category == 'mentalhealth' %}
-      <p class="govuk-body">
-        {% trans %}If you’re applying for legal aid for a mental health issue,
-          the requirements for the financial assessment are less rigorous than
-          for other legal aid problems.{% endtrans %}
-      </p>
-
-    {% endif %}
-
-    {% if not hide_subtitle %}
-      <h2 class="govuk-heading-m">{{ _('Find a legal adviser') }}</h2>
-    {% endif %}
-
-    <form method="GET">
-      {{ Form.postcode_input(form.postcode) }}
-      {% if category %}
-        <div class="govuk-form-group">
-          <input class="govuk-input govuk-input--width-10" id="category" type="hidden" name="category" value="{{ category }}" />
-        </div>
-      {% endif %}
-      <button class="govuk-button" type="submit">
-        {{ _('Search') }}
-      </button>
-    </form>
 
   {% endif %}
+
+  {% if not hide_subtitle %}
+    <h2 class="govuk-heading-m">{{ _('Find a legal adviser') }}</h2>
+  {% endif %}
+
+{% endif %}
+
+  <form method="GET">
+    {{ Form.postcode_input(form.postcode) }}
+    {% if category %}
+      <div class="govuk-form-group">
+        <input class="govuk-input govuk-input--width-10" id="category" type="hidden" name="category" value="{{ category }}" />
+      </div>
+    {% endif %}
+    <button class="govuk-button" type="submit">
+      {{ _('Search') }}
+    </button>
+  </form>
+
 
   <script>
     window.LABELS = {
       loading: "{{ _('Loading…') }}"
     };
   </script>
-
-</section>

--- a/cla_public/templates/checker/result/face-to-face.html
+++ b/cla_public/templates/checker/result/face-to-face.html
@@ -11,12 +11,11 @@
   {% block sidebar %}{% endblock %}
 
   {% if data.origin %}
-    {% set title_prefix = _('Results for ') + data.origin.postcode + ' | ' %}
+    {% set title = _('Legal Adviser Search Results') %}
   {% else %}
-    {% set title_prefix = '' %}
+    {% set title = _('Find a legal adviser') %}
   {% endif %}
 
-  {% set title = title_prefix + _('Seek legal advice') %}
   {% block page_title %}{{ title }} - {{ super() }}{% endblock %}
 
   {% block inner_content %}

--- a/cla_public/templates/checker/result/face-to-face.html
+++ b/cla_public/templates/checker/result/face-to-face.html
@@ -21,69 +21,10 @@
 
   {% block inner_content %}
 
-    {% if category == 'clinneg' %}
-      <h1 class="govuk-heading-xl">
-        {{ _('A legal adviser may be able to help you') }}
-      </h1>
-      <p class="govuk-body">
-        {% trans %}You will usually only get legal aid for advice about
-          clinical negligence if your child has suffered a brain injury during pregnancy,
-          birth or in the first 8 weeks of life.{% endtrans %}
-      </p>
-      <h2 class="govuk-heading-m">{% trans %}What happens next{% endtrans %}</h2>
-      <p class="govuk-body">
-        {% trans %}You should contact a legal aid adviser in your area,
-            who may be able to help.{% endtrans %}
-      </p>
+    {% with postcode_info=postcode_info  %}
+      {% include "checker/result/_find-legal-adviser.html" %}
+    {% endwith %}
 
-    {% elif category == 'pi' %}
-      <h1 class="govuk-heading-xl">
-        {{ _('Legal aid is not usually available for advice about personal injury') }}
-      </h1>
-      <p class="govuk-body">
-        {% trans %}You may be able to get legal aid in exceptional cases. You
-          could seek advice from a legal adviser about whether an application
-          might succeed in your case and how to apply.{% endtrans %}
-      </p>
-      <h2 class="govuk-heading-m">What happens next</h2>
-    {% elif category == 'debt' or category == 'housing' %}
-      <h1 class="govuk-heading-xl">
-        {{ _('A legal adviser may be able to help you') }}
-      </h1>
-      <h2 class="govuk-heading-m">What happens next</h2>
-    {% else %}
-      <h1 class="govuk-heading-xl">
-        {{ _('A legal adviser may be able to help you') }}
-      </h1>
-      <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
-    {% endif %}
-
-    <p class="govuk-body">
-      {% trans %}
-        Your adviser will check whether you qualify for legal aid <strong>at
-        no cost to you</strong> by asking about your problem and your finances.
-      {% endtrans %}
-      {% trans %}In some cases you may need to pay a contribution towards your legal aid.{% endtrans %}
-    </p>
-
-    <p class="govuk-body">
-        <a class="govuk-link" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">
-          {% trans %}What did you think of this service?{% endtrans %}</a> {% trans %}(takes 30 seconds){% endtrans %}
-
-    </p>
-
-    {% if category == 'mentalhealth' %}
-      <p class="govuk-body">
-        {% trans %}If you’re applying for legal aid for a mental health issue,
-          the requirements for the financial assessment are less rigorous than
-          for other legal aid problems.{% endtrans %}
-      </p>
-
-    {% endif %}
-
-  {% with postcode_info=postcode_info  %}
-    {% include "checker/result/_find-legal-adviser.html" %}
-  {% endwith %}
     {% include "checker/time-out-warning.html" %}
   {% endblock %}
 

--- a/cla_public/templates/checker/result/face-to-face.html
+++ b/cla_public/templates/checker/result/face-to-face.html
@@ -11,7 +11,7 @@
   {% block sidebar %}{% endblock %}
 
   {% if data.origin %}
-    {% set title = _('Legal Adviser Search Results') %}
+    {% set title = _('Legal adviser search results') %}
   {% else %}
     {% set title = _('Find a legal adviser') %}
   {% endif %}

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -460,7 +460,7 @@
   {% elif custom_error != '' %}
     {% set error_message_text = custom_error %}
   {% endif %}
-  <div class="govuk-form-group {{"govuk-form-group--error" if custom_error != ''}}">
+  <div class="govuk-form-group {{"govuk-form-group--error" if error_message_text != ''}}">
     <label class="govuk-label" for="{{field.id}}">{{ _('Postcode') }}</label>
     {% if error_message_text %}
       <span id="{{field.id}}-error" class="govuk-error-message">

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -455,13 +455,13 @@
 {% endmacro %}
 
 {% macro postcode_input(field, prefix=None, suffix=None, class_='', skip=False, default_value='0', custom_error='') %}
-  <div class="govuk-form-group {{"govuk-form-group--error" if field and field.errors}}">
+  {% if field and field.errors %}
+    {% set error_message_text = field.errors[0] %}
+  {% elif custom_error != '' %}
+    {% set error_message_text = custom_error %}
+  {% endif %}
+  <div class="govuk-form-group {{"govuk-form-group--error" if custom_error != ''}}">
     <label class="govuk-label" for="{{field.id}}">{{ _('Postcode') }}</label>
-    {% if field and field.errors %}
-      {% set error_message_text = field.errors[0] %}
-    {% elif custom_error != '' %}
-      {% set error_message_text = custom_error %}
-    {% endif %}
     {% if error_message_text %}
       <span id="{{field.id}}-error" class="govuk-error-message">
         <span class="govuk-visually-hidden">{% trans %}Error{% endtrans %}: </span>

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -460,7 +460,7 @@
   {% elif custom_error != '' %}
     {% set error_message_text = custom_error %}
   {% endif %}
-  <div class="govuk-form-group {{"govuk-form-group--error" if !error_message_text}}">
+  <div class="govuk-form-group {{"govuk-form-group--error" if error_message_text|len > 1  }}">
     <label class="govuk-label" for="{{field.id}}">{{ _('Postcode') }}</label>
     {% if error_message_text %}
       <span id="{{field.id}}-error" class="govuk-error-message">

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -460,7 +460,7 @@
   {% elif custom_error != '' %}
     {% set error_message_text = custom_error %}
   {% endif %}
-  <div class="govuk-form-group {{"govuk-form-group--error" if error_message_text|len > 1  }}">
+  <div class="govuk-form-group {{"govuk-form-group--error" if error_message_text|length > 1  }}">
     <label class="govuk-label" for="{{field.id}}">{{ _('Postcode') }}</label>
     {% if error_message_text %}
       <span id="{{field.id}}-error" class="govuk-error-message">

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -454,13 +454,18 @@
   {% endif %}
 {% endmacro %}
 
-{% macro postcode_input(field, prefix=None, suffix=None, class_='', skip=False, default_value='0') %}
+{% macro postcode_input(field, prefix=None, suffix=None, class_='', skip=False, default_value='0', custom_error='') %}
   <div class="govuk-form-group {{"govuk-form-group--error" if field and field.errors}}">
     <label class="govuk-label" for="{{field.id}}">{{ _('Postcode') }}</label>
     {% if field and field.errors %}
+      {% set error_message_text = field.errors[0] %}
+    {% elif custom_error != '' %}
+      {% set error_message_text = custom_error %}
+    {% endif %}
+    {% if error_message_text %}
       <span id="{{field.id}}-error" class="govuk-error-message">
         <span class="govuk-visually-hidden">{% trans %}Error{% endtrans %}: </span>
-        <span class="cla-error-message">{{ field.errors[0] }}</span>
+        <span class="cla-error-message">{{ error_message_text }}</span>
       </span>
       {% set class_ = "govuk-input--error" %}
     {% endif %}

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -455,10 +455,10 @@
 {% endmacro %}
 
 {% macro postcode_input(field, prefix=None, suffix=None, class_='', skip=False, default_value='0', custom_error='') %}
-  {% if field and field.errors %}
-    {% set error_message_text = field.errors[0] %}
-  {% elif custom_error != '' %}
+  {% if custom_error != '' %}
     {% set error_message_text = custom_error %}
+  {% elif field and field.errors %}
+    {% set error_message_text = field.errors[0] %}
   {% endif %}
   <div class="govuk-form-group {{"govuk-form-group--error" if error_message_text|length > 1  }}">
     <label class="govuk-label" for="{{field.id}}">{{ _('Postcode') }}</label>

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -460,7 +460,7 @@
   {% elif custom_error != '' %}
     {% set error_message_text = custom_error %}
   {% endif %}
-  <div class="govuk-form-group {{"govuk-form-group--error" if error_message_text != ''}}">
+  <div class="govuk-form-group {{"govuk-form-group--error" if !error_message_text}}">
     <label class="govuk-label" for="{{field.id}}">{{ _('Postcode') }}</label>
     {% if error_message_text %}
       <span id="{{field.id}}-error" class="govuk-error-message">

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -3558,7 +3558,7 @@ msgstr "Rhowch gôd post"
 
 #: PLACEHOLDER PENDING TRANSLATION RETURN
 #: cla_public/templates/checker/result/_find-legal-adviser.html:139
-msgid "Legal Adviser Search Results"
+msgid "Legal adviser search results"
 msgstr "Canlyniadau Chwilio Cynghorydd Cyfreithiol"
 
 #: PLACEHOLDER PENDING TRANSLATION RETURN

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -3528,11 +3528,23 @@ msgid "We need to know about any money you have saved or invested."
 msgstr "Mae arnom angen gwybod am unrhyw arian yr ydych wedi’i gynilo neu fuddsoddi"
 
 #: cla_public/templates/checker/time-out-warning.html:2
-msgid ""
-"\n"
-"    Your session will time out after 30 minutes of inactivity. We do this for your security.\n"
-"  "
+msgid "Your session will time out after 30 minutes of inactivity. We do this for your security."
 msgstr "Bydd eich sesiwn yn dod i ben os yw wedi bod yn anweithredol am hanner awr. Rydym yn gwneud hyn er mwyn eich cadw’n ddiogel."
+
+#: PLACEHOLDER PENDING TRANSLATION RETURN
+#: cla_public/templates/checker/result/_find-legal-adviser.html:137
+msgid "No results returned for the Isle of Man, try a postcode in England or Wales"
+msgstr "Dim canlyniadau, Rhowch gynnig arall arni"
+
+#: PLACEHOLDER PENDING TRANSLATION RETURN
+#: cla_public/templates/checker/result/_find-legal-adviser.html:138
+msgid "No results returned for Jersey, try a postcode in England or Wales"
+msgstr "Dim canlyniadau, Rhowch gynnig arall arni"
+
+#: PLACEHOLDER PENDING TRANSLATION RETURN
+#: cla_public/templates/checker/result/_find-legal-adviser.html:139
+msgid "No results returned for Guernsey, try a postcode in England or Wales"
+msgstr "Dim canlyniadau, Rhowch gynnig arall arni"
 
 #: cla_public/templates/checker/result/_find-legal-adviser.html:17
 msgid "Search"
@@ -3602,9 +3614,7 @@ msgid "No results"
 msgstr "Dim canlyniadau"
 
 #: cla_public/templates/checker/result/_find-legal-adviser.html:157
-msgid ""
-"We couldn’t find any results for your search.\n"
-"        We are constantly updating our records so please try again later."
+msgid "We couldn’t find any results for your search. We are constantly updating our records so please try again later."
 msgstr "Nid oeddem yn gallu dod o hyd i unrhyw ganlyniadau ar gyfer eich chwiliad. Rydym yn diweddaru ein cofnodion yn barhaus, felly rhowch gynnig arall arni nes ymlaen."
 
 #: cla_public/templates/checker/result/_find-legal-adviser.html:165
@@ -3887,16 +3897,12 @@ msgstr "Fel arfer ni fydd cymorth cyfreithiol ar gael ar gyfer cyngor ar anafiad
 #: cla_public/templates/checker/result/face-to-face.html:44
 msgid ""
 "You may be able to get legal aid in exceptional cases. You\n"
-"          could seek advice from a legal adviser about whether an application\n"
-"          might succeed in your case and how to apply."
+"      could seek advice from a legal adviser about whether an application\n"
+"      might succeed in your case and how to apply."
 msgstr "Efallai y bydd cymorth cyfreithiol yn dal ar gael mewn achosion eithriadol. Gallech chi ofyn am gyngor gan gynghorydd cyfreithiol ynghylch a fydd cais am gymorth cyfreithiol yn debygol o lwyddo yn eich achos chi a sut i wneud cais."
 
 #: cla_public/templates/checker/result/face-to-face.html:62
-msgid ""
-"\n"
-"        Your adviser will check whether you qualify for legal aid <strong>at\n"
-"        no cost to you</strong> by asking about your problem and your finances.\n"
-"      "
+msgid "Your adviser will check whether you qualify for legal aid <strong>at no cost to you</strong> by asking about your problem and your finances."
 msgstr "Bydd eich cynghorydd yn gwirio a ydych chi’n gymwys i gael cymorth cyfreithiol am ddim drwy ofyn cwestiynau i chi am eich problem a’ch amgylchiadau ariannol."
 
 #: cla_public/templates/checker/result/face-to-face.html:66
@@ -3920,8 +3926,8 @@ msgstr "(mae’n cymryd 30 eiliad)"
 #: cla_public/templates/checker/result/face-to-face.html:77
 msgid ""
 "If you’re applying for legal aid for a mental health issue,\n"
-"          the requirements for the financial assessment are less rigorous than\n"
-"          for other legal aid problems."
+"      the requirements for the financial assessment are less rigorous than\n"
+"      for other legal aid problems."
 msgstr "Os ydych yn gwneud cais am gymorth cyfreithiol ar gyfer problem iechyd meddwl, nid yw’r gofynion ar gyfer yr asesiad ariannol mor llym o’i gymharu â phroblemau cymorth cyfreithiol eraill."
 
 #: cla_public/templates/checker/result/ineligible.html:3

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -3534,22 +3534,37 @@ msgstr "Bydd eich sesiwn yn dod i ben os yw wedi bod yn anweithredol am hanner a
 #: PLACEHOLDER PENDING TRANSLATION RETURN
 #: cla_public/templates/checker/result/_find-legal-adviser.html:137
 msgid "No results returned for the Isle of Man, try a postcode in England or Wales"
-msgstr "Dim canlyniadau, Rhowch gynnig arall arni"
+msgstr "Dim canlyniadau, rhowch gynnig arall arni"
 
 #: PLACEHOLDER PENDING TRANSLATION RETURN
 #: cla_public/templates/checker/result/_find-legal-adviser.html:138
 msgid "No results returned for Jersey, try a postcode in England or Wales"
-msgstr "Dim canlyniadau, Rhowch gynnig arall arni"
+msgstr "Dim canlyniadau, rhowch gynnig arall arni"
 
 #: PLACEHOLDER PENDING TRANSLATION RETURN
 #: cla_public/templates/checker/result/_find-legal-adviser.html:139
 msgid "No results returned for Guernsey, try a postcode in England or Wales"
-msgstr "Dim canlyniadau, Rhowch gynnig arall arni"
+msgstr "Dim canlyniadau, rhowch gynnig arall arni"
 
 #: PLACEHOLDER PENDING TRANSLATION RETURN
 #: cla_public/templates/checker/result/_find-legal-adviser.html:139
 msgid "Postcode not found"
-msgstr "Cod post heb ei ddarganfod"
+msgstr "Côd post heb ei ddarganfod"
+
+#: PLACEHOLDER PENDING TRANSLATION RETURN
+#: cla_public/templates/checker/result/_find-legal-adviser.html:139
+msgid "Enter a postcode"
+msgstr "Rhowch gôd post"
+
+#: PLACEHOLDER PENDING TRANSLATION RETURN
+#: cla_public/templates/checker/result/_find-legal-adviser.html:139
+msgid "Legal Adviser Search Results"
+msgstr "Canlyniadau Chwilio Cynghorydd Cyfreithiol"
+
+#: PLACEHOLDER PENDING TRANSLATION RETURN
+#: cla_public/templates/checker/result/_find-legal-adviser.html:17
+msgid "Search again"
+msgstr "Chwilio eto"
 
 #: cla_public/templates/checker/result/_find-legal-adviser.html:17
 msgid "Search"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -3867,8 +3867,8 @@ msgstr "Efallai gall cynghorydd cyfreithiol eich helpu"
 #: cla_public/templates/checker/result/face-to-face.html:29
 msgid ""
 "You will usually only get legal aid for advice about\n"
-"          clinical negligence if your child has suffered a brain injury during pregnancy,\n"
-"          birth or in the first 8 weeks of life."
+"      clinical negligence if your child has suffered a brain injury during pregnancy,\n"
+"      birth or in the first 8 weeks of life."
 msgstr "Fel arfer, dim ond os yw’ch plentyn wedi cael anaf i’r ymennydd yn ystod beichiogrwydd, genedigaeth neu yn ystod 8 wythnos gyntaf ei fywyd y byddwch chi’n cael cymorth cyfreithiol ar gyfer cyngor ar esgeuluster clinigol."
 
 #: cla_public/templates/checker/result/face-to-face.html:33
@@ -3877,12 +3877,8 @@ msgid "What happens next"
 msgstr "Beth sy’n di"
 
 #: cla_public/templates/checker/result/face-to-face.html:35
-msgid ""
-"You should contact a legal aid adviser in your area,\n"
-"            who may be able to help."
-msgstr ""
-"Dylech gysylltu â chynghorydd cymorth cyfreithiol yn eich ardal,\n"
-"all eich cynorthwyo o bosib."
+msgid "You should contact a legal aid adviser in your area, who may be able to help."
+msgstr "Dylech gysylltu â chynghorydd cymorth cyfreithiol yn eich ardal, all eich cynorthwyo o bosib."
 
 #: cla_public/templates/checker/result/face-to-face.html:41
 msgid "Legal aid is not usually available for advice about personal injury"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -3546,6 +3546,11 @@ msgstr "Dim canlyniadau, Rhowch gynnig arall arni"
 msgid "No results returned for Guernsey, try a postcode in England or Wales"
 msgstr "Dim canlyniadau, Rhowch gynnig arall arni"
 
+#: PLACEHOLDER PENDING TRANSLATION RETURN
+#: cla_public/templates/checker/result/_find-legal-adviser.html:139
+msgid "Postcode not found"
+msgstr "Cod post heb ei ddarganfod"
+
 #: cla_public/templates/checker/result/_find-legal-adviser.html:17
 msgid "Search"
 msgstr "Chwilio"


### PR DESCRIPTION
## What does this pull request do?

LARP page
- If results are found, the whole page changes as opposed to just the map being shown. So the if statements now encompass most of the page rather than just the map section.  
- Most of the text from `face-to-face` has been moved into this structure in `find-legal-adviser`, after the map results bit.
- New titles, new text.
- New error messages, including tests for Crown Dependency postcodes.
- Re-wrote postcode input function to take a custom error message which forces an error style.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
