### PR TITLE
LGA-1710-welsh-mean-ineligible

### DIFF
--- a/cla_public/templates/checker/result/ineligible.html
+++ b/cla_public/templates/checker/result/ineligible.html
@@ -56,7 +56,8 @@
       {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'Family Mediation Council') %}
       {% trans family_mediation_link=Element.link_same_window('http://www.familymediationcouncil.org.uk/', _('Family Mediation Council'), True, **{'data-ga': ga_event}) %}
         If you want to make an application to court about a family matter you need to first of all
-        see if family mediation will help. Use the{% endtrans %} {{ family_mediation_link }} {% trans %}directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM).{% endtrans %}
+        see if family mediation will help. Use the {{ family_mediation_link }} directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM).
+      {% endtrans %}
     </p>
   {% endif %}
 

--- a/cla_public/templates/checker/result/ineligible.html
+++ b/cla_public/templates/checker/result/ineligible.html
@@ -55,10 +55,9 @@
     <p class="govuk-body">
       {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'Family Mediation Council') %}
       {% trans family_mediation_link=Element.link_same_window('http://www.familymediationcouncil.org.uk/', _('Family Mediation Council'), True, **{'data-ga': ga_event}) %}
-        If you want to make an application to court about a family matter you need to first of all
+        {% trans %}If you want to make an application to court about a family matter you need to first of all
         see if family mediation will help. Use the {{ family_mediation_link }} directory to find a mediator
-        and make an appointment for a Mediation Information and Assessment Meeting (MIAM).
-      {% endtrans %}
+        and make an appointment for a Mediation Information and Assessment Meeting (MIAM).{% endtrans %}
     </p>
   {% endif %}
 

--- a/cla_public/templates/checker/result/ineligible.html
+++ b/cla_public/templates/checker/result/ineligible.html
@@ -54,7 +54,7 @@
   {% if category == 'family' %}
     <p class="govuk-body">
       {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'Family Mediation Council') %}
-      {% trans family_mediation_link=Element.link_same_window('http://www.familymediationcouncil.org.uk/', _('Family Mediation Council'), True, **{'data-ga': ga_event}) %}If you want to make an application to court about a family matter you need to first of all see if family mediation will help. Use the{% endtrans %} {{ family_mediation_link }} {% trans %}directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM).{% endtrans %}
+      {% trans family_mediation_link=Element.link_same_window('http://www.familymediationcouncil.org.uk/', _('Family Mediation Council'), True, **{'data-ga': ga_event}) %}If you want to make an application to court about a family matter you need to first of all see if family mediation will help. Use the{% endtrans %} <a class="govuk-link" href="http://www.familymediationcouncil.org.uk">{% trans %}Family Mediation Council{% endtrans %}</a> {% trans %}directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM).{% endtrans %}
     </p>
   {% endif %}
 

--- a/cla_public/templates/checker/result/ineligible.html
+++ b/cla_public/templates/checker/result/ineligible.html
@@ -55,7 +55,7 @@
     <p class="govuk-body">
       {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'Family Mediation Council') %}
       {% trans family_mediation_link=Element.link_same_window('http://www.familymediationcouncil.org.uk/', _('Family Mediation Council'), True, **{'data-ga': ga_event}) %}
-        {% trans %}If you want to make an application to court about a family matter you need to first of all
+        If you want to make an application to court about a family matter you need to first of all
         see if family mediation will help. Use the{% endtrans %} {{ family_mediation_link }} {% trans %}directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM).{% endtrans %}
     </p>
   {% endif %}
@@ -64,8 +64,7 @@
 
           <a class="govuk-link" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">
             {% trans %}What did you think of this service?{% endtrans %}</a> {% trans %}(takes 30 seconds){% endtrans %}
-          </a>
-    </p>
+      </p>
 
   <h2 class="govuk-heading-l">{{ _('A legal adviser may still be able to help') }}</h2>
 

