### PR TITLE
LGA-1585 Modern Slavery LARP to search all categories

### DIFF
--- a/cla_public/apps/checker/constants.py
+++ b/cla_public/apps/checker/constants.py
@@ -177,8 +177,6 @@ LAALAA_PROVIDER_CATEGORIES_MAP = {
 
 # adds another to the above - see get_category_for_larp
 LAALAA_PROVIDER_CATEGORIES_MAP.update({"traffickingslavery": [""]})
-# REVERT TO THIS WHEN THE MOSL IS SET UP ON PRODUCTION
-# LAALAA_PROVIDER_CATEGORIES_MAP.update({"traffickingslavery": ["mosl"]})
 
 END_SERVICE_FLASH_MESSAGE = _(
     u"The information you’ve entered has not been stored on your computer or "

--- a/cla_public/apps/checker/constants.py
+++ b/cla_public/apps/checker/constants.py
@@ -176,7 +176,9 @@ LAALAA_PROVIDER_CATEGORIES_MAP = {
 }
 
 # adds another to the above - see get_category_for_larp
-LAALAA_PROVIDER_CATEGORIES_MAP.update({"traffickingslavery": ["mosl"]})
+LAALAA_PROVIDER_CATEGORIES_MAP.update({"traffickingslavery": [""]})
+# REVERT TO THIS WHEN THE MOSL IS SET UP ON PRODUCTION
+# LAALAA_PROVIDER_CATEGORIES_MAP.update({"traffickingslavery": ["mosl"]})
 
 END_SERVICE_FLASH_MESSAGE = _(
     u"The information you’ve entered has not been stored on your computer or "


### PR DESCRIPTION
## What does this pull request do?

Comments out old code and makes `traffickingslavery` search for a blank, which returns all providers.  
Old code to be reinstated when new `mosl` category is set up on Production.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
