### PR TITLE
LGA-1570 Modern Slavery Category Search [pending go-ahead]

### DIFF
--- a/cla_public/apps/checker/constants.py
+++ b/cla_public/apps/checker/constants.py
@@ -176,7 +176,7 @@ LAALAA_PROVIDER_CATEGORIES_MAP = {
 }
 
 # adds another to the above - see get_category_for_larp
-LAALAA_PROVIDER_CATEGORIES_MAP.update({"traffickingslavery": [""]})
+LAALAA_PROVIDER_CATEGORIES_MAP.update({"traffickingslavery": ["mosl"]})
 
 END_SERVICE_FLASH_MESSAGE = _(
     u"The information you’ve entered has not been stored on your computer or "


### PR DESCRIPTION
```diff
! Do not merge yet !
! Do not merge yet !
! Do not merge yet !
```

## What does this pull request do?

Modern Slavery search only searches for modern slavery

**This cannot be merged yet**
- This needs the `mosl` category to be set up in production.  If this is merged prior to that, no results will be returned (as seen when this was previously merged ahead of time and fixed in [PR 1051 (LGA-1585)](https://github.com/ministryofjustice/cla_public/pull/1051)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
