### PR TITLE
LGA-1382 - Update cla_common for restored operator hours

### DIFF
--- a/cla_public/apps/contact/tests/test_availability.py
+++ b/cla_public/apps/contact/tests/test_availability.py
@@ -172,12 +172,12 @@ class TestDayTimeChoices(unittest.TestCase):
             field = DayChoiceField()
             field = field.bind(form, "day")
             choices = field.day_time_choices
-            # no availability on saturday
-            self.assertNotIn("20150214", choices.keys())
+            # lower availability on saturday
+            self.assertEqual(7, len(choices["20150214"]))
             # can book before 11am on monday. Monday morning call back capping removed.
-            self.assertEqual(16, len(choices["20150216"]))
+            self.assertEqual(22, len(choices["20150216"]))
             # can book any slot on tuesday
-            self.assertEqual(16, len(choices["20150217"]))
+            self.assertEqual(22, len(choices["20150217"]))
 
     def test_monday_available_before_11_on_saturday(self):
         with override_current_time(datetime.datetime(2015, 5, 9, 10, 30)):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ PyYAML==3.11
 Werkzeug==0.9.6
 argparse==1.2.1
 blinker==1.3
-git+https://github.com/ministryofjustice/cla_common.git@0.3.8#egg=cla_common
+git+https://github.com/ministryofjustice/cla_common.git@0.3.10#egg=cla_common
 speaklater==1.3 # Required by cla_common
 itsdangerous==0.24
 logstash_formatter==0.5.9


### PR DESCRIPTION
## What does this pull request do?
cla_common has been updated with [new operator hours](https://github.com/ministryofjustice/cla_common/pull/98)
While this repo does not directly use those changes, it should be kept up to date.
It should not be merged here until it's ready to be used on cla_frontend and cla_backend, just to keep things simple

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"