### PR TITLE
LGA-1428 & 1427 Welsh Translations and Accessibility Statement update

### DIFF
--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -77,14 +77,14 @@
 
   <h4 class="govuk-heading-m">{{ _('Time-out') }}</h4>
 
-  <p class="govuk-body">
+  <p class="govuk-body govuk-inset-text">
     {% trans %}Users are not able to turn off, adjust or extend the time in which inactivity will result in a loss of data. This fails WCAG 2.1 2.2.1 A (Timing Adjustable).{% endtrans %}
   </p>
   <p class="govuk-body">
     {% trans %}We are experiencing intermittent problems with the time-out feature where users are unexpectedly timed-out without the time-out warning appearing. We are currently investigating the source of this issue.{% endtrans %}
   </p>
   <h4 class="govuk-heading-m">{{ _('Hide this page') }}</h4>
-  <p class="govuk-body">
+  <p class="govuk-body govuk-inset-text">
     {% trans %}The ‘Hide this page’ button does not accurately describe the link destination. This fails WCAG 2.1 1.3.1 A (Info and relationships) and 2.4.6 AA (Headings and Labels).{% endtrans %}
   </p>
   <p class="govuk-body">

--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -33,7 +33,10 @@
   <h2 class="govuk-heading-m">{{ _('What to do if you can’t access part of this service') }}</h2>
 
   <p class="govuk-body">
-    {% trans %}If you need information on this service in a different format, you can contact us at <a class="govuk-link email" href="mailto:civil-legal-advice@digital.justice.gov.uk">civil-legal-advice@digital.justice.gov.uk</a>.{% endtrans %}
+    {% trans
+      email_link=Element.link_same_window('mailto:civil-legal-advice@digital.justice.gov.uk', civil-legal-advice@digital.justice.gov.uk, **{'class': 'email'}) )
+    %}
+    If you need information on this service in a different format, you can contact us at {{email_link}}.{% endtrans %}
   </p>
 
   <h2 class="govuk-heading-m">{{ _('Reporting accessibility problems') }}</h2>

--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -33,13 +33,17 @@
   <h2 class="govuk-heading-m">{{ _('What to do if you can’t access part of this service') }}</h2>
 
   <p class="govuk-body">
-    {% trans %}If you need information on this service in a different format, you can contact us at <a class="govuk-link email" href="mailto:civil-legal-advice@digital.justice.gov.uk">civil-legal-advice@digital.justice.gov.uk</a>.{% endtrans %}
+    {% trans
+      email = Element.link_same_window('mailto:civil-legal-advice@digital.justice.gov.uk', 'civil-legal-advice@digital.justice.gov.uk', **{'class': 'email'})
+    %}If you need information on this service in a different format, you can contact us at {{ email }}.{% endtrans %}
   </p>
 
   <h2 class="govuk-heading-m">{{ _('Reporting accessibility problems') }}</h2>
   
   <p class="govuk-body">
-    {% trans %}We’re always looking to improve the accessibility of this service. If you find any problems that aren’t listed on this page or think we’re not meeting the requirements of the accessibility regulations, contact <a class="govuk-link email" href="mailto:civil-legal-advice@digital.justice.gov.uk">civil-legal-advice@digital.justice.gov.uk</a> giving details of the issue and any assistive technology you are using.{% endtrans %}
+    {% trans
+      email = Element.link_same_window('mailto:civil-legal-advice@digital.justice.gov.uk', 'civil-legal-advice@digital.justice.gov.uk', **{'class': 'email'})
+    %}We’re always looking to improve the accessibility of this service. If you find any problems that aren’t listed on this page or think we’re not meeting the requirements of the accessibility regulations, contact {{email}} giving details of the issue and any assistive technology you are using.{% endtrans %}
   </p>
 
   <h2 class="govuk-heading-m">{{ _('Enforcement procedure') }}</h2>
@@ -56,7 +60,7 @@
 
   <p class="govuk-body">
     {% trans
-      wcaglink=Element.link_same_window('https://www.w3.org/TR/WCAG21/', _('Web Content Accessibility Guidelines version 2.1'), True)
+      wcaglink=Element.link_same_window('https://www.w3.org/TR/WCAG21/', _('Web Content Accessibility Guidelines version 2.1'), is_external=True)
     %}This service is partially compliant with the {{ wcaglink }} AA standard, due to the non-compliance issues listed below.{% endtrans %}
   </p>
 

--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -84,7 +84,7 @@
     {% trans %}We are experiencing intermittent problems with the time-out feature where users are unexpectedly timed-out without the time-out warning appearing. We are currently investigating the source of this issue.{% endtrans %}
   </p>
   <h4 class="govuk-heading-m">{{ _('Hide this page') }}</h4>
-  <p>
+  <p class="govuk-body">
     {% trans %}The ‘Hide this page’ button does not accurately describe the link destination. This fails WCAG 2.1 1.3.1 A (Info and relationships) and 2.4.6 AA (Headings and Labels).{% endtrans %}
   </p>
   <p class="govuk-body">

--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -149,26 +149,5 @@
     {% trans %}The <abbr title='Digital Accessibility Centre'>DAC</abbr> tested the service available at <a class='govuk-link' href='https://checklegalaid.service.gov.uk/'>https://checklegalaid.service.gov.uk/</a>.{% endtrans %}
   </p>
 
-  <h2 class="govuk-heading-m">{{ _('What we’re doing to improve accessibility') }}</h2>
-
-  <p class="govuk-body">
-    {% trans
-      month = _('December'),
-      year = "2020"
-    %}We are working to fix the issues listed in this statement by {{ month }} {{ year }}. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>.{% endtrans %}
-  </p>
-
-  <p class="govuk-body">
-    {% trans %}We will monitor the accessibility of this service on an ongoing basis and fix any accessibility issues reported to us.{% endtrans %}
-  </p>
-
-  <p class="govuk-body">
-    {% trans
-      day = "17",
-      month = _('September'),
-      year = "2020"
-    %}This statement was prepared on {{ day }} {{ month }} {{ year }}.{% endtrans %}
-  </p>
-
   {% include "checker/time-out-warning.html" %}
 {% endblock %}

--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -50,7 +50,7 @@
   <h2 class="govuk-heading-m">{{ _('Enforcement procedure') }}</h2>
 
   <p class="govuk-body">
-    {% trans %}The Equality and Human Rights Commission (EHRC) is responsible for enforcing the accessibility regulations. If you’re not happy with how we respond to your complaint, contact the <a class="govuk-link" href="https://www.equalityadvisoryservice.com/" rel="external">Equality Advisory and Support Service (<abbr>EASS</abbr>)</a>.{% endtrans %}
+    {% trans %}The Equality and Human Rights Commission (<abbr>EHRC</abbr>) is responsible for enforcing the accessibility regulations. If you’re not happy with how we respond to your complaint, contact the <a class="govuk-link" href="https://www.equalityadvisoryservice.com/" rel="external">Equality Advisory and Support Service (<abbr>EASS</abbr>)</a>.{% endtrans %}
   </p>
 
   <h2 class="govuk-heading-m">{{ _('Technical information about this service’s accessibility') }}</h2>
@@ -125,7 +125,7 @@
       day = "30",
       month = _('November'),
       year = "2020"
-    %}It was last reviewed on 30 November 2020.{% endtrans %}
+    %}It was last reviewed on {{ day }} {{ month }} {{ year }}.{% endtrans %}
   </p>
 
   <p class="govuk-body">

--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -77,14 +77,14 @@
 
   <h4 class="govuk-heading-m">{{ _('Time-out') }}</h4>
 
-  <p class="govuk-body govuk-inset-text">
+  <p class="govuk-body">
     {% trans %}Users are not able to turn off, adjust or extend the time in which inactivity will result in a loss of data. This fails WCAG 2.1 2.2.1 A (Timing Adjustable).{% endtrans %}
   </p>
   <p class="govuk-body">
     {% trans %}We are experiencing intermittent problems with the time-out feature where users are unexpectedly timed-out without the time-out warning appearing. We are currently investigating the source of this issue.{% endtrans %}
   </p>
   <h4 class="govuk-heading-m">{{ _('Hide this page') }}</h4>
-  <p class="govuk-body govuk-inset-text">
+  <p class="govuk-body">
     {% trans %}The ‘Hide this page’ button does not accurately describe the link destination. This fails WCAG 2.1 1.3.1 A (Info and relationships) and 2.4.6 AA (Headings and Labels).{% endtrans %}
   </p>
   <p class="govuk-body">

--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -27,7 +27,7 @@
   </ul>
   
   <p class="govuk-body">
-    {% trans %}<a class="govuk-link" href="https://mcmw.abilitynet.org.uk/" rel="external">AbilityNet has advice on making your device easier to use if you have a disability.</a>{% endtrans %}
+    <a class="govuk-link" href="https://mcmw.abilitynet.org.uk/" rel="external">{% trans %}AbilityNet has advice on making your device easier to use if you have a disability.{% endtrans %}</a>
   </p>
 
   <h2 class="govuk-heading-m">{{ _('What to do if you can’t access part of this service') }}</h2>
@@ -45,13 +45,13 @@
   <h2 class="govuk-heading-m">{{ _('Enforcement procedure') }}</h2>
 
   <p class="govuk-body">
-    {% trans %}The Equality and Human Rights Commission (EHRC) is responsible for enforcing the accessibility regulations. If you’re not happy with how we respond to your complaint, contact the <a class="govuk-link" href="https://www.equalityadvisoryservice.com/" rel="external">Equality Advisory and Support Service (EASS)</a>.{% endtrans %}
+    {% trans %}The Equality and Human Rights Commission (EHRC) is responsible for enforcing the accessibility regulations. If you’re not happy with how we respond to your complaint, contact the <a class="govuk-link" href="https://www.equalityadvisoryservice.com/" rel="external">Equality Advisory and Support Service (<abbr>EASS</abbr>)</a>.{% endtrans %}
   </p>
 
   <h2 class="govuk-heading-m">{{ _('Technical information about this service’s accessibility') }}</h2>
 
   <p class="govuk-body">
-    {% trans %}The Legal Aid Agency is committed to making its service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.{% endtrans %}
+    {% trans %}The Legal Aid Agency is committed to making its service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (&#8470; 2) Accessibility Regulations 2018.{% endtrans %}
   </p>
 
   <p class="govuk-body">
@@ -93,17 +93,17 @@
   <h2 class="govuk-heading-m">{{ _('How we tested this service') }}</h2>
 
   <p class="govuk-body">
-    {% trans %}This service was last tested on 22 July 2020. The test was carried out by the Digital Accessibility Centre (DAC).{% endtrans %}
+    {% trans %}This service was last tested on 22 July 2020. The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>).{% endtrans %}
   </p>
 
   <p class="govuk-body">
-    {% trans %}The DAC tested the service available at <a class="govuk-link" href="https://checklegalaid.service.gov.uk/">https://checklegalaid.service.gov.uk/</a>.{% endtrans %}
+    {% trans %}The <abbr title='Digital Accessibility Centre'>DAC</abbr> tested the service available at <a class="govuk-link" href="https://checklegalaid.service.gov.uk/">https://checklegalaid.service.gov.uk/</a>.{% endtrans %}
   </p>
 
   <h2 class="govuk-heading-m">{{ _('What we’re doing to improve accessibility') }}</h2>
 
   <p class="govuk-body">
-    {% trans %}We are working to fix the issues listed in this statement by December 2020. When the issues are fixed we will send the service for a re-test with the DAC.{% endtrans %}
+    {% trans %}We are working to fix the issues listed in this statement by December 2020. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>.{% endtrans %}
   </p>
 
   <p class="govuk-body">

--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -33,10 +33,7 @@
   <h2 class="govuk-heading-m">{{ _('What to do if you can’t access part of this service') }}</h2>
 
   <p class="govuk-body">
-    {% trans
-      email_link=Element.link_same_window('mailto:civil-legal-advice@digital.justice.gov.uk', civil-legal-advice@digital.justice.gov.uk, **{'class': 'email'}) )
-    %}
-    If you need information on this service in a different format, you can contact us at {{email_link}}.{% endtrans %}
+    {% trans %}If you need information on this service in a different format, you can contact us at <a class="govuk-link email" href="mailto:civil-legal-advice@digital.justice.gov.uk">civil-legal-advice@digital.justice.gov.uk</a>.{% endtrans %}
   </p>
 
   <h2 class="govuk-heading-m">{{ _('Reporting accessibility problems') }}</h2>

--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -75,7 +75,7 @@
 
   <h3 class="govuk-heading-m">{{ _('Non-compliance with the accessibility regulations') }}</h3>
 
-  <h4 class="govuk-heading-m">{{ _('Time-out') }}</h4>
+  <h4 class="govuk-heading-s">{{ _('Time-out') }}</h4>
 
   <p class="govuk-body">
     {% trans %}Users are not able to turn off, adjust or extend the time in which inactivity will result in a loss of data. This fails WCAG 2.1 2.2.1 A (Timing Adjustable).{% endtrans %}
