### PR TITLE
LGA-1180 - Fix time selector when changing callback day

### DIFF
--- a/cla_public/static-src/javascripts/modules/availability-times.js
+++ b/cla_public/static-src/javascripts/modules/availability-times.js
@@ -34,7 +34,7 @@
 
       var dayTimes = dayTimeHours[dayValue];
       var timeOptions = _.keys(dayTimes).sort();
-      var $timeSelector = $daySelector.closest('[role=radiogroup]').find(this.$timeSelectors);
+      var $timeSelector = $daySelector.closest('.govuk-radios').find(this.$timeSelectors);
       var $options = _.map(timeOptions, function(v) {
         var d = dayTimes[v];
         return $('<option>', { value: v, html: d });


### PR DESCRIPTION
## What does this pull request do?
The markup was changed when switching to the design system, breaking the
jQuery selector and therefore causing the time slots not to be updated
and a random one chosen when switching days.

## Any other changes that would benefit highlighting?
At the moment, the time slots are the same on all days that have time slots (Saturdays
have no slots, rather than reduced hours), so this change won't be as apparent yet.

However, the change that broke this also caused the selector to no longer select a random
time slot when switching dates: this behaviour is also restored by this PR, and can be seen to
be working even with the current operator hours.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
