### PR TITLE
LGA-1475 Two H1s on one page

### DIFF
--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -152,7 +152,8 @@
     {% endcall %}
   {% endif %}
 
-  {% if category == 'pi' %}
+  {% if title %}
+  {% elif category == 'pi' %}
     <h1 class="govuk-heading-xl">
       {{ _('Legal aid is not usually available for advice about personal injury') }}
     </h1>


### PR DESCRIPTION
## What does this pull request do?

Checked for title attribute - if set, that means a title is already used (in laalaa.html).  Otherwise use title as normal.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
