### PR TITLE
LGA-1649-welsh-info-stored-message

### DIFF
--- a/cla_public/apps/checker/constants.py
+++ b/cla_public/apps/checker/constants.py
@@ -185,7 +185,8 @@ CONTACT_PREFERENCE = Choices(
 LEGAL_ADVISER_SEARCH_PREFERENCE = (("location", _(u"Location")), ("organisation", _(u"Organisation")))
 
 END_SERVICE_FLASH_MESSAGE = _(
-    u"The information you’ve entered has not been stored on your computer or "
-    u"mobile device. If you are at risk of harm, you should delete your "
-    u"browser history."
+    u"The information that you have entered has not been stored on your "
+    u"computer or mobile device, but your browsing history will record "
+    u"that you have visited this service. If you are at risk of harm, you "
+    u"should delete your browser history."
 )

--- a/cla_public/apps/checker/constants.py
+++ b/cla_public/apps/checker/constants.py
@@ -185,7 +185,7 @@ CONTACT_PREFERENCE = Choices(
 LEGAL_ADVISER_SEARCH_PREFERENCE = (("location", _(u"Location")), ("organisation", _(u"Organisation")))
 
 END_SERVICE_FLASH_MESSAGE = _(
-    u"The information that you have entered has not been stored on your "
+    u"The information you have entered has not been stored on your "
     u"computer or mobile device, but your browsing history will record "
     u"that you have visited this service. If you are at risk of harm, you "
     u"should delete your browser history."

--- a/cla_public/apps/checker/constants.py
+++ b/cla_public/apps/checker/constants.py
@@ -187,6 +187,6 @@ LEGAL_ADVISER_SEARCH_PREFERENCE = (("location", _(u"Location")), ("organisation"
 END_SERVICE_FLASH_MESSAGE = _(
     u"The information you have entered has not been stored on your "
     u"computer or mobile device, but your browsing history will record "
-    u"that you have visited this service. If you are at risk of harm, you "
+    u"you have visited this service. If you are at risk of harm, you "
     u"should delete your browser history."
 )

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4949,6 +4949,9 @@ msgstr "Rydym yn addo rhoi gwybod i chi pam fod angen eich data personol arnom a
 msgid "When we ask you for information, we will keep to the law. If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:"
 msgstr "Pan fyddwn yn gofyn am wybodaeth gennych, byddwn yn cydymffurfio â'r gyfraith. Os ydych chi'n teimlo bod eich gwybodaeth wedi'i thrin yn anghywir, gallwch gysylltu â'r Comisiynydd Gwybodaeth am gyngor annibynnol ynghylch diogelu data. Gallwch gysylltu â'r Comisiynydd Gwybodaeth yn:"
 
+msgid "The information that you have entered has not been stored on your computer or mobile device, but your browsing history will record that you have visited this service. If you are at risk of harm, you should delete your browser history."
+msgstr "Nid yw’r wybodaeth a roddwyd gennych chi wedi cael ei storio ar eich cyfrifiadur na’ch dyfais symudol, ond bydd eich hanes pori yn dangos eich bod wedi ymweld â’r gwasanaeth hwn. Os ydych chi mewn perygl o niwed, dylech chi ddileu eich hanes pori."
+
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"
 

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4949,7 +4949,7 @@ msgstr "Rydym yn addo rhoi gwybod i chi pam fod angen eich data personol arnom a
 msgid "When we ask you for information, we will keep to the law. If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:"
 msgstr "Pan fyddwn yn gofyn am wybodaeth gennych, byddwn yn cydymffurfio â'r gyfraith. Os ydych chi'n teimlo bod eich gwybodaeth wedi'i thrin yn anghywir, gallwch gysylltu â'r Comisiynydd Gwybodaeth am gyngor annibynnol ynghylch diogelu data. Gallwch gysylltu â'r Comisiynydd Gwybodaeth yn:"
 
-msgid "The information that you have entered has not been stored on your computer or mobile device, but your browsing history will record that you have visited this service. If you are at risk of harm, you should delete your browser history."
+msgid "The information you have entered has not been stored on your computer or mobile device, but your browsing history will record that you have visited this service. If you are at risk of harm, you should delete your browser history."
 msgstr "Nid yw’r wybodaeth a roddwyd gennych chi wedi cael ei storio ar eich cyfrifiadur na’ch dyfais symudol, ond bydd eich hanes pori yn dangos eich bod wedi ymweld â’r gwasanaeth hwn. Os ydych chi mewn perygl o niwed, dylech chi ddileu eich hanes pori."
 
 #~ msgid "Overall, how did you feel about the service you received today?"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4949,7 +4949,7 @@ msgstr "Rydym yn addo rhoi gwybod i chi pam fod angen eich data personol arnom a
 msgid "When we ask you for information, we will keep to the law. If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:"
 msgstr "Pan fyddwn yn gofyn am wybodaeth gennych, byddwn yn cydymffurfio â'r gyfraith. Os ydych chi'n teimlo bod eich gwybodaeth wedi'i thrin yn anghywir, gallwch gysylltu â'r Comisiynydd Gwybodaeth am gyngor annibynnol ynghylch diogelu data. Gallwch gysylltu â'r Comisiynydd Gwybodaeth yn:"
 
-msgid "The information you have entered has not been stored on your computer or mobile device, but your browsing history will record that you have visited this service. If you are at risk of harm, you should delete your browser history."
+msgid "The information you have entered has not been stored on your computer or mobile device, but your browsing history will record you have visited this service. If you are at risk of harm, you should delete your browser history."
 msgstr "Nid yw’r wybodaeth a roddwyd gennych chi wedi cael ei storio ar eich cyfrifiadur na’ch dyfais symudol, ond bydd eich hanes pori yn dangos eich bod wedi ymweld â’r gwasanaeth hwn. Os ydych chi mewn perygl o niwed, dylech chi ddileu eich hanes pori."
 
 #~ msgid "Overall, how did you feel about the service you received today?"


### PR DESCRIPTION
## What does this pull request do?

Updates the ENG text and adds the corresponding Welsh translation.

## Any other changes that would benefit highlighting?

I've removed redundant words from the original wording in the ticket to shorten the message and cognitive load and so that the message doesn't wrap onto 3 lines on desktop view.

## Checklist

LGA-1649
https://dsdmoj.atlassian.net/browse/LGA-1649