@@ -83,7 +83,7 @@
   <p class="govuk-body">
     {% trans %}We are experiencing intermittent problems with the time-out feature where users are unexpectedly timed-out without the time-out warning appearing. We are currently investigating the source of this issue.{% endtrans %}
   </p>
-  <h4 class="govuk-heading-m">{{ _('Hide this page') }}</h4>
+  <h4 class="govuk-heading-s">{{ _('Hide this page') }}</h4>
   <p class="govuk-body">
     {% trans %}The ‘Hide this page’ button does not accurately describe the link destination. This fails WCAG 2.1 1.3.1 A (Info and relationships) and 2.4.6 AA (Headings and Labels).{% endtrans %}
   </p>

--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -94,8 +94,8 @@
 
   <p class="govuk-body">
     {% trans
-      date = "22" ~ " "~ _('July') ~ " " ~ "2020"
-    %}This service was last tested on {{ date }}. The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>).{% endtrans %}
+      day = "22", month = _('July'), year = "2020"
+    %}This service was last tested on {{ day }} {{ month }} {{ year }}. The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>).{% endtrans %}
   </p>
 
   <p class="govuk-body">

--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -7,6 +7,7 @@
 
   <h2 class="govuk-heading-m">{{ _('Using this service') }}</h2>
   <p class="govuk-body">
+    {% trans %}This accessibility statement applies to <a class="govuk-link" href="https://checklegalaid.service.gov.uk/">https://checklegalaid.service.gov.uk/</a>.{% endtrans %}
     {% trans %}The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for the Civil Legal Advice (<abbr>CLA</abbr>) service.{% endtrans %}
   </p>
 
@@ -30,7 +31,7 @@
     <a class="govuk-link" href="https://mcmw.abilitynet.org.uk/" rel="external">{% trans %}AbilityNet has advice on making your device easier to use if you have a disability.{% endtrans %}</a>
   </p>
 
-  <h2 class="govuk-heading-m">{{ _('What to do if you can’t access part of this service') }}</h2>
+  <h2 class="govuk-heading-m">{{ _('Feedback and contact information') }}</h2>
 
   <p class="govuk-body">
     {% trans
@@ -58,6 +59,8 @@
     {% trans %}The Legal Aid Agency is committed to making its service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (&#8470; 2) Accessibility Regulations 2018.{% endtrans %}
   </p>
 
+  <h2 class="govuk-heading-m">{{ _('Compliance status') }}</h2>
+
   <p class="govuk-body">
     {% trans
       wcaglink=Element.link_same_window('https://www.w3.org/TR/WCAG21/', _('Web Content Accessibility Guidelines version 2.1'), is_external=True)
@@ -70,19 +73,23 @@
     {% trans %}The content listed below is non-accessible for the following reasons.{% endtrans %}
   </p>
 
-  <h3 class="govuk-heading-m">{{ _('Non compliance with the accessibility regulations') }}</h3>
+  <h3 class="govuk-heading-m">{{ _('Non-compliance with the accessibility regulations') }}</h3>
 
-  <ul class="govuk-list govuk-list--bullet">
-    <li>
-      {% trans %}Users are not able to turn off, adjust or extend the time in which inactivity will result in a loss of data. This fails WCAG 2.1 2.2.1 A (Timing Adjustable).{% endtrans %}
-    </li>
-    <li>
-      {% trans %}Some page elements are not available in Welsh. This fails WCAG 2.1 3.1.1 A (Language of Page).{% endtrans %}
-    </li>
-    <li>
-      {% trans %}When a user enters figures into form fields it is not clear that the field does not accept currency symbols. This fails WCAG 2.1 2.4.6 AA (Headings and Labels).{% endtrans %}
-    </li>
-  </ul>
+  <h4 class="govuk-heading-m">{{ _('Time-out') }}</h4>
+
+  <p class="govuk-body">
+    {% trans %}Users are not able to turn off, adjust or extend the time in which inactivity will result in a loss of data. This fails WCAG 2.1 2.2.1 A (Timing Adjustable).{% endtrans %}
+  </p>
+  <p class="govuk-body">
+    {% trans %}We are experiencing intermittent problems with the time-out feature where users are unexpectedly timed-out without the time-out warning appearing. We are currently investigating the source of this issue.{% endtrans %}
+  </p>
+  <h4 class="govuk-heading-m">{{ _('Hide this page') }}</h4>
+  <p>
+    {% trans %}The ‘Hide this page’ button does not accurately describe the link destination. This fails WCAG 2.1 1.3.1 A (Info and relationships) and 2.4.6 AA (Headings and Labels).{% endtrans %}
+  </p>
+  <p class="govuk-body">
+    {% trans %}We understand that ‘Hide this page’ does not describe the link destination. We have purposely designed the feature to protect vulnerable users and provide a quick exit from the service rather than take users to a specific destination.{% endtrans %}
+  </p>
 
   <h2 class="govuk-heading-m">{{ _('Disproportionate burden') }}</h2>
 
@@ -96,14 +103,46 @@
     {% trans %}Not applicable{% endtrans %}
   </p>
 
-  <h2 class="govuk-heading-m">{{ _('How we tested this service') }}</h2>
+  <h2 class="govuk-heading-m">{{ _('What we’re doing to improve accessibility') }}</h2>
+
+  <p class="govuk-body">
+    {% trans %}We are working to fix the time-out issue listed in this statement.{% endtrans %}
+  </p>
+
+  <p class="govuk-body">
+    {% trans %}We will monitor the accessibility of this service on an ongoing basis and fix any accessibility issues reported to us.{% endtrans %}
+  </p>
+
+  <h2 class="govuk-heading-m">{{ _('Preparation of this accessibility statement') }}</h2>
 
   <p class="govuk-body">
     {% trans
-      day = "22",
-      month = _('July'),
+      day = "17",
+      month = _('September'),
       year = "2020"
-    %}This service was last tested on {{ day }} {{ month }} {{ year }}. The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>).{% endtrans %}
+    %}This statement was prepared on {{ day }} {{ month }} {{ year }}.{% endtrans %}
+    {% trans
+      day = "30",
+      month = _('November'),
+      year = "2020"
+    %}It was last reviewed on 30 November 2020.{% endtrans %}
+  </p>
+
+  <p class="govuk-body">
+    {% trans
+      day1 = "22",
+      month1 = _('July'),
+      year1 = "2020",
+      day2 = "23",
+      month2 = _('October'),
+      year2 = "2020"
+    %}This service was tested on {{ day1 }} {{ month1 }} {{ year1 }} and issues were re-tested on {{ day2 }} {{ month2 }} {{ year2 }}.{% endtrans %}
+
+    {% trans %}The tests were carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>).{% endtrans %}
+  </p>
+
+  <p class="govuk-body">
+    {% trans %}The <abbr title='Digital Accessibility Centre'>DAC</abbr> tested core journeys, key functionality and interactive features that reflect the content that the average user may encounter.{% endtrans %}
   </p>
 
   <p class="govuk-body">

--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -55,7 +55,9 @@
   </p>
 
   <p class="govuk-body">
-    {% trans %}This service is partially compliant with the <a class="govuk-link" href="https://www.w3.org/TR/WCAG21/" rel="external">Web Content Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliance issues listed below.{% endtrans %}
+    {% trans
+      wcaglink=Element.link_same_window('https://www.w3.org/TR/WCAG21/', _('Web Content Accessibility Guidelines version 2.1'), True)
+    %}This service is partially compliant with the {{ wcaglink }} AA standard, due to the non-compliance issues listed below.{% endtrans %}
   </p>
 
    <h2 class="govuk-heading-m">{{ _('Non-accessible content') }}</h2>
@@ -94,7 +96,9 @@
 
   <p class="govuk-body">
     {% trans
-      day = "22", month = _('July'), year = "2020"
+      day = "22",
+      month = _('July'),
+      year = "2020"
     %}This service was last tested on {{ day }} {{ month }} {{ year }}. The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>).{% endtrans %}
   </p>
 
@@ -106,8 +110,9 @@
 
   <p class="govuk-body">
     {% trans
-      date = _('December') ~ " " ~ "2020"
-    %}We are working to fix the issues listed in this statement by {{ date }}. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>.{% endtrans %}
+      month = _('December'),
+      year = "2020"
+    %}We are working to fix the issues listed in this statement by {{ month }} {{ year }}. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>.{% endtrans %}
   </p>
 
   <p class="govuk-body">
@@ -116,8 +121,10 @@
 
   <p class="govuk-body">
     {% trans
-      date = "17" ~ " "~ _('September') ~ " " ~ "2020"
-    %}This statement was prepared on {{ date }}.{% endtrans %}
+      day = "17",
+      month = _('September'),
+      year = "2020"
+    %}This statement was prepared on {{ day }} {{ month }} {{ year }}.{% endtrans %}
   </p>
 
   {% include "checker/time-out-warning.html" %}

--- a/cla_public/templates/accessibility-statement.html
+++ b/cla_public/templates/accessibility-statement.html
@@ -19,7 +19,7 @@
       {% trans %}change colours, contrast levels and fonts{% endtrans %}
     </li>
     <li>
-      {% trans %}zoom in up to 300% without the text spilling off the screen{% endtrans %}
+      {% trans %}zoom in up to 300&#37; without the text spilling off the screen{% endtrans %}
     </li>
     <li>
       {% trans %}navigate the service using just a keyboard{% endtrans %}
@@ -93,17 +93,21 @@
   <h2 class="govuk-heading-m">{{ _('How we tested this service') }}</h2>
 
   <p class="govuk-body">
-    {% trans %}This service was last tested on 22 July 2020. The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>).{% endtrans %}
+    {% trans
+      date = "22" ~ " "~ _('July') ~ " " ~ "2020"
+    %}This service was last tested on {{ date }}. The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>).{% endtrans %}
   </p>
 
   <p class="govuk-body">
-    {% trans %}The <abbr title='Digital Accessibility Centre'>DAC</abbr> tested the service available at <a class="govuk-link" href="https://checklegalaid.service.gov.uk/">https://checklegalaid.service.gov.uk/</a>.{% endtrans %}
+    {% trans %}The <abbr title='Digital Accessibility Centre'>DAC</abbr> tested the service available at <a class='govuk-link' href='https://checklegalaid.service.gov.uk/'>https://checklegalaid.service.gov.uk/</a>.{% endtrans %}
   </p>
 
   <h2 class="govuk-heading-m">{{ _('What we’re doing to improve accessibility') }}</h2>
 
   <p class="govuk-body">
-    {% trans %}We are working to fix the issues listed in this statement by December 2020. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>.{% endtrans %}
+    {% trans
+      date = _('December') ~ " " ~ "2020"
+    %}We are working to fix the issues listed in this statement by {{ date }}. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>.{% endtrans %}
   </p>
 
   <p class="govuk-body">
@@ -111,7 +115,9 @@
   </p>
 
   <p class="govuk-body">
-    {% trans %}This statement was prepared on 17 September 2020.{% endtrans %}
+    {% trans
+      date = "17" ~ " "~ _('September') ~ " " ~ "2020"
+    %}This statement was prepared on {{ date }}.{% endtrans %}
   </p>
 
   {% include "checker/time-out-warning.html" %}

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4434,8 +4434,8 @@ msgid "Enforcement procedure"
 msgstr "Gweithdrefn gorfodi"
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the accessibility regulations. If you’re not happy with how we respond to your complaint, contact the <a class=\"govuk-link\" href=\"https://www.equalityadvisoryservice.com/\" rel=\"external\">Equality Advisory and Support Service (<abbr>EASS</abbr>)</a>."
-msgstr "Y Comisiwn Cydraddoldeb a Hawliau Dynol sy’n gyfrifol am orfodi’r rheoliadau hygyrchedd. Os nad ydych chi’n fodlon â sut rydyn ni’n ymateb i’ch cwyn, cysylltwch â’r <a class=\"govuk-link\" href=\"http://eass-ws.custhelp.com/app/home\" rel=\"external\">Gwasanaeth Cynghori a Chefnogi Cydraddoldeb (EASS)</a>."
+msgid "The Equality and Human Rights Commission (<abbr>EHRC</abbr>) is responsible for enforcing the accessibility regulations. If you’re not happy with how we respond to your complaint, contact the <a class=\"govuk-link\" href=\"https://www.equalityadvisoryservice.com/\" rel=\"external\">Equality Advisory and Support Service (<abbr>EASS</abbr>)</a>."
+msgstr "Y Comisiwn Cydraddoldeb a Hawliau Dynol sy’n gyfrifol am orfodi’r rheoliadau hygyrchedd. Os nad ydych chi’n fodlon â sut rydyn ni’n ymateb i’ch cwyn, cysylltwch â’r <a class=\"govuk-link\" href=\"http://eass-ws.custhelp.com/app/home\" rel=\"external\">Gwasanaeth Cynghori a Chefnogi Cydraddoldeb (<abbr>EASS</abbr>)</a>."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Technical information about this service’s accessibility"
@@ -4500,6 +4500,10 @@ msgstr "Gorffennaf"
 #: cla_public/templates/accessibility-statement.html:1
 msgid "September"
 msgstr "Medi"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "November"