--- a/cla_public/templates/checker/result/ineligible.html
+++ b/cla_public/templates/checker/result/ineligible.html
@@ -56,8 +56,7 @@
       {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'Family Mediation Council') %}
       {% trans family_mediation_link=Element.link_same_window('http://www.familymediationcouncil.org.uk/', _('Family Mediation Council'), True, **{'data-ga': ga_event}) %}
         {% trans %}If you want to make an application to court about a family matter you need to first of all
-        see if family mediation will help. Use the {{ family_mediation_link }} directory to find a mediator
-        and make an appointment for a Mediation Information and Assessment Meeting (MIAM).{% endtrans %}
+        see if family mediation will help. Use the{% endtrans %} {{ family_mediation_link }} {% trans %}directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM).{% endtrans %}
     </p>
   {% endif %}
 

--- a/cla_public/templates/checker/result/ineligible.html
+++ b/cla_public/templates/checker/result/ineligible.html
@@ -54,10 +54,7 @@
   {% if category == 'family' %}
     <p class="govuk-body">
       {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'Family Mediation Council') %}
-      {% trans family_mediation_link=Element.link_same_window('http://www.familymediationcouncil.org.uk/', _('Family Mediation Council'), True, **{'data-ga': ga_event}) %}
-        If you want to make an application to court about a family matter you need to first of all
-        see if family mediation will help. Use the {{ family_mediation_link }} directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM).
-      {% endtrans %}
+      {% trans family_mediation_link=Element.link_same_window('http://www.familymediationcouncil.org.uk/', _('Family Mediation Council'), True, **{'data-ga': ga_event}) %}If you want to make an application to court about a family matter you need to first of all see if family mediation will help. Use the {{ family_mediation_link }} directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM).{% endtrans %}
     </p>
   {% endif %}
 

--- a/cla_public/templates/checker/result/ineligible.html
+++ b/cla_public/templates/checker/result/ineligible.html
@@ -54,7 +54,7 @@
   {% if category == 'family' %}
     <p class="govuk-body">
       {% set ga_event = 'event:%s/%s/%s' % ('External Link Clicked', 'click', 'Family Mediation Council') %}
-      {% trans family_mediation_link=Element.link_same_window('http://www.familymediationcouncil.org.uk/', _('Family Mediation Council'), True, **{'data-ga': ga_event}) %}If you want to make an application to court about a family matter you need to first of all see if family mediation will help. Use the {{ family_mediation_link }} directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM).{% endtrans %}
+      {% trans family_mediation_link=Element.link_same_window('http://www.familymediationcouncil.org.uk/', _('Family Mediation Council'), True, **{'data-ga': ga_event}) %}If you want to make an application to court about a family matter you need to first of all see if family mediation will help. Use the{% endtrans %} {{ family_mediation_link }} {% trans %}directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM).{% endtrans %}
     </p>
   {% endif %}
 

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4090,16 +4090,6 @@ msgstr "Incwm gwario yw'r ariansydd gennych ar ôl ar ôl i ni gynnwys rhai cost
 msgid "Family Mediation Council"
 msgstr ""
 
-#: cla_public/templates/checker/result/ineligible.html:57
-#, python-format
-msgid ""
-"\n"
-"        If you want to make an application to court about a family matter you need to first of all\n"
-"        see if family mediation will help. Use the %(family_mediation_link)s directory to find a mediator\n"
-"        and make an appointment for a Mediation Information and Assessment Meeting (MIAM).\n"
-"      "
-msgstr "Defnyddiwch gyfeirlyfr y Cyngor Cyfryngu Teuluol i ddod o hyd i gyfryngwr ac i wneud apwyntiad am Gyfarfod Gwybodaeth ac Asesu Cyfryngu (MIAM)."
-
 #: cla_public/templates/checker/result/ineligible.html:72
 msgid "A legal adviser may still be able to help"
 msgstr "Efallai y bydd cynghorydd cyfreithiol yn gallu helpu o hyd."
