### PR TITLE
LGA-1737-Welsh-emergency-unavailable-message

### DIFF
--- a/cla_public/templates/macros/emergency_message.html
+++ b/cla_public/templates/macros/emergency_message.html
@@ -2,12 +2,12 @@
     <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header">
         <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-            Important
+            {% trans %}Important{% endtrans %}
         </h2>
         </div>
         <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">
-            <h3 class="govuk-heading-m">The CLA helpline is currently unavailable</h3>
+            <h3 class="govuk-heading-m">{% trans %}The CLA helpline is currently unavailable{% endtrans %}</h3>
             {{ caller() }}
         </p>
         </div>

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4959,6 +4959,15 @@ msgstr "I chwilio am gyfryngwyr sydd â chontract cymorth cyfreithiol, ticiwch y
 msgid "The mediator can check if you qualify for legal aid."
 msgstr "Gall y cyfryngwr wirio a ydych chi’n gymwys i gael cymorth cyfreithiol."
 
+msgid "Important"
+msgstr "Pwysig"
+
+msgid "The CLA helpline is currently unavailable"
+msgstr "Nid yw llinell gymorth CLA ar gael ar hyn o bryd"
+
+msgid "Book a call back or text ‘legalaid’ and your name to 80010 and we will contact you as soon as we can."
+msgstr "Trefnwch alwad yn ôl neu tecstiwch ‘legalaid’ a’ch enw at 80010 a byddwn mewn cysylltiad â chi cyn gynted ag y gallwn."
+
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"
 


### PR DESCRIPTION
## What does this pull request do?

Add Welsh translation for the emergency message if the CLA helpline is unavailable

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

https://dsdmoj.atlassian.net/browse/LGA-1737