+msgstr "/ 11 /"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "December"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4381,6 +4381,139 @@ msgstr "Chwiliwch am gyfryngwr teulu yn eich ardal chi i ganfod a ydych yn gymwy
 msgid "Find your local mediator"
 msgstr "Dewch o hyd i’ch cyfryngwr lleol"
 
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Accessibility statement"
+msgstr "Datganiad hygyrchedd"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Using this service"
+msgstr "Defnyddio’r gwasanaeth hwn"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is responsible for the Civil Legal Advice (<abbr title=\"Civil Legal Advice\">CLA</abbr>) service."
+msgstr "Yr Asiantaeth Cymorth Cyfreithiol (<abbr title=\"Asiantaeth Cymorth Cyfreithiol\">LAA</abbr>) sy’n gyfrifol am y gwasanaeth Cyngor Cyfreithiol Sifil (<abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>)."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "We want as many people as possible to be able to use this service. For example, that means you should be able to:"
+msgstr "Rydyn ni am i gynifer o bobl â phosibl allu defnyddio’r gwasanaeth hwn. Er enghraifft, mae hynny’n golygu y dylech allu:"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "change colours, contrast levels and fonts"
+msgstr "newid lliwiau, lefelau cyferbyniad a ffontiau"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "zoom in up to 300% without the text spilling off the screen"
+msgstr "chwyddo mewn hyd at 300% heb i'r testun ollwng oddi ar y sgrin"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "navigate the service using just a keyboard"
+msgstr "symud o gwmpas gan ddefnyddio bysellfwrdd yn unig"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "AbilityNet has advice on making your device easier to use if you have a disability."
+msgstr "Mae gan AbilityNet gyngor ar wneud eich dyfais yn haws ei defnyddio os oes gennych chi anabledd."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "What to do if you can’t access part of this service"
+msgstr "Beth i’w wneud os na allwch gael mynediad at ran o’r gwasanaeth hwn"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "If you need information on this service in a different format, you can contact us at civil-legal-advice@digital.justice.gov.uk."
+msgstr "Os oes angen gwybodaeth arnoch am y gwasanaeth hwn mewn fformat gwahanol, gallwch gysylltu â ni yn civil-legal-advice@digital.justice.gov.uk."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Reporting accessibility problems"
+msgstr "Rhoi gwybod am broblemau hygyrchedd"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "We’re always looking to improve the accessibility of this service. If you find any problems that aren’t listed on this page or think we’re not meeting the requirements of the accessibility regulations, contact civil-legal-advice@digital.justice.gov.uk giving details of the issue and any assistive technology you are using."
+msgstr "Rydyn ni bob amser yn ceisio gwella hygyrchedd y gwasanaeth hwn. Os byddwch chi’n dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon neu os ydych chi’n meddwl nad ydyn ni’n bodloni gofynion y rheoliadau hygyrchedd, cysylltwch â civil-legal-advice@digital.justice.gov.uk gan roi manylion y broblem ac unrhyw dechnoleg gynorthwyol rydych chi’n ei defnyddio."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Enforcement procedure"
+msgstr "Gweithdrefn gorfodi"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the accessibility regulations. If you’re not happy with how we respond to your complaint, contact the <a class=\"govuk-link\" href=\"https://www.equalityadvisoryservice.com/\" rel=\"external\">Equality Advisory and Support Service (<abbr>EASS</abbr>)</a>."
+msgstr "Y Comisiwn Cydraddoldeb a Hawliau Dynol sy’n gyfrifol am orfodi’r rheoliadau hygyrchedd. Os nad ydych chi’n fodlon â sut rydyn ni’n ymateb i’ch cwyn, cysylltwch â’r <a class=\"govuk-link\" href=\"http://eass-ws.custhelp.com/app/home\" rel=\"external\">Gwasanaeth Cynghori a Chefnogi Cydraddoldeb (EASS)</a>."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Technical information about this service’s accessibility"
+msgstr "Gwybodaeth dechnegol am hygyrchedd y gwasanaeth hwn"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "The Legal Aid Agency is committed to making its service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (&#8470; 2) Accessibility Regulations 2018."
+msgstr "Mae’r Asiantaeth Cymorth Cyfreithiol wedi ymrwymo i wneud ei gwasanaeth yn hygyrch, yn unol â Rheoliadau Hygyrchedd Cyrff Sector Cyhoeddus (Gwefannau a Rhaglenni Symudol) (Rhif 2) 2018."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "This service is partially compliant with the <a class=\"govuk-link\" href=\"https://www.w3.org/TR/WCAG21/\" rel=\"external\">Web Content Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliance issues listed below."
+msgstr "Mae’r gwasanaeth hwn yn cydymffurfio’n rhannol â safon AA <a class=\"govuk-link\" href=\"https://www.w3.org/TR/WCAG21/\" rel=\"external\">Canllawiau Hygyrchedd Cynnwys y We fersiwn 2.1</a>, oherwydd y materion diffyg cydymffurfio a restrir isod."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Non-accessible content"
+msgstr "Cynnwys nad oes modd cael gafael arno"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "The content listed below is non-accessible for the following reasons."
+msgstr "Nid oes modd cael gafael ar y cynnwys a restrir isod am y rhesymau canlynol."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Non compliance with the accessibility regulations"
+msgstr "Ddim yn cydymffurfio â’r rheoliadau hygyrchedd"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Users are not able to turn off, adjust or extend the time in which inactivity will result in a loss of data. This fails WCAG 2.1 2.2.1 A (Timing Adjustable)."
+msgstr "Ni all defnyddwyr ddiffodd, addasu nac ymestyn yr amser pan fydd anweithgarwch yn arwain at golli data. Mae hyn yn methu WCAG 2.1 2.2.1 A (Addasu’r Amseriad)."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Some page elements are not available in Welsh. This fails WCAG 2.1 3.1.1 A (Language of Page)."
+msgstr "Nid yw rhai elfennau tudalen ar gael yn Gymraeg. Mae hyn yn methu WCAG 2.1 3.1.1 A (Iaith Tudalen)."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "When a user enters figures into form fields it is not clear that the field does not accept currency symbols. This fails WCAG 2.1 2.4.6 AA (Headings and Labels)."
+msgstr "Pan fydd defnyddiwr yn rhoi ffigurau mewn meysydd ffurflen, nid yw’n glir nad yw’r maes yn derbyn symbolau arian. Mae hyn yn methu WCAG 2.1 2.4.6 AA (Penawdau a Labeli)."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Disproportionate burden"
+msgstr "Baich anghymesur"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Not applicable"
+msgstr "Ddim yn berthnasol"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Content that’s not within the scope of the accessibility regulations"
+msgstr "Cynnwys nad yw o fewn cwmpas y rheoliadau hygyrchedd"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "How we tested this service"
+msgstr "Sut y buom yn profi’r gwasanaeth hwn"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "This service was last tested on 22 July 2020. The test was carried out by the Digital Accessibility Centre (DAC)."
+msgstr "Cafodd y gwasanaeth hwn ei brofi ddiwethaf ar 22 Gorffennaf 2020. Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC)."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "The <abbr title='Digital Accessibility Centre'>DAC</abbr> tested the service available at <a class='govuk-link' href='https://checklegalaid.service.gov.uk/'>https://checklegalaid.service.gov.uk/</a>."
+msgstr "Profodd y <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr> y gwasanaeth sydd ar gael yn <a class='govuk-link' href='https://www.gov.uk/gwirio-os-ydych-yn-gymwys-i-gael-cymorth-cyfreithiol'>https://checklegalaid.service.gov.uk/</a>."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "What we’re doing to improve accessibility"
+msgstr "Beth rydyn ni’n ei wneud i wella hygyrchedd"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "We are working to fix the issues listed in this statement by December 2020. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>."
+msgstr "Rydyn ni’n gweithio i ddatrys y materion a restrir yn y datganiad hwn erbyn mis Rhagfyr 2020. Pan fydd y materion yn cael eu datrys, byddwn yn anfon y gwasanaeth i gael ail brawf gyda’r <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr>."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "We will monitor the accessibility of this service on an ongoing basis and fix any accessibility issues reported to us."
+msgstr "Byddwn yn monitro hygyrchedd y gwasanaeth hwn yn barhaus ac yn datrys unrhyw broblemau hygyrchedd y rhoddir gwybod i ni amdanyn nhw."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "This statement was prepared on 17 September 2020."
+msgstr "Cafodd y datganiad hwn ei baratoi ar 17 Medi 2020."
+
+
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"
 

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4402,8 +4402,8 @@ msgid "change colours, contrast levels and fonts"
 msgstr "newid lliwiau, lefelau cyferbyniad a ffontiau"
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "zoom in up to 300\% without the text spilling off the screen"
-msgstr "chwyddo mewn hyd at 300\% heb i’r testun ollwng oddi ar y sgrin"
+msgid "zoom in up to 300&#37; without the text spilling off the screen"
+msgstr "chwyddo mewn hyd at 300&#37; heb i’r testun ollwng oddi ar y sgrin"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "navigate the service using just a keyboard"
@@ -4490,8 +4490,20 @@ msgid "How we tested this service"
 msgstr "Sut y buom yn profi’r gwasanaeth hwn"
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "This service was last tested on 22 July 2020. The test was carried out by the Digital Accessibility Centre (DAC)."
-msgstr "Cafodd y gwasanaeth hwn ei brofi ddiwethaf ar 22 Gorffennaf 2020. Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC)."
+msgid "July"
+msgstr "Gorffennaf"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "September"
+msgstr "Medi"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "December"
+msgstr "Rhagfyr"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "This service was last tested on %(date)s. The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>)."
+msgstr "Cafodd y gwasanaeth hwn ei brofi ddiwethaf ar %(date)s. Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC)."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The <abbr title='Digital Accessibility Centre'>DAC</abbr> tested the service available at <a class='govuk-link' href='https://checklegalaid.service.gov.uk/'>https://checklegalaid.service.gov.uk/</a>."
@@ -4502,16 +4514,16 @@ msgid "What we’re doing to improve accessibility"
 msgstr "Beth rydyn ni’n ei wneud i wella hygyrchedd"
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "We are working to fix the issues listed in this statement by December 2020. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>."
-msgstr "Rydyn ni’n gweithio i ddatrys y materion a restrir yn y datganiad hwn erbyn mis Rhagfyr 2020. Pan fydd y materion yn cael eu datrys, byddwn yn anfon y gwasanaeth i gael ail brawf gyda’r <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr>."
+msgid "We are working to fix the issues listed in this statement by %(date)s. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>."
+msgstr "Rydyn ni’n gweithio i ddatrys y materion a restrir yn y datganiad hwn erbyn mis %(date)s. Pan fydd y materion yn cael eu datrys, byddwn yn anfon y gwasanaeth i gael ail brawf gyda’r <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr>."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "We will monitor the accessibility of this service on an ongoing basis and fix any accessibility issues reported to us."
 msgstr "Byddwn yn monitro hygyrchedd y gwasanaeth hwn yn barhaus ac yn datrys unrhyw broblemau hygyrchedd y rhoddir gwybod i ni amdanyn nhw."
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "This statement was prepared on 17 September 2020."
-msgstr "Cafodd y datganiad hwn ei baratoi ar 17 Medi 2020."
+msgid "This statement was prepared on %(date)s."
+msgstr "Cafodd y datganiad hwn ei baratoi ar %(date)s."
 
 
 #~ msgid "Overall, how did you feel about the service you received today?"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4390,8 +4390,8 @@ msgid "Using this service"
 msgstr "Defnyddio’r gwasanaeth hwn"
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "The Legal Aid Agency (<abbr title=\"Legal Aid Agency\">LAA</abbr>) is responsible for the Civil Legal Advice (<abbr title=\"Civil Legal Advice\">CLA</abbr>) service."
-msgstr "Yr Asiantaeth Cymorth Cyfreithiol (<abbr title=\"Asiantaeth Cymorth Cyfreithiol\">LAA</abbr>) sy’n gyfrifol am y gwasanaeth Cyngor Cyfreithiol Sifil (<abbr title=\"Cyngor Cyfreithiol Sifil\">CLA</abbr>)."
+msgid "The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for the Civil Legal Advice (<abbr>CLA</abbr>) service."
+msgstr "Yr Asiantaeth Cymorth Cyfreithiol (<abbr>LAA</abbr>) sy’n gyfrifol am y gwasanaeth Cyngor Cyfreithiol Sifil (<abbr>CLA</abbr>)."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "We want as many people as possible to be able to use this service. For example, that means you should be able to:"
@@ -4402,8 +4402,8 @@ msgid "change colours, contrast levels and fonts"
 msgstr "newid lliwiau, lefelau cyferbyniad a ffontiau"
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "zoom in up to 300% without the text spilling off the screen"
-msgstr "chwyddo mewn hyd at 300% heb i'r testun ollwng oddi ar y sgrin"
+msgid "zoom in up to 300\% without the text spilling off the screen"
+msgstr "chwyddo mewn hyd at 300\% heb i’r testun ollwng oddi ar y sgrin"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "navigate the service using just a keyboard"
@@ -4418,8 +4418,8 @@ msgid "What to do if you can’t access part of this service"
 msgstr "Beth i’w wneud os na allwch gael mynediad at ran o’r gwasanaeth hwn"
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "If you need information on this service in a different format, you can contact us at civil-legal-advice@digital.justice.gov.uk."
-msgstr "Os oes angen gwybodaeth arnoch am y gwasanaeth hwn mewn fformat gwahanol, gallwch gysylltu â ni yn civil-legal-advice@digital.justice.gov.uk."
+msgid "If you need information on this service in a different format, you can contact us at %(email_link)s."
+msgstr "Os oes angen gwybodaeth arnoch am y gwasanaeth hwn mewn fformat gwahanol, gallwch gysylltu â ni yn %(email_link)s."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Reporting accessibility problems"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4462,7 +4462,7 @@ msgid "The content listed below is non-accessible for the following reasons."
 msgstr "Nid oes modd cael gafael ar y cynnwys a restrir isod am y rhesymau canlynol."
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "Non compliance with the accessibility regulations"
+msgid "Non-compliance with the accessibility regulations"
 msgstr "Ddim yn cydymffurfio â’r rheoliadau hygyrchedd"
 
 #: cla_public/templates/accessibility-statement.html:1
@@ -4506,8 +4506,12 @@ msgid "December"
 msgstr "Rhagfyr"
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "This service was last tested on %(day)s %(month)s %(year)s. The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>)."
-msgstr "Cafodd y gwasanaeth hwn ei brofi ddiwethaf ar %(day)s %(month)s %(year)s. Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC)."
+msgid "This service was last tested on %(day)s %(month)s %(year)s."
+msgstr "Cafodd y gwasanaeth hwn ei brofi ddiwethaf ar %(day)s %(month)s %(year)s."
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>)."
+msgstr "Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC)."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The <abbr title='Digital Accessibility Centre'>DAC</abbr> tested the service available at <a class='govuk-link' href='https://checklegalaid.service.gov.uk/'>https://checklegalaid.service.gov.uk/</a>."

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4418,8 +4418,8 @@ msgid "What to do if you can’t access part of this service"
 msgstr "Beth i’w wneud os na allwch gael mynediad at ran o’r gwasanaeth hwn"
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "If you need information on this service in a different format, you can contact us at %(email_link)s."
-msgstr "Os oes angen gwybodaeth arnoch am y gwasanaeth hwn mewn fformat gwahanol, gallwch gysylltu â ni yn %(email_link)s."
+msgid "If you need information on this service in a different format, you can contact us at civil-legal-advice@digital.justice.gov.uk."
+msgstr "Os oes angen gwybodaeth arnoch am y gwasanaeth hwn mewn fformat gwahanol, gallwch gysylltu â ni yn civil-legal-advice@digital.justice.gov.uk."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Reporting accessibility problems"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -54,7 +54,7 @@ msgstr "Ydych chi mewn perygl uniongyrchol o niwed?"
 msgid "Have you already started family mediation? (This includes cases that have already finished)"
 msgstr "Ydych chi wedi dechrau cyfryngu teuluol eisoes? (Mae hyn yn cynnwys achosion sydd wedi dod i ben eisoes)"
 msgid "Have you taken part in a family mediation session?"