@@ -4967,6 +4957,10 @@ msgstr "Nid yw llinell gymorth CLA ar gael ar hyn o bryd"
 
 msgid "Book a call back or text ‘legalaid’ and your name to 80010 and we will contact you as soon as we can."
 msgstr "Trefnwch alwad yn ôl neu tecstiwch ‘legalaid’ a’ch enw at 80010 a byddwn mewn cysylltiad â chi cyn gynted ag y gallwn."
+
+msgid "If you want to make an application to court about a family matter you need to first of all see if family mediation will help. Use the {{ family_mediation_link }} directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM)."
+msgstr "Os ydych eisiau gwneud cais i'r llys am fater teuluol, mae angen i chi weld yn gyntaf a fydd cyfryngu teuluol yn helpu. Defnyddiwch gyfeirlyfr y
+Cyngor Cyfryngu Teuluol i ddod o hyd i gyfryngwr ac i wneud apwyntiad am Gyfarfod Gwybodaeth ac Asesu Cyfryngu (MIAM)."
 
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4961,6 +4961,9 @@ msgstr "Trefnwch alwad yn ôl neu tecstiwch ‘legalaid’ a’ch enw at 80010 a
 msgid "If you want to make an application to court about a family matter you need to first of all see if family mediation will help. Use the" 
 msgstr "Os ydych eisiau gwneud cais i'r llys am fater teuluol, mae angen i chi weld yn gyntaf a fydd cyfryngu teuluol yn helpu. Defnyddiwch gyfeirlyfr y"
 
+msgid "Family Mediation Council" 
+msgstr "Cyngor Cyfryngu Teuluol"
+
 msgid "directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM)."
 msgstr "i ddod o hyd i gyfryngwr ac i wneud apwyntiad am Gyfarfod Gwybodaeth ac Asesu Cyfryngu (MIAM)."
 

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4981,9 +4981,11 @@ msgid "Disposable income is the money you have left after we’ve accounted\n
 msgstr "Incwm gwario yw'r ariansydd gennych ar ôl ar ôl i ni gynnwys rhai costau byw, fel rhent neu daliadau morgais."
 
 msgid "If you want to make an application to court about a family matter you need to first of all\n
-        see if family mediation will help. Use the {{ family_mediation_link }} directory to find a mediator\n
-        and make an appointment for a Mediation Information and Assessment Meeting (MIAM)."
-msgstr "Os ydych eisiau gwneud cais i'r llys am fater teuluol, mae angen i chi weld yn gyntaf a fydd cyfryngu teuluol yn helpu. Defnyddiwch gyfeirlyfr y Cyngor Cyfryngu Teuluol i ddod o hyd i gyfryngwr ac i wneud apwyntiad am Gyfarfod Gwybodaeth ac Asesu Cyfryngu (MIAM)."
+        see if family mediation will help. Use the"
+msgstr "Os ydych eisiau gwneud cais i'r llys am fater teuluol, mae angen i chi weld yn gyntaf a fydd cyfryngu teuluol yn helpu. Defnyddiwch gyfeirlyfr y"
+
+msgid "directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM)."
+msgstr "i ddod o hyd i gyfryngwr ac i wneud apwyntiad am Gyfarfod Gwybodaeth ac Asesu Cyfryngu (MIAM)."
 
 msgid "You may still qualify for legal aid to seek a court order for protection. To find out if you
       might qualify, contact a legal adviser in your area."

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4088,7 +4088,7 @@ msgstr "Incwm gwario yw'r ariansydd gennych ar ôl ar ôl i ni gynnwys rhai cost
 
 #: cla_public/templates/checker/result/ineligible.html:57
 msgid "Family Mediation Council"
-msgstr ""
+msgstr "Cyngor Cyfryngu Teuluol"
 
 #: cla_public/templates/checker/result/ineligible.html:72
 msgid "A legal adviser may still be able to help"
