### PR TITLE
LGA-1407 numbers

### DIFF
--- a/cla_public/templates/checker/about.html
+++ b/cla_public/templates/checker/about.html
@@ -17,14 +17,14 @@
     {% call Form.fieldset(form.have_children) %}
       <div class="govuk-radios__conditional">
         {{ Form.group(form.num_children, '',
-            controlled_by=form.have_children, field_attrs={'class': 'govuk-input--width-4'}) }}
+            controlled_by=form.have_children, field_attrs={'class': 'govuk-input--width-4', 'inputmode':'numeric'}) }}
       </div>
     {% endcall %}
 
     {% call Form.fieldset(form.have_dependants) %}
       <div class="govuk-radios__conditional">
         {{ Form.group(form.num_dependants, '',
-            controlled_by=form.have_dependants, field_attrs={'class': 'govuk-input--width-4'}) }}
+            controlled_by=form.have_dependants, field_attrs={'class': 'govuk-input--width-4', 'inputmode':'numeric'}) }}
       </div>
     {% endcall %}
     

--- a/cla_public/templates/checker/about.html
+++ b/cla_public/templates/checker/about.html
@@ -3,7 +3,7 @@
 {% block inner_content %}
   {{ Form.handle_errors(form) }}
   <h1 class="govuk-heading-xl">{{ title }}</h1>
-  <form method="POST">
+  <form method="POST" novalidate>
     {{ form.csrf_token }}
 
     {% call Form.fieldset(form.have_partner) %}

--- a/cla_public/templates/checker/about.html
+++ b/cla_public/templates/checker/about.html
@@ -17,14 +17,14 @@
     {% call Form.fieldset(form.have_children) %}
       <div class="govuk-radios__conditional">
         {{ Form.group(form.num_children, '',
-            controlled_by=form.have_children, field_attrs={'class': 'govuk-input--width-4', 'inputmode':'numeric'}) }}
+            controlled_by=form.have_children, field_attrs={'class': 'govuk-input--width-4', 'inputmode':'numeric', 'pattern':'[0-9]*'}) }}
       </div>
     {% endcall %}
 
     {% call Form.fieldset(form.have_dependants) %}
       <div class="govuk-radios__conditional">
         {{ Form.group(form.num_dependants, '',
-            controlled_by=form.have_dependants, field_attrs={'class': 'govuk-input--width-4', 'inputmode':'numeric'}) }}
+            controlled_by=form.have_dependants, field_attrs={'class': 'govuk-input--width-4', 'inputmode':'numeric', 'pattern':'[0-9]*'}) }}
       </div>
     {% endcall %}
     

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -228,7 +228,7 @@
                       class_='govuk-input govuk-input--width-10%s'  % (' govuk-select--error' if field and (field.errors and controlled_by and not controlled_by.errors or field.errors and not controlled_by) ),
                       autocomplete='off',
                       spellcheck='false',
-                      inputmode='numeric',
+                      inputmode='decimal',
                       **{'aria-required': 'false' if field.flags.optional else 'true', 'aria-describedby':field.name+'-hint'}
                     )
                   }}
@@ -447,7 +447,7 @@
     {% else %}
       {% set attribs={'aria-required': 'false' if field.flags.optional else 'true'} %}
     {% endif %}
-    {{ field(class_='govuk-input govuk-input--width-10 ' + class_, autocomplete='off', spellcheck='false', inputmode='numeric', **attribs) }}
+    {{ field(class_='govuk-input govuk-input--width-10 ' + class_, autocomplete='off', spellcheck='false', inputmode='decimal', **attribs) }}
     {% if prefix %}
       </div>
     {% endif %}

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -228,7 +228,6 @@
                       class_='govuk-input govuk-input--width-10%s'  % (' govuk-select--error' if field and (field.errors and controlled_by and not controlled_by.errors or field.errors and not controlled_by) ),
                       autocomplete='off',
                       spellcheck='false',
-                      inputmode='decimal',
                       **{'aria-required': 'false' if field.flags.optional else 'true', 'aria-describedby':field.name+'-hint'}
                     )
                   }}
@@ -447,7 +446,7 @@
     {% else %}
       {% set attribs={'aria-required': 'false' if field.flags.optional else 'true'} %}
     {% endif %}
-    {{ field(class_='govuk-input govuk-input--width-10 ' + class_, autocomplete='off', spellcheck='false', inputmode='decimal', **attribs) }}
+    {{ field(class_='govuk-input govuk-input--width-10 ' + class_, autocomplete='off', spellcheck='false', **attribs) }}
     {% if prefix %}
       </div>
     {% endif %}


### PR DESCRIPTION
## What does this pull request do?

Adds a `pattern` and `inputmode=numeric` to the integer entry fields for _**number of depentants**_ and _**number of children**_.  
Removes the same from the currency fields as per GDS guidelines.  

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