-msgstr "Ydych chi wedi cymryd rhan mewn sesiwn gyfryngu i’r teulu?"
+msgstr "Ydych chi wedi cymryd rhan mewn sesiwn cyfryngu i deuluoedd?"
 msgid "What kind of dispute is it?"
 msgstr "Pa fath o anghydfod ydyw?"
 msgid "Is the child a victim of child abuse within the family?"
@@ -220,6 +220,18 @@ msgstr "Gallwch ddewis mwy nag un opsiwn"
 #: cla_public/apps/base/forms.py:91
 msgid "Please specify"
 msgstr "Manylwch"
+
+#: cla_public/apps/base/forms.py:171
+msgid "Tell us whether your partner is self-employed"
+msgstr "Dywedwch wrthym a yw eich partner yn hunangyflogedig"
+
+#: cla_public/apps/base/forms.py:171
+msgid "Tell us whether your partner is employed"
+msgstr "Dywedwch wrthym a yw eich partner yn gyflogedig"
+
+#: cla_public/apps/base/forms.py:386
+msgid "See below for examples of what valuable items to include"
+msgstr "Gweler isod am enghreifftiau o’r eitemau gwerthfawr i’w cynnwys"
 
 #: cla_public/apps/base/views.py:99
 msgid "Something went wrong. Please try again."
@@ -818,7 +830,7 @@ msgstr "Rhaid i’r rhif fod rhwng 1 a 50"
 #: cla_public/apps/checker/forms.py:96 cla_public/apps/checker/forms.py:97
 #: cla_public/apps/checker/forms.py:113 cla_public/apps/checker/forms.py:114
 msgid "Enter a number between 1 and 50"
-msgstr "Rhowch rif fod rhwng 1 a 50"
+msgstr "Rhowch rif rhwng 1 a 50"
 
 #: cla_public/apps/checker/forms.py:101
 msgid "Do you have any dependants aged 16 or over?"
@@ -1830,7 +1842,7 @@ msgstr "Bydd yr amser a neilltuwyd ar gyfer eich cais yn dod i ben cyn bo hir"
 #: Welsh still says "continue" (the old text), waiting for new translation to update this
 #: cla_public/templates/_modal-dialog.html:12
 msgid "Extend time limit"
-msgstr "Ymlaen"
+msgstr "Ymestyn y terfyn amser"
 
 #: cla_public/templates/checker/about.html:42
 #: cla_public/templates/checker/additional-benefits.html:26
@@ -1949,7 +1961,7 @@ msgstr "Dangos {count} mwy"
 
 #: cla_public/templates/base.html:148
 msgid "Show {count} more sources of help"
-msgstr "Dangos {count} mwy"
+msgstr "Dangos {count} ffynhonnell cymorth arall"
 
 #: cla_public/templates/base.html:155 cla_public/templates/online-safety.html:3
 #: cla_public/templates/online-safety.html:6
@@ -3398,23 +3410,23 @@ msgstr "Dechrau eto"
 
 #: cla_public/templates/checker/_progress.html:14
 msgid "Current page"
-msgstr ""
+msgstr "Tudalen gyfredol"
 
 #: cla_public/templates/checker/_progress.html:16
 msgid "Completed page"
-msgstr "Wedi’i gwblhau"
+msgstr "Tudalen wedi’i chwblhau"
 
 #: cla_public/templates/checker/_progress.html:18
 msgid "Future page"
-msgstr ""
+msgstr "Tudalen i’r dyfodol"
 
 #: cla_public/templates/checker/_progress.html:29
 msgid "Final page"
-msgstr ""
+msgstr "Tudalen olaf"
 
 #: cla_public/templates/checker/_progress.html:31
 msgid "Approximately %(approximate_percentage)s&#37; completed"
-msgstr "Tua %(approximate_percentage)s&#37; wedi’i gwblhau"
+msgstr "Cwblhawyd tua %(approximate_percentage)s&#37;"
 
 #: cla_public/templates/checker/_progress.html:61
 msgid "Several future pages"
@@ -3538,22 +3550,22 @@ msgstr "Bydd eich sesiwn yn dod i ben os yw wedi bod yn anweithredol am hanner a
 #: PLACEHOLDER PENDING TRANSLATION RETURN
 #: cla_public/templates/checker/result/_find-legal-adviser.html:137
 msgid "No results returned for the Isle of Man, try a postcode in England or Wales"
-msgstr "Dim canlyniadau, rhowch gynnig arall arni"
+msgstr "Dim canlyniadau wedi’u dychwelyd ar gyfer Ynys Manaw. Rhowch gynnig ar gôd post yng Nghymru neu Loegr."
 
 #: PLACEHOLDER PENDING TRANSLATION RETURN
 #: cla_public/templates/checker/result/_find-legal-adviser.html:138
 msgid "No results returned for Jersey, try a postcode in England or Wales"
-msgstr "Dim canlyniadau, rhowch gynnig arall arni"
+msgstr "Dim canlyniadau wedi’u dychwelyd ar gyfer Jersey. Rhowch gynnig ar gôd post yng Nghymru neu Loegr."
 
 #: PLACEHOLDER PENDING TRANSLATION RETURN
 #: cla_public/templates/checker/result/_find-legal-adviser.html:139
 msgid "No results returned for Guernsey, try a postcode in England or Wales"
-msgstr "Dim canlyniadau, rhowch gynnig arall arni"
+msgstr "Dim canlyniadau wedi’u dychwelyd ar gyfer Ynys y Garn. Rhowch gynnig ar gôd post yng Nghymru neu Loegr."
 
 #: PLACEHOLDER PENDING TRANSLATION RETURN
 #: cla_public/templates/checker/result/_find-legal-adviser.html:139
 msgid "Postcode not found"
-msgstr "Côd post heb ei ddarganfod"
+msgstr "Heb ddod o hyd i gôd post"
 
 #: PLACEHOLDER PENDING TRANSLATION RETURN
 #: cla_public/templates/checker/result/_find-legal-adviser.html:139
@@ -3639,7 +3651,7 @@ msgstr "Dim canlyniadau"
 
 #: cla_public/templates/checker/result/_find-legal-adviser.html:157
 msgid "We couldn’t find any results for your search. We are constantly updating our records so please try again later."
-msgstr "Nid oeddem yn gallu dod o hyd i unrhyw ganlyniadau ar gyfer eich chwiliad. Rydym yn diweddaru ein cofnodion yn barhaus, felly rhowch gynnig arall arni nes ymlaen."
+msgstr "Doedd dim modd i ni ddod o hyd i unrhyw ganlyniadau ar gyfer eich chwiliad. Rydyn ni’n diweddaru ein cofnodion yn gyson, felly rhowch gynnig arall arni yn nes ymlaen."
 
 #: cla_public/templates/checker/result/_find-legal-adviser.html:165
 msgid "Loading…"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4381,159 +4381,159 @@ msgstr "Chwiliwch am gyfryngwr teulu yn eich ardal chi i ganfod a ydych yn gymwy
 msgid "Find your local mediator"
 msgstr "Dewch o hyd i’ch cyfryngwr lleol"
 