@@ -4960,9 +4960,6 @@ msgstr "Trefnwch alwad yn ôl neu tecstiwch ‘legalaid’ a’ch enw at 80010 a
 
 msgid "If you want to make an application to court about a family matter you need to first of all see if family mediation will help. Use the" 
 msgstr "Os ydych eisiau gwneud cais i'r llys am fater teuluol, mae angen i chi weld yn gyntaf a fydd cyfryngu teuluol yn helpu. Defnyddiwch gyfeirlyfr y"
-
-msgid "Family Mediation Council" 
-msgstr "Cyngor Cyfryngu Teuluol"
 
 msgid "directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM)."
 msgstr "i ddod o hyd i gyfryngwr ac i wneud apwyntiad am Gyfarfod Gwybodaeth ac Asesu Cyfryngu (MIAM)."

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4968,6 +4968,27 @@ msgstr "Nid yw llinell gymorth CLA ar gael ar hyn o bryd"
 msgid "Book a call back or text ‘legalaid’ and your name to 80010 and we will contact you as soon as we can."
 msgstr "Trefnwch alwad yn ôl neu tecstiwch ‘legalaid’ a’ch enw at 80010 a byddwn mewn cysylltiad â chi cyn gynted ag y gallwn."
 
+msgid "gross income is more than\n
+      the maximum allowed"
+msgstr "mae eich incwm gros yn fwy na'r uchafswm sy’n cael ei ganiatáu"
+
+msgid "disposable income is\n
+      higher than the limit we allow"
+msgstr "mae eich incwm gwario yn uwch na'r terfyn sy’n cael ei ganiatáu"
+
+msgid "Disposable income is the money you have left after we’ve accounted\n
+      for certain living expenses, like rent or mortgage payments."
+msgstr "Incwm gwario yw'r ariansydd gennych ar ôl ar ôl i ni gynnwys rhai costau byw, fel rhent neu daliadau morgais."
+
+msgid "If you want to make an application to court about a family matter you need to first of all\n
+        see if family mediation will help. Use the {{ family_mediation_link }} directory to find a mediator\n
+        and make an appointment for a Mediation Information and Assessment Meeting (MIAM)."
+msgstr "Os ydych eisiau gwneud cais i'r llys am fater teuluol, mae angen i chi weld yn gyntaf a fydd cyfryngu teuluol yn helpu. Defnyddiwch gyfeirlyfr y Cyngor Cyfryngu Teuluol i ddod o hyd i gyfryngwr ac i wneud apwyntiad am Gyfarfod Gwybodaeth ac Asesu Cyfryngu (MIAM)."
+
+msgid "You may still qualify for legal aid to seek a court order for protection. To find out if you
+      might qualify, contact a legal adviser in your area."
+msgstr "Efallai y byddwch dal yn gymwys am gymorth cyfreithiol i ofyn am orchymyn llys i’ch amddiffyn. I weld os allwch chi fod yn gymwys, cysylltwch â chynghorydd cyfreithiol yn eich ardal."
+
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"
 

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4959,8 +4959,7 @@ msgid "Book a call back or text ‘legalaid’ and your name to 80010 and we wil
 msgstr "Trefnwch alwad yn ôl neu tecstiwch ‘legalaid’ a’ch enw at 80010 a byddwn mewn cysylltiad â chi cyn gynted ag y gallwn."
 
 msgid "If you want to make an application to court about a family matter you need to first of all see if family mediation will help. Use the {{ family_mediation_link }} directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM)."
-msgstr "Os ydych eisiau gwneud cais i'r llys am fater teuluol, mae angen i chi weld yn gyntaf a fydd cyfryngu teuluol yn helpu. Defnyddiwch gyfeirlyfr y
-Cyngor Cyfryngu Teuluol i ddod o hyd i gyfryngwr ac i wneud apwyntiad am Gyfarfod Gwybodaeth ac Asesu Cyfryngu (MIAM)."
+msgstr "Os ydych eisiau gwneud cais i'r llys am fater teuluol, mae angen i chi weld yn gyntaf a fydd cyfryngu teuluol yn helpu. Defnyddiwch gyfeirlyfr y Cyngor Cyfryngu Teuluol i ddod o hyd i gyfryngwr ac i wneud apwyntiad am Gyfarfod Gwybodaeth ac Asesu Cyfryngu (MIAM)."
 
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4066,13 +4066,13 @@ msgstr "gennych ormod o gyfalaf gwario"
 msgid ""
 "gross income is more than\n"
 "      the maximum allowed"
