### PR TITLE
LGA-1574 - Reinstate noisy, but potentially important uwsgi errors

### DIFF
--- a/docker/cla_public.ini
+++ b/docker/cla_public.ini
@@ -16,7 +16,4 @@ logformat={"process_name": "uwsgi", "timestamp_msec": %(tmsecs), "method": "%(me
 post-buffering = 1
 buffer-size=32768
 post-buffering-bufsize=32768
-ignore-sigpipe = true
-ignore-write-errors = true
-disable-write-exception = true
 die-on-term=True


### PR DESCRIPTION
## What does this pull request do?

Stops filtering out these types of i/o errors from reaching Sentry. These errors may actually have (at least partly) indicated a problem after all. We've added config to cla_backend to try to reduce them, so I'd like to see if that's actually had any effect on them.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