+#: TESTING
+
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Accessibility statement"
-msgstr "Datganiad hygyrchedd"
+msgstr "<span style='color:red'>Datganiad hygyrchedd</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Using this service"
-msgstr "Defnyddio’r gwasanaeth hwn"
+msgstr "<span style='color:red'>Defnyddio’r gwasanaeth hwn</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for the Civil Legal Advice (<abbr>CLA</abbr>) service."
-msgstr "Yr Asiantaeth Cymorth Cyfreithiol (<abbr>LAA</abbr>) sy’n gyfrifol am y gwasanaeth Cyngor Cyfreithiol Sifil (<abbr>CLA</abbr>)."
+msgstr "<span style='color:red'>Yr Asiantaeth Cymorth Cyfreithiol (<abbr>LAA</abbr>) sy’n gyfrifol am y gwasanaeth Cyngor Cyfreithiol Sifil (<abbr>CLA</abbr>).</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "We want as many people as possible to be able to use this service. For example, that means you should be able to:"
-msgstr "Rydyn ni am i gynifer o bobl â phosibl allu defnyddio’r gwasanaeth hwn. Er enghraifft, mae hynny’n golygu y dylech allu:"
+msgstr "<span style='color:red'>Rydyn ni am i gynifer o bobl â phosibl allu defnyddio’r gwasanaeth hwn. Er enghraifft, mae hynny’n golygu y dylech allu:</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "change colours, contrast levels and fonts"
-msgstr "newid lliwiau, lefelau cyferbyniad a ffontiau"
+msgstr "<span style='color:red'>newid lliwiau, lefelau cyferbyniad a ffontiau</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "zoom in up to 300&#37; without the text spilling off the screen"
-msgstr "chwyddo mewn hyd at 300&#37; heb i’r testun ollwng oddi ar y sgrin"
+msgstr "<span style='color:red'>chwyddo mewn hyd at 300&#37; heb i’r testun ollwng oddi ar y sgrin</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "navigate the service using just a keyboard"
-msgstr "symud o gwmpas gan ddefnyddio bysellfwrdd yn unig"
+msgstr "<span style='color:red'>symud o gwmpas gan ddefnyddio bysellfwrdd yn unig</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "AbilityNet has advice on making your device easier to use if you have a disability."
-msgstr "Mae gan AbilityNet gyngor ar wneud eich dyfais yn haws ei defnyddio os oes gennych chi anabledd."
+msgstr "<span style='color:red'>Mae gan AbilityNet gyngor ar wneud eich dyfais yn haws ei defnyddio os oes gennych chi anabledd.</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "What to do if you can’t access part of this service"
-msgstr "Beth i’w wneud os na allwch gael mynediad at ran o’r gwasanaeth hwn"
+msgstr "<span style='color:red'>Beth i’w wneud os na allwch gael mynediad at ran o’r gwasanaeth hwn</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "If you need information on this service in a different format, you can contact us at %(email)s."
-msgstr "Os oes angen gwybodaeth arnoch am y gwasanaeth hwn mewn fformat gwahanol, gallwch gysylltu â ni yn %(email)s."
+msgstr "<span style='color:red'>Os oes angen gwybodaeth arnoch am y gwasanaeth hwn mewn fformat gwahanol, gallwch gysylltu â ni yn %(email)s.</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Reporting accessibility problems"
-msgstr "Rhoi gwybod am broblemau hygyrchedd"
+msgstr "<span style='color:red'>Rhoi gwybod am broblemau hygyrchedd</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "We’re always looking to improve the accessibility of this service. If you find any problems that aren’t listed on this page or think we’re not meeting the requirements of the accessibility regulations, contact %(email)s giving details of the issue and any assistive technology you are using."
-msgstr "Rydyn ni bob amser yn ceisio gwella hygyrchedd y gwasanaeth hwn. Os byddwch chi’n dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon neu os ydych chi’n meddwl nad ydyn ni’n bodloni gofynion y rheoliadau hygyrchedd, cysylltwch â %(email)s gan roi manylion y broblem ac unrhyw dechnoleg gynorthwyol rydych chi’n ei defnyddio."
+msgstr "<span style='color:red'>Rydyn ni bob amser yn ceisio gwella hygyrchedd y gwasanaeth hwn. Os byddwch chi’n dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon neu os ydych chi’n meddwl nad ydyn ni’n bodloni gofynion y rheoliadau hygyrchedd, cysylltwch â %(email)s gan roi manylion y broblem ac unrhyw dechnoleg gynorthwyol rydych chi’n ei defnyddio.</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Enforcement procedure"
-msgstr "Gweithdrefn gorfodi"
+msgstr "<span style='color:red'>Gweithdrefn gorfodi</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the accessibility regulations. If you’re not happy with how we respond to your complaint, contact the <a class=\"govuk-link\" href=\"https://www.equalityadvisoryservice.com/\" rel=\"external\">Equality Advisory and Support Service (<abbr>EASS</abbr>)</a>."
-msgstr "Y Comisiwn Cydraddoldeb a Hawliau Dynol sy’n gyfrifol am orfodi’r rheoliadau hygyrchedd. Os nad ydych chi’n fodlon â sut rydyn ni’n ymateb i’ch cwyn, cysylltwch â’r <a class=\"govuk-link\" href=\"http://eass-ws.custhelp.com/app/home\" rel=\"external\">Gwasanaeth Cynghori a Chefnogi Cydraddoldeb (EASS)</a>."
+msgstr "<span style='color:red'>Y Comisiwn Cydraddoldeb a Hawliau Dynol sy’n gyfrifol am orfodi’r rheoliadau hygyrchedd. Os nad ydych chi’n fodlon â sut rydyn ni’n ymateb i’ch cwyn, cysylltwch â’r <a class=\"govuk-link\" href=\"http://eass-ws.custhelp.com/app/home\" rel=\"external\">Gwasanaeth Cynghori a Chefnogi Cydraddoldeb (EASS)</a>.</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Technical information about this service’s accessibility"
-msgstr "Gwybodaeth dechnegol am hygyrchedd y gwasanaeth hwn"
+msgstr "<span style='color:red'>Gwybodaeth dechnegol am hygyrchedd y gwasanaeth hwn</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The Legal Aid Agency is committed to making its service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (&#8470; 2) Accessibility Regulations 2018."
-msgstr "Mae’r Asiantaeth Cymorth Cyfreithiol wedi ymrwymo i wneud ei gwasanaeth yn hygyrch, yn unol â Rheoliadau Hygyrchedd Cyrff Sector Cyhoeddus (Gwefannau a Rhaglenni Symudol) (Rhif 2) 2018."
+msgstr "<span style='color:red'>Mae’r Asiantaeth Cymorth Cyfreithiol wedi ymrwymo i wneud ei gwasanaeth yn hygyrch, yn unol â Rheoliadau Hygyrchedd Cyrff Sector Cyhoeddus (Gwefannau a Rhaglenni Symudol) (Rhif 2) 2018.</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Web Content Accessibility Guidelines version 2.1"
-msgstr "Canllawiau Hygyrchedd Cynnwys y We fersiwn 2.1"
+msgstr "<span style='color:red'>Canllawiau Hygyrchedd Cynnwys y We fersiwn 2.1</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "This service is partially compliant with the %(wcaglink)s AA standard, due to the non-compliance issues listed below."
-msgstr "Mae’r gwasanaeth hwn yn cydymffurfio’n rhannol â safon AA %(wcaglink)s, oherwydd y materion diffyg cydymffurfio a restrir isod."
+msgstr "<span style='color:red'>Mae’r gwasanaeth hwn yn cydymffurfio’n rhannol â safon AA %(wcaglink)s, oherwydd y materion diffyg cydymffurfio a restrir isod.</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Non-accessible content"
-msgstr "Cynnwys nad oes modd cael gafael arno"
+msgstr "<span style='color:red'>Cynnwys nad oes modd cael gafael arno</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The content listed below is non-accessible for the following reasons."
-msgstr "Nid oes modd cael gafael ar y cynnwys a restrir isod am y rhesymau canlynol."
+msgstr "<span style='color:red'>Nid oes modd cael gafael ar y cynnwys a restrir isod am y rhesymau canlynol.</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Non-compliance with the accessibility regulations"
-msgstr "Ddim yn cydymffurfio â’r rheoliadau hygyrchedd"
+msgstr "<span style='color:red'>Ddim yn cydymffurfio â’r rheoliadau hygyrchedd</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Users are not able to turn off, adjust or extend the time in which inactivity will result in a loss of data. This fails WCAG 2.1 2.2.1 A (Timing Adjustable)."
-msgstr "Ni all defnyddwyr ddiffodd, addasu nac ymestyn yr amser pan fydd anweithgarwch yn arwain at golli data. Mae hyn yn methu WCAG 2.1 2.2.1 A (Addasu’r Amseriad)."
+msgstr "<span style='color:red'>Ni all defnyddwyr ddiffodd, addasu nac ymestyn yr amser pan fydd anweithgarwch yn arwain at golli data. Mae hyn yn methu WCAG 2.1 2.2.1 A (Addasu’r Amseriad).</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Some page elements are not available in Welsh. This fails WCAG 2.1 3.1.1 A (Language of Page)."
-msgstr "Nid yw rhai elfennau tudalen ar gael yn Gymraeg. Mae hyn yn methu WCAG 2.1 3.1.1 A (Iaith Tudalen)."
+msgstr "<span style='color:red'>Nid yw rhai elfennau tudalen ar gael yn Gymraeg. Mae hyn yn methu WCAG 2.1 3.1.1 A (Iaith Tudalen).</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "When a user enters figures into form fields it is not clear that the field does not accept currency symbols. This fails WCAG 2.1 2.4.6 AA (Headings and Labels)."
-msgstr "Pan fydd defnyddiwr yn rhoi ffigurau mewn meysydd ffurflen, nid yw’n glir nad yw’r maes yn derbyn symbolau arian. Mae hyn yn methu WCAG 2.1 2.4.6 AA (Penawdau a Labeli)."
+msgstr "<span style='color:red'>Pan fydd defnyddiwr yn rhoi ffigurau mewn meysydd ffurflen, nid yw’n glir nad yw’r maes yn derbyn symbolau arian. Mae hyn yn methu WCAG 2.1 2.4.6 AA (Penawdau a Labeli).</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Disproportionate burden"
-msgstr "Baich anghymesur"
+msgstr "<span style='color:red'>Baich anghymesur</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Not applicable"
-msgstr "Ddim yn berthnasol"
+msgstr "<span style='color:red'>Ddim yn berthnasol</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Content that’s not within the scope of the accessibility regulations"
-msgstr "Cynnwys nad yw o fewn cwmpas y rheoliadau hygyrchedd"
+msgstr "<span style='color:red'>Cynnwys nad yw o fewn cwmpas y rheoliadau hygyrchedd</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "How we tested this service"
-msgstr "Sut y buom yn profi’r gwasanaeth hwn"
+msgstr "<span style='color:red'>Sut y buom yn profi’r gwasanaeth hwn</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "July"
-msgstr "Gorffennaf"
+msgstr "<span style='color:red'>Gorffennaf</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "September"
-msgstr "Medi"
+msgstr "<span style='color:red'>Medi</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "December"
-msgstr "Rhagfyr"
+msgstr "<span style='color:red'>Rhagfyr</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "This service was last tested on %(day)s %(month)s %(year)s."
-msgstr "Cafodd y gwasanaeth hwn ei brofi ddiwethaf ar %(day)s %(month)s %(year)s."
+msgstr "<span style='color:red'>Cafodd y gwasanaeth hwn ei brofi ddiwethaf ar %(day)s %(month)s %(year)s.</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>)."
-msgstr "Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC)."
+msgstr "<span style='color:red'>Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC).</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The <abbr title='Digital Accessibility Centre'>DAC</abbr> tested the service available at <a class='govuk-link' href='https://checklegalaid.service.gov.uk/'>https://checklegalaid.service.gov.uk/</a>."
-msgstr "Profodd y <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr> y gwasanaeth sydd ar gael yn <a class='govuk-link' href='https://www.gov.uk/gwirio-os-ydych-yn-gymwys-i-gael-cymorth-cyfreithiol'>https://checklegalaid.service.gov.uk/</a>."
+msgstr "<span style='color:red'>Profodd y <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr> y gwasanaeth sydd ar gael yn <a class='govuk-link' href='https://www.gov.uk/gwirio-os-ydych-yn-gymwys-i-gael-cymorth-cyfreithiol'>https://checklegalaid.service.gov.uk/</a>.</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "What we’re doing to improve accessibility"
-msgstr "Beth rydyn ni’n ei wneud i wella hygyrchedd"
+msgstr "<span style='color:red'>Beth rydyn ni’n ei wneud i wella hygyrchedd</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "We are working to fix the issues listed in this statement by %(month)s %(year)s. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>."
-msgstr "Rydyn ni’n gweithio i ddatrys y materion a restrir yn y datganiad hwn erbyn mis %(month)s %(year)s. Pan fydd y materion yn cael eu datrys, byddwn yn anfon y gwasanaeth i gael ail brawf gyda’r <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr>."
+msgstr "<span style='color:red'>Rydyn ni’n gweithio i ddatrys y materion a restrir yn y datganiad hwn erbyn mis %(month)s %(year)s. Pan fydd y materion yn cael eu datrys, byddwn yn anfon y gwasanaeth i gael ail brawf gyda’r <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr>.</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "We will monitor the accessibility of this service on an ongoing basis and fix any accessibility issues reported to us."
-msgstr "Byddwn yn monitro hygyrchedd y gwasanaeth hwn yn barhaus ac yn datrys unrhyw broblemau hygyrchedd y rhoddir gwybod i ni amdanyn nhw."
+msgstr "<span style='color:red'>Byddwn yn monitro hygyrchedd y gwasanaeth hwn yn barhaus ac yn datrys unrhyw broblemau hygyrchedd y rhoddir gwybod i ni amdanyn nhw.</span>"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "This statement was prepared on %(day)s %(month)s %(year)s."
-msgstr "Cafodd y datganiad hwn ei baratoi ar %(day)s %(month)s %(year)s."
-
-
+msgstr "<span style='color:red'>Cafodd y datganiad hwn ei baratoi ar %(day)s %(month)s %(year)s."
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"
 

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4381,159 +4381,159 @@ msgstr "Chwiliwch am gyfryngwr teulu yn eich ardal chi i ganfod a ydych yn gymwy
 msgid "Find your local mediator"
 msgstr "Dewch o hyd i’ch cyfryngwr lleol"
 