-msgstr ""
+msgstr "mae eich incwm gros yn fwy na'r uchafswm sy’n cael ei ganiatáu"
 
 #: cla_public/templates/checker/result/ineligible.html:36
 msgid ""
 "disposable income is\n"
 "      higher than the limit we allow"
-msgstr ""
+msgstr "mae eich incwm gwario yn uwch na'r terfyn sy’n cael ei ganiatáu"
 
 #: cla_public/templates/checker/result/ineligible.html:43
 msgid ""
@@ -4084,7 +4084,7 @@ msgstr "Mae cyfalaf gwario yn cynnwys cynilion, eitemau gwerthfawr a'r ecwiti yn
 msgid ""
 "Disposable income is the money you have left after we’ve accounted\n"
 "      for certain living expenses, like rent or mortgage payments."
-msgstr ""
+msgstr "Incwm gwario yw'r ariansydd gennych ar ôl ar ôl i ni gynnwys rhai costau byw, fel rhent neu daliadau morgais."
 
 #: cla_public/templates/checker/result/ineligible.html:57
 msgid "Family Mediation Council"
@@ -4968,20 +4968,8 @@ msgstr "Nid yw llinell gymorth CLA ar gael ar hyn o bryd"
 msgid "Book a call back or text ‘legalaid’ and your name to 80010 and we will contact you as soon as we can."
 msgstr "Trefnwch alwad yn ôl neu tecstiwch ‘legalaid’ a’ch enw at 80010 a byddwn mewn cysylltiad â chi cyn gynted ag y gallwn."
 
-msgid "gross income is more than\n
-      the maximum allowed"
-msgstr "mae eich incwm gros yn fwy na'r uchafswm sy’n cael ei ganiatáu"
-
-msgid "disposable income is\n
-      higher than the limit we allow"
-msgstr "mae eich incwm gwario yn uwch na'r terfyn sy’n cael ei ganiatáu"
-
-msgid "Disposable income is the money you have left after we’ve accounted\n
-      for certain living expenses, like rent or mortgage payments."
-msgstr "Incwm gwario yw'r ariansydd gennych ar ôl ar ôl i ni gynnwys rhai costau byw, fel rhent neu daliadau morgais."
-
-msgid "If you want to make an application to court about a family matter you need to first of all\n
-        see if family mediation will help. Use the"
+msgid "If you want to make an application to court about a family matter you need to first of all\n"
+"      see if family mediation will help. Use the"
 msgstr "Os ydych eisiau gwneud cais i'r llys am fater teuluol, mae angen i chi weld yn gyntaf a fydd cyfryngu teuluol yn helpu. Defnyddiwch gyfeirlyfr y"
 
 msgid "directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM)."

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4958,8 +4958,11 @@ msgstr "Nid yw llinell gymorth CLA ar gael ar hyn o bryd"
 msgid "Book a call back or text ‘legalaid’ and your name to 80010 and we will contact you as soon as we can."
 msgstr "Trefnwch alwad yn ôl neu tecstiwch ‘legalaid’ a’ch enw at 80010 a byddwn mewn cysylltiad â chi cyn gynted ag y gallwn."
 
