### PR TITLE
LGA-1567 - Use cla_common version with boxing day hours

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ PyYAML==3.11
 Werkzeug==0.9.6
 argparse==1.2.1
 blinker==1.3
-git+https://github.com/ministryofjustice/cla_common.git@0.3.11#egg=cla_common
+git+https://github.com/ministryofjustice/cla_common.git@0.3.12#egg=cla_common
 speaklater==1.3 # Required by cla_common
 itsdangerous==0.24
 logstash_formatter==0.5.9


### PR DESCRIPTION
## What does this pull request do?

Use cla_common version with boxing day hours

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