-#: TESTING
-
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Accessibility statement"
-msgstr "<span style='color:red'>Datganiad hygyrchedd</span>"
+msgstr "Datganiad hygyrchedd"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Using this service"
-msgstr "<span style='color:red'>Defnyddio’r gwasanaeth hwn</span>"
+msgstr "Defnyddio’r gwasanaeth hwn"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for the Civil Legal Advice (<abbr>CLA</abbr>) service."
-msgstr "<span style='color:red'>Yr Asiantaeth Cymorth Cyfreithiol (<abbr>LAA</abbr>) sy’n gyfrifol am y gwasanaeth Cyngor Cyfreithiol Sifil (<abbr>CLA</abbr>).</span>"
+msgstr "Yr Asiantaeth Cymorth Cyfreithiol (<abbr>LAA</abbr>) sy’n gyfrifol am y gwasanaeth Cyngor Cyfreithiol Sifil (<abbr>CLA</abbr>)."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "We want as many people as possible to be able to use this service. For example, that means you should be able to:"
-msgstr "<span style='color:red'>Rydyn ni am i gynifer o bobl â phosibl allu defnyddio’r gwasanaeth hwn. Er enghraifft, mae hynny’n golygu y dylech allu:</span>"
+msgstr "Rydyn ni am i gynifer o bobl â phosibl allu defnyddio’r gwasanaeth hwn. Er enghraifft, mae hynny’n golygu y dylech allu:"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "change colours, contrast levels and fonts"
-msgstr "<span style='color:red'>newid lliwiau, lefelau cyferbyniad a ffontiau</span>"
+msgstr "newid lliwiau, lefelau cyferbyniad a ffontiau"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "zoom in up to 300&#37; without the text spilling off the screen"
-msgstr "<span style='color:red'>chwyddo mewn hyd at 300&#37; heb i’r testun ollwng oddi ar y sgrin</span>"
+msgstr "chwyddo mewn hyd at 300&#37; heb i’r testun ollwng oddi ar y sgrin"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "navigate the service using just a keyboard"
-msgstr "<span style='color:red'>symud o gwmpas gan ddefnyddio bysellfwrdd yn unig</span>"
+msgstr "symud o gwmpas gan ddefnyddio bysellfwrdd yn unig"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "AbilityNet has advice on making your device easier to use if you have a disability."
-msgstr "<span style='color:red'>Mae gan AbilityNet gyngor ar wneud eich dyfais yn haws ei defnyddio os oes gennych chi anabledd.</span>"
+msgstr "Mae gan AbilityNet gyngor ar wneud eich dyfais yn haws ei defnyddio os oes gennych chi anabledd."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "What to do if you can’t access part of this service"
-msgstr "<span style='color:red'>Beth i’w wneud os na allwch gael mynediad at ran o’r gwasanaeth hwn</span>"
+msgstr "Beth i’w wneud os na allwch gael mynediad at ran o’r gwasanaeth hwn"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "If you need information on this service in a different format, you can contact us at %(email)s."
-msgstr "<span style='color:red'>Os oes angen gwybodaeth arnoch am y gwasanaeth hwn mewn fformat gwahanol, gallwch gysylltu â ni yn %(email)s.</span>"
+msgstr "Os oes angen gwybodaeth arnoch am y gwasanaeth hwn mewn fformat gwahanol, gallwch gysylltu â ni yn %(email)s."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Reporting accessibility problems"
-msgstr "<span style='color:red'>Rhoi gwybod am broblemau hygyrchedd</span>"
+msgstr "Rhoi gwybod am broblemau hygyrchedd"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "We’re always looking to improve the accessibility of this service. If you find any problems that aren’t listed on this page or think we’re not meeting the requirements of the accessibility regulations, contact %(email)s giving details of the issue and any assistive technology you are using."
-msgstr "<span style='color:red'>Rydyn ni bob amser yn ceisio gwella hygyrchedd y gwasanaeth hwn. Os byddwch chi’n dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon neu os ydych chi’n meddwl nad ydyn ni’n bodloni gofynion y rheoliadau hygyrchedd, cysylltwch â %(email)s gan roi manylion y broblem ac unrhyw dechnoleg gynorthwyol rydych chi’n ei defnyddio.</span>"
+msgstr "Rydyn ni bob amser yn ceisio gwella hygyrchedd y gwasanaeth hwn. Os byddwch chi’n dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon neu os ydych chi’n meddwl nad ydyn ni’n bodloni gofynion y rheoliadau hygyrchedd, cysylltwch â %(email)s gan roi manylion y broblem ac unrhyw dechnoleg gynorthwyol rydych chi’n ei defnyddio."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Enforcement procedure"
-msgstr "<span style='color:red'>Gweithdrefn gorfodi</span>"
+msgstr "Gweithdrefn gorfodi"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the accessibility regulations. If you’re not happy with how we respond to your complaint, contact the <a class=\"govuk-link\" href=\"https://www.equalityadvisoryservice.com/\" rel=\"external\">Equality Advisory and Support Service (<abbr>EASS</abbr>)</a>."
-msgstr "<span style='color:red'>Y Comisiwn Cydraddoldeb a Hawliau Dynol sy’n gyfrifol am orfodi’r rheoliadau hygyrchedd. Os nad ydych chi’n fodlon â sut rydyn ni’n ymateb i’ch cwyn, cysylltwch â’r <a class=\"govuk-link\" href=\"http://eass-ws.custhelp.com/app/home\" rel=\"external\">Gwasanaeth Cynghori a Chefnogi Cydraddoldeb (EASS)</a>.</span>"
+msgstr "Y Comisiwn Cydraddoldeb a Hawliau Dynol sy’n gyfrifol am orfodi’r rheoliadau hygyrchedd. Os nad ydych chi’n fodlon â sut rydyn ni’n ymateb i’ch cwyn, cysylltwch â’r <a class=\"govuk-link\" href=\"http://eass-ws.custhelp.com/app/home\" rel=\"external\">Gwasanaeth Cynghori a Chefnogi Cydraddoldeb (EASS)</a>."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Technical information about this service’s accessibility"
-msgstr "<span style='color:red'>Gwybodaeth dechnegol am hygyrchedd y gwasanaeth hwn</span>"
+msgstr "Gwybodaeth dechnegol am hygyrchedd y gwasanaeth hwn"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The Legal Aid Agency is committed to making its service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (&#8470; 2) Accessibility Regulations 2018."
-msgstr "<span style='color:red'>Mae’r Asiantaeth Cymorth Cyfreithiol wedi ymrwymo i wneud ei gwasanaeth yn hygyrch, yn unol â Rheoliadau Hygyrchedd Cyrff Sector Cyhoeddus (Gwefannau a Rhaglenni Symudol) (Rhif 2) 2018.</span>"
+msgstr "Mae’r Asiantaeth Cymorth Cyfreithiol wedi ymrwymo i wneud ei gwasanaeth yn hygyrch, yn unol â Rheoliadau Hygyrchedd Cyrff Sector Cyhoeddus (Gwefannau a Rhaglenni Symudol) (Rhif 2) 2018."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Web Content Accessibility Guidelines version 2.1"
-msgstr "<span style='color:red'>Canllawiau Hygyrchedd Cynnwys y We fersiwn 2.1</span>"
+msgstr "Canllawiau Hygyrchedd Cynnwys y We fersiwn 2.1"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "This service is partially compliant with the %(wcaglink)s AA standard, due to the non-compliance issues listed below."
-msgstr "<span style='color:red'>Mae’r gwasanaeth hwn yn cydymffurfio’n rhannol â safon AA %(wcaglink)s, oherwydd y materion diffyg cydymffurfio a restrir isod.</span>"
+msgstr "Mae’r gwasanaeth hwn yn cydymffurfio’n rhannol â safon AA %(wcaglink)s, oherwydd y materion diffyg cydymffurfio a restrir isod."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Non-accessible content"
-msgstr "<span style='color:red'>Cynnwys nad oes modd cael gafael arno</span>"
+msgstr "Cynnwys nad oes modd cael gafael arno"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The content listed below is non-accessible for the following reasons."
-msgstr "<span style='color:red'>Nid oes modd cael gafael ar y cynnwys a restrir isod am y rhesymau canlynol.</span>"
+msgstr "Nid oes modd cael gafael ar y cynnwys a restrir isod am y rhesymau canlynol."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Non-compliance with the accessibility regulations"
-msgstr "<span style='color:red'>Ddim yn cydymffurfio â’r rheoliadau hygyrchedd</span>"
+msgstr "Ddim yn cydymffurfio â’r rheoliadau hygyrchedd"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Users are not able to turn off, adjust or extend the time in which inactivity will result in a loss of data. This fails WCAG 2.1 2.2.1 A (Timing Adjustable)."
-msgstr "<span style='color:red'>Ni all defnyddwyr ddiffodd, addasu nac ymestyn yr amser pan fydd anweithgarwch yn arwain at golli data. Mae hyn yn methu WCAG 2.1 2.2.1 A (Addasu’r Amseriad).</span>"
+msgstr "Ni all defnyddwyr ddiffodd, addasu nac ymestyn yr amser pan fydd anweithgarwch yn arwain at golli data. Mae hyn yn methu WCAG 2.1 2.2.1 A (Addasu’r Amseriad)."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Some page elements are not available in Welsh. This fails WCAG 2.1 3.1.1 A (Language of Page)."
-msgstr "<span style='color:red'>Nid yw rhai elfennau tudalen ar gael yn Gymraeg. Mae hyn yn methu WCAG 2.1 3.1.1 A (Iaith Tudalen).</span>"
+msgstr "Nid yw rhai elfennau tudalen ar gael yn Gymraeg. Mae hyn yn methu WCAG 2.1 3.1.1 A (Iaith Tudalen)."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "When a user enters figures into form fields it is not clear that the field does not accept currency symbols. This fails WCAG 2.1 2.4.6 AA (Headings and Labels)."
-msgstr "<span style='color:red'>Pan fydd defnyddiwr yn rhoi ffigurau mewn meysydd ffurflen, nid yw’n glir nad yw’r maes yn derbyn symbolau arian. Mae hyn yn methu WCAG 2.1 2.4.6 AA (Penawdau a Labeli).</span>"
+msgstr "Pan fydd defnyddiwr yn rhoi ffigurau mewn meysydd ffurflen, nid yw’n glir nad yw’r maes yn derbyn symbolau arian. Mae hyn yn methu WCAG 2.1 2.4.6 AA (Penawdau a Labeli)."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Disproportionate burden"
-msgstr "<span style='color:red'>Baich anghymesur</span>"
+msgstr "Baich anghymesur"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Not applicable"
-msgstr "<span style='color:red'>Ddim yn berthnasol</span>"
+msgstr "Ddim yn berthnasol"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Content that’s not within the scope of the accessibility regulations"
-msgstr "<span style='color:red'>Cynnwys nad yw o fewn cwmpas y rheoliadau hygyrchedd</span>"
+msgstr "Cynnwys nad yw o fewn cwmpas y rheoliadau hygyrchedd"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "How we tested this service"
-msgstr "<span style='color:red'>Sut y buom yn profi’r gwasanaeth hwn</span>"
+msgstr "Sut y buom yn profi’r gwasanaeth hwn"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "July"
-msgstr "<span style='color:red'>Gorffennaf</span>"
+msgstr "Gorffennaf"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "September"
-msgstr "<span style='color:red'>Medi</span>"
+msgstr "Medi"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "December"
-msgstr "<span style='color:red'>Rhagfyr</span>"
+msgstr "Rhagfyr"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "This service was last tested on %(day)s %(month)s %(year)s."
-msgstr "<span style='color:red'>Cafodd y gwasanaeth hwn ei brofi ddiwethaf ar %(day)s %(month)s %(year)s.</span>"
+msgstr "Cafodd y gwasanaeth hwn ei brofi ddiwethaf ar %(day)s %(month)s %(year)s."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>)."
-msgstr "<span style='color:red'>Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC).</span>"
+msgstr "Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (<abbr>DAC</abbr>)."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The <abbr title='Digital Accessibility Centre'>DAC</abbr> tested the service available at <a class='govuk-link' href='https://checklegalaid.service.gov.uk/'>https://checklegalaid.service.gov.uk/</a>."
-msgstr "<span style='color:red'>Profodd y <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr> y gwasanaeth sydd ar gael yn <a class='govuk-link' href='https://www.gov.uk/gwirio-os-ydych-yn-gymwys-i-gael-cymorth-cyfreithiol'>https://checklegalaid.service.gov.uk/</a>.</span>"
+msgstr "Profodd y <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr> y gwasanaeth sydd ar gael yn <a class='govuk-link' href='https://www.gov.uk/gwirio-os-ydych-yn-gymwys-i-gael-cymorth-cyfreithiol'>https://checklegalaid.service.gov.uk/</a>."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "What we’re doing to improve accessibility"
-msgstr "<span style='color:red'>Beth rydyn ni’n ei wneud i wella hygyrchedd</span>"
+msgstr "Beth rydyn ni’n ei wneud i wella hygyrchedd"
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "We are working to fix the issues listed in this statement by %(month)s %(year)s. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>."
-msgstr "<span style='color:red'>Rydyn ni’n gweithio i ddatrys y materion a restrir yn y datganiad hwn erbyn mis %(month)s %(year)s. Pan fydd y materion yn cael eu datrys, byddwn yn anfon y gwasanaeth i gael ail brawf gyda’r <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr>.</span>"
+msgstr "Rydyn ni’n gweithio i ddatrys y materion a restrir yn y datganiad hwn erbyn mis %(month)s %(year)s. Pan fydd y materion yn cael eu datrys, byddwn yn anfon y gwasanaeth i gael ail brawf gyda’r <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr>."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "We will monitor the accessibility of this service on an ongoing basis and fix any accessibility issues reported to us."
-msgstr "<span style='color:red'>Byddwn yn monitro hygyrchedd y gwasanaeth hwn yn barhaus ac yn datrys unrhyw broblemau hygyrchedd y rhoddir gwybod i ni amdanyn nhw.</span>"
+msgstr "Byddwn yn monitro hygyrchedd y gwasanaeth hwn yn barhaus ac yn datrys unrhyw broblemau hygyrchedd y rhoddir gwybod i ni amdanyn nhw."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "This statement was prepared on %(day)s %(month)s %(year)s."
-msgstr "<span style='color:red'>Cafodd y datganiad hwn ei baratoi ar %(day)s %(month)s %(year)s."
+msgstr "Cafodd y datganiad hwn ei baratoi ar %(day)s %(month)s %(year)s."
+
+
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"
 
