### PR TITLE
LGA-1340 Pound sign prefixing for currency input fields

### DIFF
--- a/cla_public/apps/checker/fields.py
+++ b/cla_public/apps/checker/fields.py
@@ -161,22 +161,21 @@ class MoneyField(SetZeroIntegerField):
         self.min_val = min_val
         self.max_val = max_val
 
-    def convert_amount_to_utf8(self, amount):
-        # Covert pounds side of the input into UTF-8 format
+    def extract_pounds_and_pence(self, valuelist):
+        pounds, _, pence = valuelist[0].strip().partition(".")
         try:
-            amount = amount.decode("utf-8")
+            pounds = pounds.decode("utf-8")
         except UnicodeEncodeError:
             # Input is already in UTF-8 format
             pass
 
-        return amount
+        # xa3 is the numeric character reference for the pound sign
+        pounds = re.sub(r"^\xa3|[\s,]+", "", pounds)
+        return pounds, pence
 
     def process_formdata(self, valuelist):
         if valuelist:
-            pounds, _, pence = valuelist[0].strip().partition(".")
-            pounds = self.convert_amount_to_utf8(pounds)
-            # xa3 is the numeric character reference for the pound sign
-            pounds = re.sub(r"^\xa3|[\s,]+", "", pounds)
+            pounds, pence = self.extract_pounds_and_pence(valuelist)
 
             if pence:
                 if len(pence) > 2:

--- a/cla_public/apps/checker/fields.py
+++ b/cla_public/apps/checker/fields.py
@@ -164,7 +164,7 @@ class MoneyField(SetZeroIntegerField):
     def process_formdata(self, valuelist):
         if valuelist:
             pounds, _, pence = valuelist[0].strip().partition(".")
-            pounds = re.sub(r"[£\s,]+", "", pounds)
+            pounds = re.sub(r"[\s,]+", "", pounds)
 
             if pence:
                 if len(pence) > 2:

--- a/cla_public/apps/checker/fields.py
+++ b/cla_public/apps/checker/fields.py
@@ -164,7 +164,7 @@ class MoneyField(SetZeroIntegerField):
     def process_formdata(self, valuelist):
         if valuelist:
             pounds, _, pence = valuelist[0].strip().partition(".")
-            pounds = re.sub(r"[£\s,]+", "", pounds)
+            pounds = re.sub(r"^(£|\xa3)|[\s,]+", "", pounds)
 
             if pence:
                 if len(pence) > 2:

--- a/cla_public/apps/checker/fields.py
+++ b/cla_public/apps/checker/fields.py
@@ -164,7 +164,7 @@ class MoneyField(SetZeroIntegerField):
     def process_formdata(self, valuelist):
         if valuelist:
             pounds, _, pence = valuelist[0].strip().partition(".")
-            pounds = re.sub(r"[\s,]+", "", pounds)
+            pounds = re.sub(r"[£\s,]+", "", pounds)
 
             if pence:
                 if len(pence) > 2:

--- a/cla_public/apps/checker/fields.py
+++ b/cla_public/apps/checker/fields.py
@@ -169,7 +169,7 @@ class MoneyField(SetZeroIntegerField):
             # Input is already in UTF-8 format
             pass
 
-        # xa3 is the numeric character reference for the pound sign
+        # xa3 is the ASCII character reference for the pound sign
         pounds = re.sub(r"^\xa3|[\s,]+", "", pounds)
         return pounds, pence
 

--- a/cla_public/apps/checker/fields.py
+++ b/cla_public/apps/checker/fields.py
@@ -176,7 +176,7 @@ class MoneyField(SetZeroIntegerField):
             pounds, _, pence = valuelist[0].strip().partition(".")
             pounds = self.convert_amount_to_utf8(pounds)
             # xa3 is the numeric character reference for the pound sign
-            pounds = re.sub(r"^(£|\xa3)|[\s,]+", "", pounds)
+            pounds = re.sub(r"^\xa3|[\s,]+", "", pounds)
 
             if pence:
                 if len(pence) > 2:

