### PR TITLE
Feature/LGA-1579-welsh-disregards

### DIFF
--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -5057,6 +5057,14 @@ msgstr "Dydd Llun, 10yb &ndash; 8yh;<br />Dydd Mawrth, 10yb &ndash; 5yp;<br />Dy
 #~ msgid "Go back and change answer"
 #~ msgstr "Mynd yn ôl i newid ateb"
 
-#: cla_public/templates/checker/savings.html:24
-#~ msgid "What payments do not count as savings?"
-#~ msgstr "Pa daliadau nad ydynt yn cyfrif fel cynilion?"
+msgid "What payments do not count as savings?"
+msgstr "Pa daliadau nad ydynt yn cyfrif fel cynilion?"
+
+msgid "Do not include monies received from the following schemes"
+msgstr "Peidiwch â chynnwys arian a geir o'r cynlluniau canlynol"
+
+msgid "National Emergencies Trust"
+msgstr "Ymddiriedolaeth Argyfyngau Cenedlaethol"
+
+msgid "We Love Manchester Emergency Fund"
+msgstr "Cronfa Argyfwng We Love Manchester"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4770,6 +4770,18 @@ msgstr "Dydd Llun, 10yb &ndash; 6yh;<br />Dydd Mawrth/Iau/Gwener, 10yb &ndash; 4
 msgid "Monday, 10am-8pm\nTuesday, 10am-5pm , (1pm-5pm Tuesday is a trans-specific service)\nWednesday, 10am-5pm \nThursday, 10am - 8pm"
 msgstr "Dydd Llun, 10yb &ndash; 8yh;<br />Dydd Mawrth, 10yb &ndash; 5yp;<br />Dydd Mercher, 10yb &ndash; 5yp;<br />Dydd Iau, 10yb &ndash; 8yh"
 
+msgid "What payments do not count as savings?"
+msgstr "Pa daliadau nad ydynt yn cyfrif fel cynilion?"
+
+msgid "Do not include monies received from the following schemes"
+msgstr "Peidiwch â chynnwys arian a geir o'r cynlluniau canlynol"
+
+msgid "National Emergencies Trust"
+msgstr "Ymddiriedolaeth Argyfyngau Cenedlaethol"
+
+msgid "We Love Manchester Emergency Fund"
+msgstr "Cronfa Argyfwng We Love Manchester"
+
 
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"
@@ -5056,15 +5068,3 @@ msgstr "Dydd Llun, 10yb &ndash; 8yh;<br />Dydd Mawrth, 10yb &ndash; 5yp;<br />Dy
 
 #~ msgid "Go back and change answer"
 #~ msgstr "Mynd yn ôl i newid ateb"
-
-msgid "What payments do not count as savings?"
-msgstr "Pa daliadau nad ydynt yn cyfrif fel cynilion?"
-
-msgid "Do not include monies received from the following schemes"
-msgstr "Peidiwch â chynnwys arian a geir o'r cynlluniau canlynol"
-
-msgid "National Emergencies Trust"
-msgstr "Ymddiriedolaeth Argyfyngau Cenedlaethol"
-
-msgid "We Love Manchester Emergency Fund"
-msgstr "Cronfa Argyfwng We Love Manchester"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4773,6 +4773,9 @@ msgstr "Dydd Llun, 10yb &ndash; 8yh;<br />Dydd Mawrth, 10yb &ndash; 5yp;<br />Dy
 msgid "What payments do not count as savings?"
 msgstr "Pa daliadau nad ydynt yn cyfrif fel cynilion?"
 
+msgid "What payments do not count as income?"
+msgstr "Pa daliadau nad ydynt yn cyfrif fel incwm?"
+
 msgid "Do not include monies received from the following schemes"
 msgstr "Peidiwch â chynnwys arian a geir o'r cynlluniau canlynol"
 

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -5057,4 +5057,5 @@ msgstr "Dydd Llun, 10yb &ndash; 8yh;<br />Dydd Mawrth, 10yb &ndash; 5yp;<br />Dy
 #~ msgid "Go back and change answer"
 #~ msgstr "Mynd yn ôl i newid ateb"
 
-
+#~ msgid "What payments do not count as savings?"
+#~ msgstr "Pa daliadau nad ydynt yn cyfrif fel cynilion?"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -5057,5 +5057,6 @@ msgstr "Dydd Llun, 10yb &ndash; 8yh;<br />Dydd Mawrth, 10yb &ndash; 5yp;<br />Dy
 #~ msgid "Go back and change answer"
 #~ msgstr "Mynd yn ôl i newid ateb"
 
+#: cla_public/templates/checker/savings.html:24
 #~ msgid "What payments do not count as savings?"
 #~ msgstr "Pa daliadau nad ydynt yn cyfrif fel cynilion?"

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -4257,3 +4257,5 @@ msgstr ""
 #~ "      "
 #~ msgstr ""
 
+#~ msgid "What payments do not count as savings?"
+#~ msgstr ""

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -4256,7 +4256,3 @@ msgstr ""
 #~ "        You can also %(apply_directly_link)s to the Legal Aid Agency.\n"
 #~ "      "
 #~ msgstr ""
-
-#: cla_public/templates/checker/savings.html:9
-#~ msgid "What payments do not count as savings?"
-#~ msgstr ""

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -4257,5 +4257,6 @@ msgstr ""
 #~ "      "
 #~ msgstr ""
 
+#: cla_public/templates/checker/savings.html:9
 #~ msgid "What payments do not count as savings?"
 #~ msgstr ""


### PR DESCRIPTION
## What does this pull request do?

Adds the Welsh translations for:

"What payments do not count as savings?"
"What payments do not count as income?"
"Do not include monies received from the following schemes"
"National Emergencies Trust"
"We Love Manchester Emergency Fund"

## Any other changes that would benefit highlighting?


## Checklist
https://dsdmoj.atlassian.net/browse/LGA-1579

