### PR TITLE
LGA-1463 - uwsgi graceful termination workaround 

### DIFF
--- a/docker/cla_public.ini
+++ b/docker/cla_public.ini
@@ -19,3 +19,4 @@ post-buffering-bufsize=32768
 ignore-sigpipe = true
 ignore-write-errors = true
 disable-write-exception = true
+die-on-term=True

--- a/helm_deploy/cla-public/templates/deployment.yaml
+++ b/helm_deploy/cla-public/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      terminationGracePeriodSeconds: 30
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -47,6 +48,10 @@ spec:
             initialDelaySeconds: 5
             timeoutSeconds: 1
             periodSeconds: 10
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep","10"]
           env:
             - name: ALLOWED_HOSTS
               value: "{{ .Values.host }}"


### PR DESCRIPTION
## What does this pull request do?

Add preStop lifecycle hook and terminationGracePeriod to allow enough time for uwsgi finish processing requests

Changes explained:

- **die-on-term** - respect the convention of shutting down the instance
- **preStop** - Sleep for 30 seconds. Called before receiving SIGTERM. Aim here is to sleep enough time for the current requests to finish.
- **terminationGracePeriodSeconds** - Amount of time kubernetes waits before sending us the SIGKILL signal.

Important note from the [kubernetes documentation ](https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-terminating-with-grace)on how the preStop and terminationGracePeriodSeconds interact:

> It’s important to note that this(_terminationGracePeriodSeconds_) happens in parallel to the preStop hook and the SIGTERM signal. Kubernetes does not wait for the preStop hook to finish.
If your app finishes shutting down and exits before the terminationGracePeriod is done, Kubernetes moves to the next step immediately.


## Any other changes that would benefit highlighting?

Related PR https://github.com/ministryofjustice/cla_backend/pull/665
Set sleep time to 10 seconds as opposed to 30 in the related PR -- because these requests should be lighter than the cla_backend project

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