@@ -4821,160 +4821,3 @@ msgstr "<span style='color:red'>Cafodd y datganiad hwn ei baratoi ar %(day)s %(m
 #~ msgstr "Mynd yn ôl i newid ateb"
 
 
-
-
-
-
-#: TESTING
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "Accessibility statement"
-msgstr "<span style='color:red'>Datganiad hygyrchedd</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "Using this service"
-msgstr "<span style='color:red'>Defnyddio’r gwasanaeth hwn</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for the Civil Legal Advice (<abbr>CLA</abbr>) service."
-msgstr "<span style='color:red'>Yr Asiantaeth Cymorth Cyfreithiol (<abbr>LAA</abbr>) sy’n gyfrifol am y gwasanaeth Cyngor Cyfreithiol Sifil (<abbr>CLA</abbr>).</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "We want as many people as possible to be able to use this service. For example, that means you should be able to:"
-msgstr "<span style='color:red'>Rydyn ni am i gynifer o bobl â phosibl allu defnyddio’r gwasanaeth hwn. Er enghraifft, mae hynny’n golygu y dylech allu:</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "change colours, contrast levels and fonts"
-msgstr "<span style='color:red'>newid lliwiau, lefelau cyferbyniad a ffontiau</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "zoom in up to 300&#37; without the text spilling off the screen"
-msgstr "<span style='color:red'>chwyddo mewn hyd at 300&#37; heb i’r testun ollwng oddi ar y sgrin</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "navigate the service using just a keyboard"
-msgstr "<span style='color:red'>symud o gwmpas gan ddefnyddio bysellfwrdd yn unig</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "AbilityNet has advice on making your device easier to use if you have a disability."
-msgstr "<span style='color:red'>Mae gan AbilityNet gyngor ar wneud eich dyfais yn haws ei defnyddio os oes gennych chi anabledd.</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "What to do if you can’t access part of this service"
-msgstr "<span style='color:red'>Beth i’w wneud os na allwch gael mynediad at ran o’r gwasanaeth hwn</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "If you need information on this service in a different format, you can contact us at %(email)s."
-msgstr "<span style='color:red'>Os oes angen gwybodaeth arnoch am y gwasanaeth hwn mewn fformat gwahanol, gallwch gysylltu â ni yn %(email)s.</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "Reporting accessibility problems"
-msgstr "<span style='color:red'>Rhoi gwybod am broblemau hygyrchedd</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "We’re always looking to improve the accessibility of this service. If you find any problems that aren’t listed on this page or think we’re not meeting the requirements of the accessibility regulations, contact %(email)s giving details of the issue and any assistive technology you are using."
-msgstr "<span style='color:red'>Rydyn ni bob amser yn ceisio gwella hygyrchedd y gwasanaeth hwn. Os byddwch chi’n dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon neu os ydych chi’n meddwl nad ydyn ni’n bodloni gofynion y rheoliadau hygyrchedd, cysylltwch â %(email)s gan roi manylion y broblem ac unrhyw dechnoleg gynorthwyol rydych chi’n ei defnyddio.</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "Enforcement procedure"
-msgstr "<span style='color:red'>Gweithdrefn gorfodi</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the accessibility regulations. If you’re not happy with how we respond to your complaint, contact the <a class=\"govuk-link\" href=\"https://www.equalityadvisoryservice.com/\" rel=\"external\">Equality Advisory and Support Service (<abbr>EASS</abbr>)</a>."
-msgstr "<span style='color:red'>Y Comisiwn Cydraddoldeb a Hawliau Dynol sy’n gyfrifol am orfodi’r rheoliadau hygyrchedd. Os nad ydych chi’n fodlon â sut rydyn ni’n ymateb i’ch cwyn, cysylltwch â’r <a class=\"govuk-link\" href=\"http://eass-ws.custhelp.com/app/home\" rel=\"external\">Gwasanaeth Cynghori a Chefnogi Cydraddoldeb (EASS)</a>.</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "Technical information about this service’s accessibility"
-msgstr "<span style='color:red'>Gwybodaeth dechnegol am hygyrchedd y gwasanaeth hwn</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "The Legal Aid Agency is committed to making its service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (&#8470; 2) Accessibility Regulations 2018."
-msgstr "<span style='color:red'>Mae’r Asiantaeth Cymorth Cyfreithiol wedi ymrwymo i wneud ei gwasanaeth yn hygyrch, yn unol â Rheoliadau Hygyrchedd Cyrff Sector Cyhoeddus (Gwefannau a Rhaglenni Symudol) (Rhif 2) 2018.</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "Web Content Accessibility Guidelines version 2.1"
-msgstr "<span style='color:red'>Canllawiau Hygyrchedd Cynnwys y We fersiwn 2.1</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "This service is partially compliant with the %(wcaglink)s AA standard, due to the non-compliance issues listed below."
-msgstr "<span style='color:red'>Mae’r gwasanaeth hwn yn cydymffurfio’n rhannol â safon AA %(wcaglink)s, oherwydd y materion diffyg cydymffurfio a restrir isod.</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "Non-accessible content"
-msgstr "<span style='color:red'>Cynnwys nad oes modd cael gafael arno</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "The content listed below is non-accessible for the following reasons."
-msgstr "<span style='color:red'>Nid oes modd cael gafael ar y cynnwys a restrir isod am y rhesymau canlynol.</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "Non-compliance with the accessibility regulations"
-msgstr "<span style='color:red'>Ddim yn cydymffurfio â’r rheoliadau hygyrchedd</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "Users are not able to turn off, adjust or extend the time in which inactivity will result in a loss of data. This fails WCAG 2.1 2.2.1 A (Timing Adjustable)."
-msgstr "<span style='color:red'>Ni all defnyddwyr ddiffodd, addasu nac ymestyn yr amser pan fydd anweithgarwch yn arwain at golli data. Mae hyn yn methu WCAG 2.1 2.2.1 A (Addasu’r Amseriad).</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "Some page elements are not available in Welsh. This fails WCAG 2.1 3.1.1 A (Language of Page)."
-msgstr "<span style='color:red'>Nid yw rhai elfennau tudalen ar gael yn Gymraeg. Mae hyn yn methu WCAG 2.1 3.1.1 A (Iaith Tudalen).</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "When a user enters figures into form fields it is not clear that the field does not accept currency symbols. This fails WCAG 2.1 2.4.6 AA (Headings and Labels)."
-msgstr "<span style='color:red'>Pan fydd defnyddiwr yn rhoi ffigurau mewn meysydd ffurflen, nid yw’n glir nad yw’r maes yn derbyn symbolau arian. Mae hyn yn methu WCAG 2.1 2.4.6 AA (Penawdau a Labeli).</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "Disproportionate burden"
-msgstr "<span style='color:red'>Baich anghymesur</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "Not applicable"
-msgstr "<span style='color:red'>Ddim yn berthnasol</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "Content that’s not within the scope of the accessibility regulations"
-msgstr "<span style='color:red'>Cynnwys nad yw o fewn cwmpas y rheoliadau hygyrchedd</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "How we tested this service"
-msgstr "<span style='color:red'>Sut y buom yn profi’r gwasanaeth hwn</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "July"
-msgstr "<span style='color:red'>Gorffennaf</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "September"
-msgstr "<span style='color:red'>Medi</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "December"
-msgstr "<span style='color:red'>Rhagfyr</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "This service was last tested on %(day)s %(month)s %(year)s."
-msgstr "<span style='color:red'>Cafodd y gwasanaeth hwn ei brofi ddiwethaf ar %(day)s %(month)s %(year)s.</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>)."
-msgstr "<span style='color:red'>Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC).</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "The <abbr title='Digital Accessibility Centre'>DAC</abbr> tested the service available at <a class='govuk-link' href='https://checklegalaid.service.gov.uk/'>https://checklegalaid.service.gov.uk/</a>."
-msgstr "<span style='color:red'>Profodd y <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr> y gwasanaeth sydd ar gael yn <a class='govuk-link' href='https://www.gov.uk/gwirio-os-ydych-yn-gymwys-i-gael-cymorth-cyfreithiol'>https://checklegalaid.service.gov.uk/</a>.</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "What we’re doing to improve accessibility"
-msgstr "<span style='color:red'>Beth rydyn ni’n ei wneud i wella hygyrchedd</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "We are working to fix the issues listed in this statement by %(month)s %(year)s. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>."
-msgstr "<span style='color:red'>Rydyn ni’n gweithio i ddatrys y materion a restrir yn y datganiad hwn erbyn mis %(month)s %(year)s. Pan fydd y materion yn cael eu datrys, byddwn yn anfon y gwasanaeth i gael ail brawf gyda’r <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr>.</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "We will monitor the accessibility of this service on an ongoing basis and fix any accessibility issues reported to us."
-msgstr "<span style='color:red'>Byddwn yn monitro hygyrchedd y gwasanaeth hwn yn barhaus ac yn datrys unrhyw broblemau hygyrchedd y rhoddir gwybod i ni amdanyn nhw.</span>"
-
-#: cla_public/templates/accessibility-statement.html:1
-msgid "This statement was prepared on %(day)s %(month)s %(year)s."
-msgstr "<span style='color:red'>Cafodd y datganiad hwn ei baratoi ar %(day)s %(month)s %(year)s."

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4502,8 +4502,8 @@ msgid "December"
 msgstr "Rhagfyr"
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "This service was last tested on %(date)s. The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>)."
-msgstr "Cafodd y gwasanaeth hwn ei brofi ddiwethaf ar %(date)s. Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC)."
+msgid "This service was last tested on %(day)s %(month)s %(year)s. The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>)."
+msgstr "Cafodd y gwasanaeth hwn ei brofi ddiwethaf ar %(day)s %(month)s %(year)s. Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC)."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "The <abbr title='Digital Accessibility Centre'>DAC</abbr> tested the service available at <a class='govuk-link' href='https://checklegalaid.service.gov.uk/'>https://checklegalaid.service.gov.uk/</a>."

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4418,16 +4418,16 @@ msgid "What to do if you can’t access part of this service"
 msgstr "Beth i’w wneud os na allwch gael mynediad at ran o’r gwasanaeth hwn"
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "If you need information on this service in a different format, you can contact us at civil-legal-advice@digital.justice.gov.uk."
-msgstr "Os oes angen gwybodaeth arnoch am y gwasanaeth hwn mewn fformat gwahanol, gallwch gysylltu â ni yn civil-legal-advice@digital.justice.gov.uk."
+msgid "If you need information on this service in a different format, you can contact us at %(email)s."
+msgstr "Os oes angen gwybodaeth arnoch am y gwasanaeth hwn mewn fformat gwahanol, gallwch gysylltu â ni yn %(email)s."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Reporting accessibility problems"
 msgstr "Rhoi gwybod am broblemau hygyrchedd"
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "We’re always looking to improve the accessibility of this service. If you find any problems that aren’t listed on this page or think we’re not meeting the requirements of the accessibility regulations, contact civil-legal-advice@digital.justice.gov.uk giving details of the issue and any assistive technology you are using."
-msgstr "Rydyn ni bob amser yn ceisio gwella hygyrchedd y gwasanaeth hwn. Os byddwch chi’n dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon neu os ydych chi’n meddwl nad ydyn ni’n bodloni gofynion y rheoliadau hygyrchedd, cysylltwch â civil-legal-advice@digital.justice.gov.uk gan roi manylion y broblem ac unrhyw dechnoleg gynorthwyol rydych chi’n ei defnyddio."
+msgid "We’re always looking to improve the accessibility of this service. If you find any problems that aren’t listed on this page or think we’re not meeting the requirements of the accessibility regulations, contact %(email)s giving details of the issue and any assistive technology you are using."
+msgstr "Rydyn ni bob amser yn ceisio gwella hygyrchedd y gwasanaeth hwn. Os byddwch chi’n dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon neu os ydych chi’n meddwl nad ydyn ni’n bodloni gofynion y rheoliadau hygyrchedd, cysylltwch â %(email)s gan roi manylion y broblem ac unrhyw dechnoleg gynorthwyol rydych chi’n ei defnyddio."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Enforcement procedure"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4446,8 +4446,12 @@ msgid "The Legal Aid Agency is committed to making its service accessible, in ac
 msgstr "Mae’r Asiantaeth Cymorth Cyfreithiol wedi ymrwymo i wneud ei gwasanaeth yn hygyrch, yn unol â Rheoliadau Hygyrchedd Cyrff Sector Cyhoeddus (Gwefannau a Rhaglenni Symudol) (Rhif 2) 2018."
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "This service is partially compliant with the <a class=\"govuk-link\" href=\"https://www.w3.org/TR/WCAG21/\" rel=\"external\">Web Content Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliance issues listed below."
-msgstr "Mae’r gwasanaeth hwn yn cydymffurfio’n rhannol â safon AA <a class=\"govuk-link\" href=\"https://www.w3.org/TR/WCAG21/\" rel=\"external\">Canllawiau Hygyrchedd Cynnwys y We fersiwn 2.1</a>, oherwydd y materion diffyg cydymffurfio a restrir isod."
+msgid "Web Content Accessibility Guidelines version 2.1"
+msgstr "Canllawiau Hygyrchedd Cynnwys y We fersiwn 2.1"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "This service is partially compliant with the %(wcaglink)s AA standard, due to the non-compliance issues listed below."
+msgstr "Mae’r gwasanaeth hwn yn cydymffurfio’n rhannol â safon AA %(wcaglink)s, oherwydd y materion diffyg cydymffurfio a restrir isod."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "Non-accessible content"
@@ -4514,16 +4518,16 @@ msgid "What we’re doing to improve accessibility"
 msgstr "Beth rydyn ni’n ei wneud i wella hygyrchedd"
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "We are working to fix the issues listed in this statement by %(date)s. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>."
-msgstr "Rydyn ni’n gweithio i ddatrys y materion a restrir yn y datganiad hwn erbyn mis %(date)s. Pan fydd y materion yn cael eu datrys, byddwn yn anfon y gwasanaeth i gael ail brawf gyda’r <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr>."
+msgid "We are working to fix the issues listed in this statement by %(month)s %(year)s. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>."
+msgstr "Rydyn ni’n gweithio i ddatrys y materion a restrir yn y datganiad hwn erbyn mis %(month)s %(year)s. Pan fydd y materion yn cael eu datrys, byddwn yn anfon y gwasanaeth i gael ail brawf gyda’r <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr>."
 
 #: cla_public/templates/accessibility-statement.html:1
 msgid "We will monitor the accessibility of this service on an ongoing basis and fix any accessibility issues reported to us."
 msgstr "Byddwn yn monitro hygyrchedd y gwasanaeth hwn yn barhaus ac yn datrys unrhyw broblemau hygyrchedd y rhoddir gwybod i ni amdanyn nhw."
 
 #: cla_public/templates/accessibility-statement.html:1
-msgid "This statement was prepared on %(date)s."
-msgstr "Cafodd y datganiad hwn ei baratoi ar %(date)s."
+msgid "This statement was prepared on %(day)s %(month)s %(year)s."
+msgstr "Cafodd y datganiad hwn ei baratoi ar %(day)s %(month)s %(year)s."
 
 
 #~ msgid "Overall, how did you feel about the service you received today?"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4821,3 +4821,160 @@ msgstr "Cafodd y datganiad hwn ei baratoi ar %(day)s %(month)s %(year)s."
 #~ msgstr "Mynd yn ôl i newid ateb"
 
 
+
+
+
+
+#: TESTING
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Accessibility statement"
+msgstr "<span style='color:red'>Datganiad hygyrchedd</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Using this service"
+msgstr "<span style='color:red'>Defnyddio’r gwasanaeth hwn</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "The Legal Aid Agency (<abbr>LAA</abbr>) is responsible for the Civil Legal Advice (<abbr>CLA</abbr>) service."
+msgstr "<span style='color:red'>Yr Asiantaeth Cymorth Cyfreithiol (<abbr>LAA</abbr>) sy’n gyfrifol am y gwasanaeth Cyngor Cyfreithiol Sifil (<abbr>CLA</abbr>).</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "We want as many people as possible to be able to use this service. For example, that means you should be able to:"
+msgstr "<span style='color:red'>Rydyn ni am i gynifer o bobl â phosibl allu defnyddio’r gwasanaeth hwn. Er enghraifft, mae hynny’n golygu y dylech allu:</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "change colours, contrast levels and fonts"
+msgstr "<span style='color:red'>newid lliwiau, lefelau cyferbyniad a ffontiau</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "zoom in up to 300&#37; without the text spilling off the screen"
+msgstr "<span style='color:red'>chwyddo mewn hyd at 300&#37; heb i’r testun ollwng oddi ar y sgrin</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "navigate the service using just a keyboard"
+msgstr "<span style='color:red'>symud o gwmpas gan ddefnyddio bysellfwrdd yn unig</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "AbilityNet has advice on making your device easier to use if you have a disability."
+msgstr "<span style='color:red'>Mae gan AbilityNet gyngor ar wneud eich dyfais yn haws ei defnyddio os oes gennych chi anabledd.</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "What to do if you can’t access part of this service"
+msgstr "<span style='color:red'>Beth i’w wneud os na allwch gael mynediad at ran o’r gwasanaeth hwn</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "If you need information on this service in a different format, you can contact us at %(email)s."
+msgstr "<span style='color:red'>Os oes angen gwybodaeth arnoch am y gwasanaeth hwn mewn fformat gwahanol, gallwch gysylltu â ni yn %(email)s.</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Reporting accessibility problems"
+msgstr "<span style='color:red'>Rhoi gwybod am broblemau hygyrchedd</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "We’re always looking to improve the accessibility of this service. If you find any problems that aren’t listed on this page or think we’re not meeting the requirements of the accessibility regulations, contact %(email)s giving details of the issue and any assistive technology you are using."
+msgstr "<span style='color:red'>Rydyn ni bob amser yn ceisio gwella hygyrchedd y gwasanaeth hwn. Os byddwch chi’n dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon neu os ydych chi’n meddwl nad ydyn ni’n bodloni gofynion y rheoliadau hygyrchedd, cysylltwch â %(email)s gan roi manylion y broblem ac unrhyw dechnoleg gynorthwyol rydych chi’n ei defnyddio.</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Enforcement procedure"
+msgstr "<span style='color:red'>Gweithdrefn gorfodi</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the accessibility regulations. If you’re not happy with how we respond to your complaint, contact the <a class=\"govuk-link\" href=\"https://www.equalityadvisoryservice.com/\" rel=\"external\">Equality Advisory and Support Service (<abbr>EASS</abbr>)</a>."
+msgstr "<span style='color:red'>Y Comisiwn Cydraddoldeb a Hawliau Dynol sy’n gyfrifol am orfodi’r rheoliadau hygyrchedd. Os nad ydych chi’n fodlon â sut rydyn ni’n ymateb i’ch cwyn, cysylltwch â’r <a class=\"govuk-link\" href=\"http://eass-ws.custhelp.com/app/home\" rel=\"external\">Gwasanaeth Cynghori a Chefnogi Cydraddoldeb (EASS)</a>.</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Technical information about this service’s accessibility"
+msgstr "<span style='color:red'>Gwybodaeth dechnegol am hygyrchedd y gwasanaeth hwn</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "The Legal Aid Agency is committed to making its service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (&#8470; 2) Accessibility Regulations 2018."
+msgstr "<span style='color:red'>Mae’r Asiantaeth Cymorth Cyfreithiol wedi ymrwymo i wneud ei gwasanaeth yn hygyrch, yn unol â Rheoliadau Hygyrchedd Cyrff Sector Cyhoeddus (Gwefannau a Rhaglenni Symudol) (Rhif 2) 2018.</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Web Content Accessibility Guidelines version 2.1"
+msgstr "<span style='color:red'>Canllawiau Hygyrchedd Cynnwys y We fersiwn 2.1</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "This service is partially compliant with the %(wcaglink)s AA standard, due to the non-compliance issues listed below."
+msgstr "<span style='color:red'>Mae’r gwasanaeth hwn yn cydymffurfio’n rhannol â safon AA %(wcaglink)s, oherwydd y materion diffyg cydymffurfio a restrir isod.</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Non-accessible content"
+msgstr "<span style='color:red'>Cynnwys nad oes modd cael gafael arno</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "The content listed below is non-accessible for the following reasons."
+msgstr "<span style='color:red'>Nid oes modd cael gafael ar y cynnwys a restrir isod am y rhesymau canlynol.</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Non-compliance with the accessibility regulations"
+msgstr "<span style='color:red'>Ddim yn cydymffurfio â’r rheoliadau hygyrchedd</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Users are not able to turn off, adjust or extend the time in which inactivity will result in a loss of data. This fails WCAG 2.1 2.2.1 A (Timing Adjustable)."
+msgstr "<span style='color:red'>Ni all defnyddwyr ddiffodd, addasu nac ymestyn yr amser pan fydd anweithgarwch yn arwain at golli data. Mae hyn yn methu WCAG 2.1 2.2.1 A (Addasu’r Amseriad).</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Some page elements are not available in Welsh. This fails WCAG 2.1 3.1.1 A (Language of Page)."
+msgstr "<span style='color:red'>Nid yw rhai elfennau tudalen ar gael yn Gymraeg. Mae hyn yn methu WCAG 2.1 3.1.1 A (Iaith Tudalen).</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "When a user enters figures into form fields it is not clear that the field does not accept currency symbols. This fails WCAG 2.1 2.4.6 AA (Headings and Labels)."
+msgstr "<span style='color:red'>Pan fydd defnyddiwr yn rhoi ffigurau mewn meysydd ffurflen, nid yw’n glir nad yw’r maes yn derbyn symbolau arian. Mae hyn yn methu WCAG 2.1 2.4.6 AA (Penawdau a Labeli).</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Disproportionate burden"
+msgstr "<span style='color:red'>Baich anghymesur</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Not applicable"
+msgstr "<span style='color:red'>Ddim yn berthnasol</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "Content that’s not within the scope of the accessibility regulations"
+msgstr "<span style='color:red'>Cynnwys nad yw o fewn cwmpas y rheoliadau hygyrchedd</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "How we tested this service"
+msgstr "<span style='color:red'>Sut y buom yn profi’r gwasanaeth hwn</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "July"
+msgstr "<span style='color:red'>Gorffennaf</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "September"
+msgstr "<span style='color:red'>Medi</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "December"
+msgstr "<span style='color:red'>Rhagfyr</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "This service was last tested on %(day)s %(month)s %(year)s."
+msgstr "<span style='color:red'>Cafodd y gwasanaeth hwn ei brofi ddiwethaf ar %(day)s %(month)s %(year)s.</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "The test was carried out by the Digital Accessibility Centre (<abbr>DAC</abbr>)."
+msgstr "<span style='color:red'>Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC).</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "The <abbr title='Digital Accessibility Centre'>DAC</abbr> tested the service available at <a class='govuk-link' href='https://checklegalaid.service.gov.uk/'>https://checklegalaid.service.gov.uk/</a>."
+msgstr "<span style='color:red'>Profodd y <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr> y gwasanaeth sydd ar gael yn <a class='govuk-link' href='https://www.gov.uk/gwirio-os-ydych-yn-gymwys-i-gael-cymorth-cyfreithiol'>https://checklegalaid.service.gov.uk/</a>.</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "What we’re doing to improve accessibility"
+msgstr "<span style='color:red'>Beth rydyn ni’n ei wneud i wella hygyrchedd</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "We are working to fix the issues listed in this statement by %(month)s %(year)s. When the issues are fixed we will send the service for a re-test with the <abbr title='Digital Accessibility Centre'>DAC</abbr>."
+msgstr "<span style='color:red'>Rydyn ni’n gweithio i ddatrys y materion a restrir yn y datganiad hwn erbyn mis %(month)s %(year)s. Pan fydd y materion yn cael eu datrys, byddwn yn anfon y gwasanaeth i gael ail brawf gyda’r <abbr title='Ganolfan Hygyrchedd Digidol'>DAC</abbr>.</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "We will monitor the accessibility of this service on an ongoing basis and fix any accessibility issues reported to us."
+msgstr "<span style='color:red'>Byddwn yn monitro hygyrchedd y gwasanaeth hwn yn barhaus ac yn datrys unrhyw broblemau hygyrchedd y rhoddir gwybod i ni amdanyn nhw.</span>"
+
+#: cla_public/templates/accessibility-statement.html:1
+msgid "This statement was prepared on %(day)s %(month)s %(year)s."
+msgstr "<span style='color:red'>Cafodd y datganiad hwn ei baratoi ar %(day)s %(month)s %(year)s."


### PR DESCRIPTION
## What does this pull request do?

LGA-1428: Adds new Welsh translations.
LGA-1427: Updates accessibility statement.
LGA-1428 & 1427: Applies Welsh translations to accessibility statement.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
