### PR TITLE
LGA-1719 - Update CLA common

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ PyYAML==3.11
 Werkzeug==0.9.6
 argparse==1.2.1
 blinker==1.3
-git+https://github.com/ministryofjustice/cla_common.git@2da49ee8d3e15031f84146339fe3d18e4581ebfa#egg=cla_common
+git+https://github.com/ministryofjustice/cla_common.git@0.3.15#egg=cla_common
 speaklater==1.3 # Required by cla_common
 itsdangerous==0.24
 logstash_formatter==0.5.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ itsdangerous==0.24
 logstash_formatter==0.5.9
 markdown2==2.3.5
 python-dateutil==2.2
-pytz==2018.5
+pytz==2021.1
 requests==2.19.1
 wsgiref==0.1.2
 Babel==1.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ PyYAML==3.11
 Werkzeug==0.9.6
 argparse==1.2.1
 blinker==1.3
-git+git://github.com/ministryofjustice/cla_common.git@0.3.14#egg=cla_common
+git+https://github.com/ministryofjustice/cla_common.git@2da49ee8d3e15031f84146339fe3d18e4581ebfa#egg=cla_common
 speaklater==1.3 # Required by cla_common
 itsdangerous==0.24
 logstash_formatter==0.5.9


### PR DESCRIPTION
## What does this pull request do?
Updates to the new cla_common release

The new version facilitates a fix in cla_backend (timezone-aware calculation
of the assigned_out_of_hours field).
The change should not change anything for this repo, as the new
behaviour defaults to the old behaviour unless specified

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
