### PR TITLE
LGA-1402 External links marked as such for screen readers only

### DIFF
--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -279,18 +279,8 @@ dl.govuk-list.govuk-list--bullet {
 }
 @media only screen {
   a[rel="external"]:after {
+    @extend .govuk-visually-hidden; 
     content:" (opens external site)";
-    position: absolute !important;
-    width: 1px !important;
-    height: 7px !important;
-    margin: 0 !important;
-    padding: 0 !important;
-    overflow: hidden !important;
-    clip: rect(0 0 0 0) !important;
-    -webkit-clip-path: inset(50%) !important;
-    clip-path: inset(50%) !important;
-    border: 0 !important;
-    white-space: nowrap !important;
   }
   *[lang=cy] a[rel="external"]:after {
     content:" (gwefan allanol)";

--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -279,7 +279,21 @@ dl.govuk-list.govuk-list--bullet {
 }
 @media only screen {
   a[rel="external"]:after {
-    content: "";
+    content:" (opens external site)";
+    position: absolute !important;
+    width: 1px !important;
+    height: 7px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+    clip: rect(0 0 0 0) !important;
+    -webkit-clip-path: inset(50%) !important;
+    clip-path: inset(50%) !important;
+    border: 0 !important;
+    white-space: nowrap !important;
+  }
+  *[lang=cy] a[rel="external"]:after {
+    content:" (gwefan allanol)";
   }
 }
 .govuk-label:not(.govuk-radios__label):not(.govuk-checkboxes__label),

--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -279,8 +279,18 @@ dl.govuk-list.govuk-list--bullet {
 }
 @media only screen {
   a[rel="external"]:after {
-    @extend .govuk-visually-hidden; 
     content:" (opens external site)";
+    position: absolute !important;
+    width: 1px !important;
+    height: 7px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+    clip: rect(0 0 0 0) !important;
+    -webkit-clip-path: inset(50%) !important;
+    clip-path: inset(50%) !important;
+    border: 0 !important;
+    white-space: nowrap !important;
   }
   *[lang=cy] a[rel="external"]:after {
     content:" (gwefan allanol)";


### PR DESCRIPTION
## What does this pull request do?

Added suffix to all links with `rel=external` to indicate to screen readers that it is a link to an external website.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
