### PR TITLE
LGA-1404 Comms page text size and optional suffix

### DIFF
--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -157,7 +157,7 @@ class ContactForm(Honeypot, BabelTranslationsFormMixin, Form):
         _(u"Tell us more about your problem"),
         validators=[Length(max=4000, message=_(u"Your notes must be 4000 characters or less")), Optional()],
     )
-    adaptations = ValidatedFormField(AdaptationsForm, _(u"Do you have any special communication needs?"))
+    adaptations = ValidatedFormField(AdaptationsForm, _(u"Do you have any special communication needs? (optional)"))
 
     def api_payload(self):
         "Form data as data structure ready to send to API"

--- a/cla_public/static-src/javascripts/modules/address-finder.js
+++ b/cla_public/static-src/javascripts/modules/address-finder.js
@@ -112,6 +112,7 @@
       // tidy up addresses for dropdown list
       $.each(addresses, function (i, addr) {
         var parts = addr.formatted_address.split('\n');
+        parts.pop();  // strip postcode
         var text = parts.join(', ');
         addrItems.push(text);
       });

--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -439,3 +439,17 @@ body.cla-dev {
     background-color:$laa-dev-colour;
   }
 }
+
+.cla-question-text--large .govuk-label {
+  font-size: 18px !important;
+  font-size: 1.125rem !important;
+  line-height: 1.11111 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .cla-question-text--large .govuk-label {
+    font-size: 24px !important;
+    font-size: 1.5rem !important;
+    line-height: 1.25 !important;
+  }
+}

--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -439,4 +439,3 @@ body.cla-dev {
     background-color:$laa-dev-colour;
   }
 }
-

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -61,7 +61,7 @@
 
     {{ Form.group(form.full_name, 'cla-question-text--large', field_attrs={'spellcheck': "false"}) }}
 
-    {% call Form.fieldset(form.contact_type, field_as_label=True) %}
+    {% call Form.fieldset(form.contact_type, field_as_label=True, legend_size='m') %}
       <div class="govuk-radios">
         {%- for option in form.contact_type -%}
           <div class="govuk-radios__item">

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -59,7 +59,7 @@
   <form method="POST" action="{{ url_for('contact.get_in_touch') }}">
     {{ form.csrf_token }}
 
-    {{ Form.group(form.full_name, field_attrs={'class': 'm-large', 'spellcheck': "false"}) }}
+    {{ Form.group(form.full_name, field_attrs={'spellcheck': "false"}) }}
 
     {% call Form.fieldset(form.contact_type, field_as_label=True) %}
       <div class="govuk-radios">
@@ -92,7 +92,7 @@
       </div>
     {% endcall %}
 
-    {{ Form.group(form.email, field_attrs={'class': 'm-large'}) }}
+    {{ Form.group(form.email) }}
 
     {% call Form.fieldset(form.address, field_as_label=True, legend_size='m') %}
       {{ Form.group(form.address.post_code,
@@ -102,12 +102,12 @@
 
       {{ Form.group(form.address.street_address,
           'form-group-plain',
-          field_attrs={'class': 'm-large', 'rows': 4}) }}
-    {% endcall %}
+          field_attrs={'rows': 4}) }}
+      {% endcall %}
 
     {% set max_length_validator = form.extra_notes.validators|selectattr('max')|first %}
     {% set max_length = max_length_validator.max if max_length_validator %}
-    {{ Form.group(form.extra_notes, field_attrs={'class': 'm-full', 'rows': 7, 'data-character-count': max_length}) }}
+    {{ Form.group(form.extra_notes, field_attrs={'rows': 7, 'data-character-count': max_length}) }}
     <div class="govuk-form-group">
       {{ Subform.adaptations(form.adaptations) }}
     </div>

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -103,7 +103,7 @@
       {{ Form.group(form.address.street_address,
           'form-group-plain',
           field_attrs={'rows': 4}) }}
-      {% endcall %}
+    {% endcall %}
 
     {% set max_length_validator = form.extra_notes.validators|selectattr('max')|first %}
     {% set max_length = max_length_validator.max if max_length_validator %}

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -59,7 +59,7 @@
   <form method="POST" action="{{ url_for('contact.get_in_touch') }}">
     {{ form.csrf_token }}
 
-    {{ Form.group(form.full_name, field_attrs={'spellcheck': "false"}) }}
+    {{ Form.group(form.full_name, 'cla-question-text--large', field_attrs={'spellcheck': "false"}) }}
 
     {% call Form.fieldset(form.contact_type, field_as_label=True) %}
       <div class="govuk-radios">
@@ -92,7 +92,7 @@
       </div>
     {% endcall %}
 
-    {{ Form.group(form.email) }}
+    {{ Form.group(form.email, 'cla-question-text--large') }}
 
     {% call Form.fieldset(form.address, field_as_label=True, legend_size='m') %}
       {{ Form.group(form.address.post_code,
@@ -107,7 +107,7 @@
 
     {% set max_length_validator = form.extra_notes.validators|selectattr('max')|first %}
     {% set max_length = max_length_validator.max if max_length_validator %}
-    {{ Form.group(form.extra_notes, field_attrs={'rows': 7, 'data-character-count': max_length}) }}
+    {{ Form.group(form.extra_notes, 'cla-question-text--large', field_attrs={'rows': 7, 'data-character-count': max_length}) }}
     <div class="govuk-form-group">
       {{ Subform.adaptations(form.adaptations) }}
     </div>

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -1603,8 +1603,8 @@ msgid "Your notes must be 4000 characters or less"
 msgstr "Rhaid i’ch nodiadau fod yn 4000 nod neu lai"
 
 #: cla_public/apps/contact/forms.py:152
-msgid "Do you have any special communication needs?"
-msgstr "Oes gennych chi unrhyw anghenion cyfathrebu arbennig?"
+msgid "Do you have any special communication needs? (optional)"
+msgstr "Oes gennych chi unrhyw anghenion cyfathrebu arbennig? (dewisol)"
 
 #: cla_public/apps/contact/forms.py:200
 msgid "Receive this confirmation by email"

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -1188,7 +1188,7 @@ msgid "Your notes must be 4000 characters or less"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:152
-msgid "Do you have any special communication needs?"
+msgid "Do you have any special communication needs? (optional)"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:200


### PR DESCRIPTION
## What does this pull request do?

Changes question text size for all but address questions.
Adds (optional) suffix to special communication needs question.

## Any other changes that would benefit highlighting?

Remove postcode repetition from address select.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