--- a/cla_public/apps/checker/fields.py
+++ b/cla_public/apps/checker/fields.py
@@ -161,9 +161,21 @@ class MoneyField(SetZeroIntegerField):
         self.min_val = min_val
         self.max_val = max_val
 
+    def convert_amount_to_utf8(self, amount):
+        # Covert pounds side of the input into UTF-8 format
+        try:
+            amount = amount.decode("utf-8")
+        except UnicodeEncodeError:
+            # Input is already in UTF-8 format
+            pass
+
+        return amount
+
     def process_formdata(self, valuelist):
         if valuelist:
             pounds, _, pence = valuelist[0].strip().partition(".")
+            pounds = self.convert_amount_to_utf8(pounds)
+            # xa3 is the numeric character reference for the pound sign
             pounds = re.sub(r"^(£|\xa3)|[\s,]+", "", pounds)
 
             if pence:

--- a/cla_public/apps/checker/tests/test_money_field.py
+++ b/cla_public/apps/checker/tests/test_money_field.py
@@ -128,8 +128,15 @@ class TestMoneyField(unittest.TestCase):
         self.assertValidAmount("£-800")
         self.assertAmountTooLow("£-800")
 
-    def test_pound_sign_in_multiple_places(self):
-        self.assertValidAmount("£30£0")
-        self.assertValidAmount("££9,300")
-        self.assertValidAmount("3£00")
-        self.assertValidAmount("754£.90")
+    def test_pound_sign_in_wrong_places(self):
+        self.assertInvalidAmount("£30£0")
+        self.assertInvalidAmount("££9,300")
+        self.assertInvalidAmount("3£00")
+        self.assertInvalidAmount("754£.90")
+
+    def test_pound_sign_after_decimal_point(self):
+        self.assertInvalidAmount("£93,200.£50")
+        self.assertInvalidAmount("£15.£4")
+        self.assertInvalidAmount("100.£20")
+        self.assertInvalidAmount("430.£2")
+        self.assertInvalidAmount("754£.£90")

--- a/cla_public/apps/checker/tests/test_money_field.py
+++ b/cla_public/apps/checker/tests/test_money_field.py
@@ -112,15 +112,15 @@ class TestMoneyField(unittest.TestCase):
 
     def test_pound_sign_as_prefix(self):
         self.assertValidAmount("£100")
-        self.assertAmount("10000", "£100")
+        self.assertAmount(10000, "£100")
         self.assertValidAmount("£435.34")
-        self.assertAmount("43534", "£435.34")
+        self.assertAmount(43534, "£435.34")
         self.assertValidAmount("£5000.2")
-        self.assertAmount("5000020", "£5000.2")
+        self.assertAmount(500020, "£5000.2")
         self.assertValidAmount("£3,412.21")
-        self.assertAmount("341221", "£3,412.21")
+        self.assertAmount(341221, "£3,412.21")
         self.assertValidAmount("£3,90   ")
-        self.assertAmount("39000", "£3,90   ")
+        self.assertAmount(39000, "£3,90   ")
 
     def test_pound_sign_with_negative_number(self):
         self.assertValidAmount("£-5000.2")

--- a/cla_public/apps/checker/tests/test_money_field.py
+++ b/cla_public/apps/checker/tests/test_money_field.py
@@ -117,10 +117,12 @@ class TestMoneyField(unittest.TestCase):
         self.assertAmount(43534, "£435.34")
         self.assertValidAmount("£5000.2")
         self.assertAmount(500020, "£5000.2")
-        self.assertValidAmount("£3,412.21")
-        self.assertAmount(341221, "£3,412.21")
+        self.assertValidAmount("£349.21")
+        self.assertAmount(34921, "£349.21")
         self.assertValidAmount("£3,90   ")
         self.assertAmount(39000, "£3,90   ")