-msgid "If you want to make an application to court about a family matter you need to first of all see if family mediation will help. Use the {{ family_mediation_link }} directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM)."
-msgstr "Os ydych eisiau gwneud cais i'r llys am fater teuluol, mae angen i chi weld yn gyntaf a fydd cyfryngu teuluol yn helpu. Defnyddiwch gyfeirlyfr y Cyngor Cyfryngu Teuluol i ddod o hyd i gyfryngwr ac i wneud apwyntiad am Gyfarfod Gwybodaeth ac Asesu Cyfryngu (MIAM)."
+msgid "If you want to make an application to court about a family matter you need to first of all see if family mediation will help. Use the" 
+msgstr "Os ydych eisiau gwneud cais i'r llys am fater teuluol, mae angen i chi weld yn gyntaf a fydd cyfryngu teuluol yn helpu. Defnyddiwch gyfeirlyfr y"
+
+msgid "directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM)."
+msgstr "i ddod o hyd i gyfryngwr ac i wneud apwyntiad am Gyfarfod Gwybodaeth ac Asesu Cyfryngu (MIAM)."
 
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4098,7 +4098,7 @@ msgid ""
 "        see if family mediation will help. Use the %(family_mediation_link)s directory to find a mediator\n"
 "        and make an appointment for a Mediation Information and Assessment Meeting (MIAM).\n"
 "      "
-msgstr ""
+msgstr "Defnyddiwch gyfeirlyfr y Cyngor Cyfryngu Teuluol i ddod o hyd i gyfryngwr ac i wneud apwyntiad am Gyfarfod Gwybodaeth ac Asesu Cyfryngu (MIAM)."
 
 #: cla_public/templates/checker/result/ineligible.html:72
 msgid "A legal adviser may still be able to help"
@@ -4108,7 +4108,7 @@ msgstr "Efallai y bydd cynghorydd cyfreithiol yn gallu helpu o hyd."
 msgid ""
 "You may still qualify for legal aid to seek a court order for protection. To find out if you\n"
 "      might qualify, contact a legal adviser in your area."
-msgstr ""
+msgstr "Efallai y byddwch dal yn gymwys am gymorth cyfreithiol i ofyn am orchymyn llys i’ch amddiffyn. I weld os allwch chi fod yn gymwys, cysylltwch â chynghorydd cyfreithiol yn eich ardal."
 
 #: cla_public/templates/checker/result/ineligible.html:80
 msgid "You can still ask a legal adviser for help – you will have to pay for their advice."
@@ -4967,17 +4967,6 @@ msgstr "Nid yw llinell gymorth CLA ar gael ar hyn o bryd"
 
 msgid "Book a call back or text ‘legalaid’ and your name to 80010 and we will contact you as soon as we can."
 msgstr "Trefnwch alwad yn ôl neu tecstiwch ‘legalaid’ a’ch enw at 80010 a byddwn mewn cysylltiad â chi cyn gynted ag y gallwn."
-
-msgid "If you want to make an application to court about a family matter you need to first of all\n"
-"      see if family mediation will help. Use the"
-msgstr "Os ydych eisiau gwneud cais i'r llys am fater teuluol, mae angen i chi weld yn gyntaf a fydd cyfryngu teuluol yn helpu. Defnyddiwch gyfeirlyfr y"
-
-msgid "directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM)."
-msgstr "i ddod o hyd i gyfryngwr ac i wneud apwyntiad am Gyfarfod Gwybodaeth ac Asesu Cyfryngu (MIAM)."
-
-msgid "You may still qualify for legal aid to seek a court order for protection. To find out if you
-      might qualify, contact a legal adviser in your area."
-msgstr "Efallai y byddwch dal yn gymwys am gymorth cyfreithiol i ofyn am orchymyn llys i’ch amddiffyn. I weld os allwch chi fod yn gymwys, cysylltwch â chynghorydd cyfreithiol yn eich ardal."
 
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"


### PR DESCRIPTION
## What does this pull request do?

Adds Welsh translations for journeys where the user is ineligible for means for exceeding maximum income and disposable income.

## Any other changes that would benefit highlighting?

The commits reflect that it was tricky to get the translations to appear and the link wasn't displaying correctly in the English version.

## Checklist

https://dsdmoj.atlassian.net/browse/LGA-1710
