### PR TITLE
LGA-1479 Erratic Other Language Select Class

### DIFF
--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -282,7 +282,7 @@
     {{ money_input(field, **field_attrs) }}
   {% else %}
     {% if field.type in ['SelectField', 'TimeChoiceField', 'DayChoiceField'] %}
-      {% do field_attrs.update(class='govuk-select cla-probe-one %s' % field_attrs.class) %} <div style="display:none;">{{ field.type }}</div>
+      {% do field_attrs.update(class='govuk-select %s' % field_attrs.class) %}
     {% elif field.type == "TextAreaField" %}
       {% do field_attrs.update(class='govuk-textarea %s' % field_attrs.class) %}
     {% elif field.type in ['StringField', 'SetZeroIntegerField'] %}

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -282,7 +282,7 @@
     {{ money_input(field, **field_attrs) }}
   {% else %}
     {% if field.type in ['SelectField', 'TimeChoiceField', 'DayChoiceField'] %}
-      {% do field_attrs.update(class='govuk-select cla-probe %s' % field_attrs.class) %} <div style="display:none;">{{ field.type }}</div>
+      {% do field_attrs.update(class='govuk-select cla-probe-one %s' % field_attrs.class) %} <div style="display:none;">{{ field.type }}</div>
     {% elif field.type == "TextAreaField" %}
       {% do field_attrs.update(class='govuk-textarea %s' % field_attrs.class) %}
     {% elif field.type in ['StringField', 'SetZeroIntegerField'] %}

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -282,7 +282,7 @@
     {{ money_input(field, **field_attrs) }}
   {% else %}
     {% if field.type in ['SelectField', 'TimeChoiceField', 'DayChoiceField'] %}
-      {% do field_attrs.update(class='govuk-select %s' % field_attrs.class) %}
+      {% do field_attrs.update(class='govuk-select cla-probe %s' % field_attrs.class) %} <div style="display:none;">{{ field.type }}</div>
     {% elif field.type == "TextAreaField" %}
       {% do field_attrs.update(class='govuk-textarea %s' % field_attrs.class) %}
     {% elif field.type in ['StringField', 'SetZeroIntegerField'] %}

--- a/cla_public/templates/macros/subform.html
+++ b/cla_public/templates/macros/subform.html
@@ -142,7 +142,8 @@
         {{ Form.group(subform.other_language, 'govuk-checkboxes__conditional',
             controlled_by=subform.is_other_language,
             control_value='y',
-            row_class='') }}
+            row_class='',
+            field_attrs={'class': 'cla-probe-two'}) }}
     <div class="govuk-checkboxes__item">
       {{ subform.is_other_adaptation(**{'aria-controls': subform.other_adaptation.id, "class": "govuk-checkboxes__input"}) }}
       <label class="govuk-label govuk-checkboxes__label" for="{{subform.is_other_adaptation.id}}">

--- a/cla_public/templates/macros/subform.html
+++ b/cla_public/templates/macros/subform.html
@@ -143,7 +143,8 @@
             controlled_by=subform.is_other_language,
             control_value='y',
             row_class='',
-            field_attrs={'class': 'cla-probe-two'}) }}
+            field_attrs={'class': ''}) }}
+         
     <div class="govuk-checkboxes__item">
       {{ subform.is_other_adaptation(**{'aria-controls': subform.other_adaptation.id, "class": "govuk-checkboxes__input"}) }}
       <label class="govuk-label govuk-checkboxes__label" for="{{subform.is_other_adaptation.id}}">

--- a/cla_public/templates/macros/subform.html
+++ b/cla_public/templates/macros/subform.html
@@ -143,8 +143,12 @@
             controlled_by=subform.is_other_language,
             control_value='y',
             row_class='',
-            field_attrs={'class': ''}) }}
-         
+            field_attrs={'class': 'govuk-!-width-two-thirds'}) }}
+        {#
+          if removing class, leave in class code like this:
+          field_attrs={'class': ''}
+          otherwise the class acts haywire (see LGA-1479)
+        #}
     <div class="govuk-checkboxes__item">
       {{ subform.is_other_adaptation(**{'aria-controls': subform.other_adaptation.id, "class": "govuk-checkboxes__input"}) }}
       <label class="govuk-label govuk-checkboxes__label" for="{{subform.is_other_adaptation.id}}">


### PR DESCRIPTION
## What does this pull request do?

- Adds in a width class to the other language select field:
  - This fixes the still-unexplained bug.
  - This also maintains the wide breadth of the select field, increasing click area.
- Added in note for any future development on this, so the bug isn't accidentally re-introduced.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