+        self.assertValidAmount("£3,,,412.57")
+        self.assertAmount(341257, "£3,,,412.57")
 
     def test_pound_sign_with_negative_number(self):
         self.assertValidAmount("£-5000.2")

--- a/cla_public/apps/checker/tests/test_money_field.py
+++ b/cla_public/apps/checker/tests/test_money_field.py
@@ -109,3 +109,27 @@ class TestMoneyField(unittest.TestCase):
 
     def test_default_max(self):
         self.assertAmountTooHigh("100000000.00", field="default_moneyfield")
+
+    def test_pound_sign_as_prefix(self):
+        self.assertValidAmount("£100")
+        self.assertAmount("10000", "£100")
+        self.assertValidAmount("£435.34")
+        self.assertAmount("43534", "£435.34")
+        self.assertValidAmount("£5000.2")
+        self.assertAmount("5000020", "£5000.2")
+        self.assertValidAmount("£3,412.21")
+        self.assertAmount("341221", "£3,412.21")
+        self.assertValidAmount("£3,90   ")
+        self.assertAmount("39000", "£3,90   ")
+
+    def test_pound_sign_with_negative_number(self):
+        self.assertValidAmount("£-5000.2")
+        self.assertAmountTooLow("£-5000.2")
+        self.assertValidAmount("£-800")
+        self.assertAmountTooLow("£-800")
+
+    def test_pound_sign_in_wrong_places(self):
+        self.assertInvalidAmount("£30£0")
+        self.assertInvalidAmount("££9,300")
+        self.assertInvalidAmount("3£00")
+        self.assertInvalidAmount("754£.90")

--- a/cla_public/apps/checker/tests/test_money_field.py
+++ b/cla_public/apps/checker/tests/test_money_field.py
@@ -128,8 +128,8 @@ class TestMoneyField(unittest.TestCase):
         self.assertValidAmount("£-800")
         self.assertAmountTooLow("£-800")
 
-    def test_pound_sign_in_wrong_places(self):
-        self.assertInvalidAmount("£30£0")
-        self.assertInvalidAmount("££9,300")
-        self.assertInvalidAmount("3£00")
-        self.assertInvalidAmount("754£.90")
+    def test_pound_sign_in_multiple_places(self):
+        self.assertValidAmount("£30£0")
+        self.assertValidAmount("££9,300")
+        self.assertValidAmount("3£00")
+        self.assertValidAmount("754£.90")

--- a/cla_public/javascript-tests/test/currency-input.test.js
+++ b/cla_public/javascript-tests/test/currency-input.test.js
@@ -22,6 +22,19 @@ test('Not a number', () => {
     expect(isValidAmount("one2three")).toBe(false)
 })
 
