### PR TITLE
LGA-1515 rel=external for sign language link

### DIFF
--- a/cla_public/templates/interstitial.html
+++ b/cla_public/templates/interstitial.html
@@ -50,7 +50,7 @@
   </p>
 
   <p class="govuk-body">
-    {% trans %}If you’re deaf or hard of hearing you can book a <a class="govuk-link" href="http://www.interpretingline.co.uk/vbooking.html"> British Sign Language interpreter</a> by completing a request form.  Once complete, the operator will get back to you to complete the eligibility check and provide any further advice.{% endtrans %}
+    {% trans %}If you’re deaf or hard of hearing you can book a <a class="govuk-link" href="http://www.interpretingline.co.uk/vbooking.html" rel="external">British Sign Language interpreter</a> by completing a request form.  Once complete, the operator will get back to you to complete the eligibility check and provide any further advice.{% endtrans %}
   </p>
 
   <a class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8 govuk-button--start" href="{{ url_for('.wizard', step='about') }}" role="button">

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -2402,8 +2402,8 @@ msgid ""
 msgstr "Os ydych o dan 18 oed, dylech <a class=\"govuk-link\" href=\"%(url)s\">gysylltu â’r CLA</a> heb gwblhau’r asesiad ariannol."
 
 #: cla_public/templates/interstitial.html:53
-msgid "If you’re deaf or hard of hearing you can book a <a class=\"govuk-link\" href=\"http://www.interpretingline.co.uk/vbooking.html\"> British Sign Language interpreter</a> by completing a request form.  Once complete, the operator will get back to you to complete the eligibility check and provide any further advice."
-msgstr "Os ydych yn fyddar neu’n drwm eich clyw gallwch lenwi ffurflen gais i ofyn am ddehonglydd <a class=\"govuk-link\" href=\"http://www.interpretingline.co.uk/vbooking.html\">Iaith Arwyddion Prydain</a>. Ar ôl i chi lenwi’r ffurflen, bydd y gweithredwr yn dod yn ôl atoch i gwblhau’r gwiriad cymhwystra a rhoi unrhyw gyngor arall."
+msgid "If you’re deaf or hard of hearing you can book a <a class=\"govuk-link\" href=\"http://www.interpretingline.co.uk/vbooking.html\" rel=\"external\">British Sign Language interpreter</a> by completing a request form.  Once complete, the operator will get back to you to complete the eligibility check and provide any further advice."
+msgstr "Os ydych yn fyddar neu’n drwm eich clyw gallwch lenwi ffurflen gais i ofyn am <a class=\"govuk-link\" href=\"http://www.interpretingline.co.uk/vbooking.html\" rel=\"external\">ddehonglydd Iaith Arwyddion Prydain</a>. Ar ôl i chi lenwi’r ffurflen, bydd y gweithredwr yn dod yn ôl atoch i gwblhau’r gwiriad cymhwystra a rhoi unrhyw gyngor arall."
 
 #: cla_public/templates/interstitial.html:57
 msgid "Check if you qualify financially"

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -1914,7 +1914,7 @@ msgid ""
 msgstr ""
 
 #: cla_public/templates/interstitial.html:53
-msgid "If you’re deaf or hard of hearing you can book a <a class=\"govuk-link\" href=\"http://www.interpretingline.co.uk/vbooking.html\"> British Sign Language interpreter</a> by completing a request form.  Once complete, the operator will get back to you to complete the eligibility check and provide any further advice."
+msgid "If you’re deaf or hard of hearing you can book a <a class=\"govuk-link\" href=\"http://www.interpretingline.co.uk/vbooking.html\" rel=\"external\">British Sign Language interpreter</a> by completing a request form.  Once complete, the operator will get back to you to complete the eligibility check and provide any further advice."
 msgstr ""
 
 #: cla_public/templates/interstitial.html:57


### PR DESCRIPTION
## What does this pull request do?

Adds `rel=external` to the sign language link for screen reader assistance etc.  
Adds it to the Welsh translation too.

## Any other changes that would benefit highlighting?

Moved the Welsh word for "interpreter" into the link to be in line with the English

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
