### PR TITLE
LGA-1685 Emergency message template

### DIFF
--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -62,8 +62,9 @@ class Contact(AllowSessionOverride, UpdatesMeansTest, SessionBackedFormView):
     template = "contact.html"
 
     def get(self, *args, **kwargs):
+        self.template_context = {"emergency_message": current_app.config["EMERGENCY_MESSAGE_ON"]}
         if ReasonsForContacting.GA_SESSION_KEY in session:
-            self.template_context = {"reasons_for_contacting": session[ReasonsForContacting.GA_SESSION_KEY]}
+            self.template_context.update({"reasons_for_contacting": session[ReasonsForContacting.GA_SESSION_KEY]})
             del session[ReasonsForContacting.GA_SESSION_KEY]
         return super(Contact, self).get(*args, **kwargs)
 

--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -8,6 +8,9 @@ PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 DEBUG = False
 
+# Sets whether the emergency message displays on the contact page or not
+EMERGENCY_MESSAGE_ON = os.environ.get("EMERGENCY_MESSAGE_ON", "False") == "True"
+
 TESTING = False
 
 CLEAR_SESSION = True

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -15,7 +15,7 @@
 {% block inner_content %}
   {% if emergency_message %}
     {% call EmergencyMessage.emergency_message() %}
-      {{ _('Text goes here')}}
+      {{ _('Book a call back or text ‘legalaid’ and your name to 80010 and we will contact you as soon as we can.')}}
     {% endcall %}
   {% endif %}
   {{ Form.handle_errors(form) }}
@@ -31,7 +31,7 @@
       to question 'Are you at immediate risk of harm?'
     #}
     {% if 'n18' in session.checker.diagnosis_previous_choices %}
-      <div class="govuk-warning-text"> 
+      <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
           {% trans %}If you’re in an emergency situation, please call the police on 999.{% endtrans %}

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -31,7 +31,7 @@
       to question 'Are you at immediate risk of harm?'
     #}
     {% if 'n18' in session.checker.diagnosis_previous_choices %}
-      <div class="govuk-warning-text"> 
+      <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
           {% trans %}If you’re in an emergency situation, please call the police on 999.{% endtrans %}

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -31,7 +31,7 @@
       to question 'Are you at immediate risk of harm?'
     #}
     {% if 'n18' in session.checker.diagnosis_previous_choices %}
-      <div class="govuk-warning-text">
+      <div class="govuk-warning-text"> 
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
           {% trans %}If you’re in an emergency situation, please call the police on 999.{% endtrans %}

--- a/cla_public/templates/contact.html
+++ b/cla_public/templates/contact.html
@@ -7,11 +7,17 @@
 {% import "macros/form.html" as Form %}
 {% import "macros/subform.html" as Subform %}
 {% import "macros/element.html" as Element %}
+{% import "macros/emergency_message.html" as EmergencyMessage %}
 
 {% set title = _('Contact Civil Legal Advice') %}
 {% block page_title %}{{ title }}{% endblock %}
 
 {% block inner_content %}
+  {% if emergency_message %}
+    {% call EmergencyMessage.emergency_message() %}
+      {{ _('Text goes here')}}
+    {% endcall %}
+  {% endif %}
   {{ Form.handle_errors(form) }}
   {% block page_text %}
     {% if config.CONTACT_ONLY %}
@@ -25,7 +31,7 @@
       to question 'Are you at immediate risk of harm?'
     #}
     {% if 'n18' in session.checker.diagnosis_previous_choices %}
-      <div class="govuk-warning-text">
+      <div class="govuk-warning-text"> 
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
           {% trans %}If you’re in an emergency situation, please call the police on 999.{% endtrans %}

--- a/cla_public/templates/macros/emergency_message.html
+++ b/cla_public/templates/macros/emergency_message.html
@@ -2,7 +2,7 @@
     <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header">
         <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-            Important
+            The CLA helpline is currently unavailable
         </h2>
         </div>
         <div class="govuk-notification-banner__content">

--- a/cla_public/templates/macros/emergency_message.html
+++ b/cla_public/templates/macros/emergency_message.html
@@ -1,0 +1,14 @@
+{% macro emergency_message() %}
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Important
+        </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">
+            {{ caller() }}
+        </p>
+        </div>
+    </div>
+  {% endmacro %}

--- a/cla_public/templates/macros/emergency_message.html
+++ b/cla_public/templates/macros/emergency_message.html
@@ -2,7 +2,7 @@
     <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header">
         <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-            The CLA helpline is currently unavailable
+            Important
         </h2>
         </div>
         <div class="govuk-notification-banner__content">

--- a/cla_public/templates/macros/emergency_message.html
+++ b/cla_public/templates/macros/emergency_message.html
@@ -2,11 +2,12 @@
     <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header">
         <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-            The CLA helpline is currently unavailable
+            Important
         </h2>
         </div>
         <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">
+            <h3 class="govuk-heading-m">The CLA helpline is currently unavailable</h3>
             {{ caller() }}
         </p>
         </div>


### PR DESCRIPTION
## What does this pull request do?

This adds an emergency message which can be turned off or on with an environment variable called emergency_message_on.  It used the gds notifications style found here:  https://design-system.service.gov.uk/components/notification-banner/
and it displays on the contact page.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