+test('Amount too high', () => {
+    expect(isValidAmount("100000000.00")).toBe(false)
+})
+
+test('High amount', () => {
+    expect(isValidAmount("10000000")).toBe(true)
+})
+
+test('Negative amounts', () => {
+    expect(isValidAmount("-32")).toBe(false)
+    expect(isValidAmount("-12.34")).toBe(false)
+})
+
 test('Input with commas and spaces', () => {
     expect(isValidAmount("1,200")).toBe(true)
     expect(isValidAmount("1,,,,2")).toBe(true)
@@ -39,11 +52,6 @@ test('Only one decimal place', () => {
 test('No commas or space in pence', () => {
     expect(isValidAmount("1.23.45")).toBe(false)
     expect(isValidAmount("12.3 45.6")).toBe(false)
-})
-
-test('Negative amounts', () => {
-    expect(isValidAmount("-32")).toBe(false)
-    expect(isValidAmount("-12.34")).toBe(false)
 })
 
 test('Input with pound sign as prefix', () => {

--- a/cla_public/javascript-tests/test/currency-input.test.js
+++ b/cla_public/javascript-tests/test/currency-input.test.js
@@ -1,0 +1,56 @@
+var isValidAmount = require('../../static-src/javascripts/modules/currencyInputValidation.js').isValidAmount
+
+test('Integer', () => {
+    expect(isValidAmount("500")).toBe(true)
+})
+
+test('Decimal', () => {
+    expect(isValidAmount("10.5")).toBe(true)
+})
+
+test('Amount', () => {
+    expect(isValidAmount("12.34")).toBe(true)
+})
+
+test('Too many decimal places', () => {
+    expect(isValidAmount("12.345")).toBe(false)
+})
+
+test('Not a number', () => {
+    expect(isValidAmount("abc")).toBe(false)
+    expect(isValidAmount("1twothree")).toBe(false)
+    expect(isValidAmount("one2three")).toBe(false)
+})
+
+test('Input with commas and spaces', () => {
+    expect(isValidAmount("1,200")).toBe(true)
+    expect(isValidAmount("1,,,,2")).toBe(true)
+    expect(isValidAmount("  1  3  ")).toBe(true)
+    expect(isValidAmount("12, 34, 56")).toBe(true)
+    expect(isValidAmount("123.4      ")).toBe(true)
+})
+
+
+test('Only one decimal place', () => {
+    expect(isValidAmount("1.23.45")).toBe(false)
+    expect(isValidAmount("12.3 45.6")).toBe(false)
+})
+
+test('No commas or space in pence', () => {
+    expect(isValidAmount("1.23.45")).toBe(false)
+    expect(isValidAmount("12.3 45.6")).toBe(false)
+})
+
+test('Negative amounts', () => {
+    expect(isValidAmount("-32")).toBe(false)
+    expect(isValidAmount("-12.34")).toBe(false)
+})
+
+test('Input with pound sign as prefix', () => {
+    expect(isValidAmount("£100")).toBe(true)
+    expect(isValidAmount("£435.34")).toBe(true)
+    expect(isValidAmount("£435.34")).toBe(true)
+    expect(isValidAmount("£5000.2")).toBe(true)
+    expect(isValidAmount("£3,90   ")).toBe(true)
+    expect(isValidAmount("£3,,,412.57")).toBe(true)
+})

--- a/cla_public/static-src/javascripts/modules/currencyInputValidation.js
+++ b/cla_public/static-src/javascripts/modules/currencyInputValidation.js
@@ -3,15 +3,22 @@
 function isValidAmount(input) {
     var maxVal = 100000000
     var minVal = 0
+    var pounds;
+    var pence;
 
-    var value = input.split('.')
-    var pounds = value[0]
-    var pence = value[1]
-    pounds = pounds.replaceAll(/^£|[\s,]+/g, "")
+    var trimmedInput = input.trim()
+
+    var decimalPointPosition = trimmedInput.indexOf('.')
+    if(decimalPointPosition === -1) {
+        pounds = trimmedInput
+    } else {
+        pounds = trimmedInput.slice(0, decimalPointPosition)
+        pence = trimmedInput.slice(decimalPointPosition + 1)
+    }
+    pounds = pounds.replace(/^£|[\s,]+/g, "")
 
     if(pence) {
-        var lengthOfPence = pence.length
-        if(lengthOfPence > 2) {
+        if(pence.length > 2) {
             return false
         }
     }
@@ -22,7 +29,6 @@ function isValidAmount(input) {
     }
 
     if(amount) {
-        console.log('Amount: ' + amount)
         if(amount > maxVal || amount < minVal) {
             return false
         }

--- a/cla_public/static-src/javascripts/modules/currencyInputValidation.js
+++ b/cla_public/static-src/javascripts/modules/currencyInputValidation.js
@@ -1,7 +1,36 @@
 // ($(this).val() && Number($(this).val()) > 0)
 
 function isValidAmount(input) {
-    return input && Number(input) > 0
+    var maxVal = 100000000
+    var minVal = 0
+
+    var value = input.split('.')
+    var pounds = value[0]
+    var pence = value[1]
+    pounds = pounds.replaceAll(/^£|[\s,]+/g, "")
+
+    if(pence) {
+        var lengthOfPence = pence.length
+        if(lengthOfPence > 2) {
+            return false
+        }
+    }
+
+    var amount = Number(pounds * 100)
+    if(pence) {
+        amount += Number(pence)
+    }
+
+    if(amount) {
+        console.log('Amount: ' + amount)
+        if(amount > maxVal || amount < minVal) {
+            return false
+        }
+    } else {
+        return false
+    }
+
+    return true
 }
 
 exports.isValidAmount = isValidAmount

--- a/cla_public/static-src/javascripts/modules/currencyInputValidation.js
+++ b/cla_public/static-src/javascripts/modules/currencyInputValidation.js
@@ -1,5 +1,5 @@
 function isValidAmount(input) {
-    var maxVal = 100000000
+    var maxVal = 9999999999
     var minVal = 0
     var pounds;
     var pence;

--- a/cla_public/static-src/javascripts/modules/currencyInputValidation.js
+++ b/cla_public/static-src/javascripts/modules/currencyInputValidation.js
@@ -1,0 +1,7 @@
+// ($(this).val() && Number($(this).val()) > 0)
+
+function isValidAmount(input) {
+    return input && Number(input) > 0
+}
+
+exports.isValidAmount = isValidAmount

--- a/cla_public/static-src/javascripts/modules/currencyInputValidation.js
+++ b/cla_public/static-src/javascripts/modules/currencyInputValidation.js
@@ -1,5 +1,3 @@
-// ($(this).val() && Number($(this).val()) > 0)
-
 function isValidAmount(input) {
     var maxVal = 100000000
     var minVal = 0

--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -145,6 +145,9 @@
             return ($(this).val())
           })
           .removeClass("govuk-select--error")
+
+          $this.find('.laa-currency .govuk-input.govuk-input--error').siblings(".laa-currency-prefix")
+          .addClass("laa-currency-prefix--error");
           
         }
 

--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -1,4 +1,5 @@
  'use strict';
+  var currencyValidation = require('./currencyInputValidation');
   var _ = require('lodash');
   moj.Modules.FormErrors = {
     init: function() {
@@ -122,7 +123,7 @@
           labelField = labelField.parents(".cla-currency-by-frequency").children("legend");
 
           $this.find(' .govuk-input').filter(function () {
-            return ($(this).val() && Number($(this).val()) > 0)
+            return currencyValidation.isValidAmount($(this).val())
           })
           .removeClass("govuk-input--error");
 

--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -129,7 +129,7 @@
           if(!inputElementWithValidEntry.length) {
             $this.find(' .govuk-input')
             .focus(function() {
-              $(".laa-currency-prefix--error")
+              $this.find('.laa-currency .govuk-input.govuk-input--error').siblings(".laa-currency-prefix")
               .removeClass("laa-currency-prefix--error")
             })
             .blur(function() {

--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -122,18 +122,30 @@
         if (labelField.parents(".cla-currency-by-frequency").length) {
           labelField = labelField.parents(".cla-currency-by-frequency").children("legend");
 
-          $this.find(' .govuk-input').filter(function () {
+          var inputElementWithValidEntry = $this.find(' .govuk-input').filter(function () {
             return currencyValidation.isValidAmount($(this).val())
           })
-          .removeClass("govuk-input--error");
+
+          if(!inputElementWithValidEntry.length) {
+            $this.find(' .govuk-input')
+            .focus(function() {
+              $(".laa-currency-prefix--error")
+              .removeClass("laa-currency-prefix--error")
+            })
+            .blur(function() {
+              $this.find('.laa-currency .govuk-input.govuk-input--error').siblings(".laa-currency-prefix")
+              .addClass("laa-currency-prefix--error");
+            })
+          }
+
+          inputElementWithValidEntry
+          .removeClass("govuk-input--error")
 
           $this.find(' .govuk-select').filter(function () {
             return ($(this).val())
           })
           .removeClass("govuk-select--error")
-
-          $this.find('.laa-currency .govuk-input.govuk-input--error').siblings(".laa-currency-prefix")
-            .addClass("laa-currency-prefix--error");
+          
         }
 
         if (errorText) {

--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -114,7 +114,15 @@
 
         $this.find(' .govuk-input')
           .not('.govuk-form-group--error .govuk-radios__conditional .govuk-input')
-          .addClass("govuk-input--error");
+          .addClass("govuk-input--error")
+          .focus(function() {
+            $this.find('.laa-currency .govuk-input.govuk-input--error').siblings(".laa-currency-prefix")
+            .removeClass("laa-currency-prefix--error")
+          })
+          .blur(function() {
+            $this.find('.laa-currency .govuk-input.govuk-input--error').siblings(".laa-currency-prefix")
+            .addClass("laa-currency-prefix--error");
+          });
         $this.find(' .govuk-select')
           .not('.govuk-form-group--error .govuk-radios__conditional .govuk-select')
           .addClass("govuk-select--error");
@@ -146,10 +154,10 @@
           })
           .removeClass("govuk-select--error")
 
-          $this.find('.laa-currency .govuk-input.govuk-input--error').siblings(".laa-currency-prefix")
-          .addClass("laa-currency-prefix--error");
-          
         }
+
+        $this.find('.laa-currency .govuk-input.govuk-input--error').siblings(".laa-currency-prefix")
+        .addClass("laa-currency-prefix--error");
 
         if (errorText) {
           var labelText = errorText;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": ">=8.9.x"
   },
   "scripts": {
-    "jest": "jest --verbose test"
+    "jest": "jest --verbose --coverage cla_public/javascript-tests/test"
   },
   "engineStrict": true,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "engines": {
     "node": ">=8.9.x"
   },
-  "scripts": {},
+  "scripts": {
+    "jest": "jest --verbose test"
+  },
   "engineStrict": true,
   "devDependencies": {
     "browser-sync": "^2.26.12",
@@ -25,6 +27,7 @@
     "gulp-sass": "^4.0.1",
     "gulp-uglify": "^3.0.0",
     "jshint": "^2.12.0",
+    "jest": "^24.0.0",
     "jshint-stylish": "~2.2.1",
     "natives": "^1.1.4",
     "require-dir": "^0.3.2",


### PR DESCRIPTION
## What does this pull request do?

- Let users optionally add a pound sign to any input requiring an amount to be entered 
- Rewrite validation for the front end which deals with how error classes get added. Validation on front end now matches the validation on the backend
- Write tests for the validation on frontend and backend
- Create a new test/test folder for the frontend validation called `javascript-tests/test`
- Ensure error and non-error colours are consistent for forms that require `an amount and frequency` (like pictured below) or just `an amount`

## Any other changes that would benefit highlighting?

> Had to work around the fact that the £ sign is a non-ASCII character and python's default encoding is ASCII. Also on the backend, data coming in from the tests comes in byte literal while data coming from the frontend comes in unicode. I attempt to convert both to unicode format. The coveralls test shows decreased coverage because since data coming from the tests are in bytes literal, they get decoded and the `except block` never gets executed via the tests. It only gets executed when submitting input from the frontend.

**Latest fix:** Latest commits are to fix the issue pictured below making sure that if the user has entered an invalid amount and submitted, the input element will be fully red when not focusing on it and fully black when focusing on it.

![image](https://user-images.githubusercontent.com/64010092/94795094-c780f700-03d4-11eb-9436-781cb88d4fcf.png)

**Worth pointing out the JS test is run using `jest`. Jest has been configured to print out coverage for the test results similar to coveralls. Possible suggestions (as they are out of scope for this ticket):**

1. Integrate the JS test into CircleCI
2. If possible integrate the JS test with coveralls or use the results produced from jest mentioned above and integrate that with CircleCI

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
