### PR TITLE
LGA-1753 CLA Public Family changes

### DIFF
--- a/cla_public/apps/checker/views.py
+++ b/cla_public/apps/checker/views.py
@@ -3,7 +3,7 @@
 import logging
 
 from cla_common.constants import ELIGIBILITY_REASONS
-from flask import abort, render_template, redirect, session, url_for, views, request
+from flask import abort, render_template, redirect, session, url_for, views, request, current_app
 from flask.ext.babel import lazy_gettext as _
 from wtforms.validators import StopValidation
 
@@ -364,7 +364,13 @@ class Eligible(HasFormMixin, RequiresSession, views.MethodView, object):
 
         current_step = {"count": len(steps) + 1, "is_current": True, "is_completed": False}
 
-        return render_template("checker/result/eligible.html", current_step=current_step, steps=steps, form=self.form)
+        return render_template(
+            "checker/result/eligible.html",
+            current_step=current_step,
+            steps=steps,
+            form=self.form,
+            family_issue_flag=current_app.config["FAMILY_ISSUE_FEATURE_FLAG"],
+        )
 
 
 checker.add_url_rule("/result/eligible", view_func=Eligible.as_view("eligible"), methods=("GET", "POST"))

--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -11,6 +11,9 @@ DEBUG = False
 # Sets whether the emergency message displays on the contact page or not
 EMERGENCY_MESSAGE_ON = os.environ.get("EMERGENCY_MESSAGE_ON", "False") == "True"
 
+# Sets whether the updated family issue text displays on the outcome (/result/eligible or /result/provisional) pages or not
+FAMILY_ISSUE_FEATURE_FLAG = os.environ.get("FAMILY_ISSUE_FEATURE_FLAG", "False") == "True"
+
 TESTING = False
 
 CLEAR_SESSION = True

--- a/cla_public/templates/checker/result/eligible.html
+++ b/cla_public/templates/checker/result/eligible.html
@@ -2,22 +2,28 @@
 
 {% import "macros/element.html" as Element %}
 
+{% if session.checker["category"] == "family" and family_issue_flag == True %}
+  {% set first_paragraph =
+    """To decide whether you might qualify for legal aid, we need more information about
+      your financial circumstances. Contact Civil Legal Advice (CLA), a national helpline for England and
+      Wales to get help to find a legal advisor in your area if you do."""
+  -%}
+{% else %}
+  {% set first_paragraph =
+    """To decide whether you might qualify for legal aid, we need more information about
+      your financial circumstances. Contact Civil Legal Advice (CLA), a national helpline for England and
+      Wales to get specialist advice."""
+  %}
+{% endif %}
+
 {% block page_text %}
   <h1 class="govuk-heading-xl">
     {% trans %}Contact Civil Legal Advice{% endtrans %}
   </h1>
   {% if session.checker.need_more_info %}
-    <p class="govuk-body">
-      {% trans %}To decide whether you might qualify for legal aid, we need more information about
-      your financial circumstances. Contact Civil Legal Advice (CLA), a national helpline for England and
-      Wales to get specialist advice.{% endtrans %}
-    </p>
+    <p class="govuk-body">{{ _(first_paragraph) }}</p>
   {% else %}
-    <p class="govuk-body">
-      {% trans %}Based on the answers you’ve given today, you might qualify for legal aid.
-      Contact Civil Legal Advice (CLA), a national helpline for England and
-      Wales, to confirm that you qualify, and get specialist advice if you do.{% endtrans %}
-    </p>
+    <p class="govuk-body">{{ _(first_paragraph) }}</p>
     <p class="govuk-body">
       {% trans %}In some cases, you may need to pay a contribution towards your legal aid.{% endtrans %}
     </p>

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -3877,6 +3877,13 @@ msgid ""
 "        advice."
 msgstr "Os nad ydych yn gymwys i gael Cymorth Cyfreithiol, bydd rhaid ichi dalu am gyngor cyfreithiol. Dylech holi gyda’ch cynghorydd am gost eu cyngor."
 
+#: cla_public/templates/checker/result/eligible.html:5
+msgid ""
+"To decide whether you might qualify for legal aid, we need more information about\n"
+"      your financial circumstances. Contact Civil Legal Advice (CLA), a national helpline for England and\n"
+"      Wales to get help to find a legal advisor in your area if you do."
+msgstr ""
+
 #: cla_public/templates/checker/result/eligible.html:11
 msgid ""
 "To decide whether you might qualify for legal aid, we need more information about\n"
@@ -4958,7 +4965,7 @@ msgstr "Nid yw llinell gymorth CLA ar gael ar hyn o bryd"
 msgid "Book a call back or text ‘legalaid’ and your name to 80010 and we will contact you as soon as we can."
 msgstr "Trefnwch alwad yn ôl neu tecstiwch ‘legalaid’ a’ch enw at 80010 a byddwn mewn cysylltiad â chi cyn gynted ag y gallwn."
 
-msgid "If you want to make an application to court about a family matter you need to first of all see if family mediation will help. Use the" 
+msgid "If you want to make an application to court about a family matter you need to first of all see if family mediation will help. Use the"
 msgstr "Os ydych eisiau gwneud cais i'r llys am fater teuluol, mae angen i chi weld yn gyntaf a fydd cyfryngu teuluol yn helpu. Defnyddiwch gyfeirlyfr y"
 
 msgid "directory to find a mediator and make an appointment for a Mediation Information and Assessment Meeting (MIAM)."

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -3312,6 +3312,13 @@ msgid ""
 "        advice."
 msgstr ""
 
+#: cla_public/templates/checker/result/eligible.html:5
+msgid ""
+"To decide whether you might qualify for legal aid, we need more information about\n"
+"      your financial circumstances. Contact Civil Legal Advice (CLA), a national helpline for England and\n"
+"      Wales to get help to find a legal advisor in your area if you do."
+msgstr ""
+
 #: cla_public/templates/checker/result/eligible.html:11
 msgid ""
 "To decide whether you might qualify for legal aid, we need more information about\n"

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -3170,6 +3170,13 @@ msgid ""
 "        advice."
 msgstr ""
 
+#: cla_public/templates/checker/result/eligible.html:5
+msgid ""
+"To decide whether you might qualify for legal aid, we need more information about\n"
+"      your financial circumstances. Contact Civil Legal Advice (CLA), a national helpline for England and\n"
+"      Wales to get help to find a legal advisor in your area if you do."
+msgstr ""
+
 #: cla_public/templates/checker/result/eligible.html:11
 msgid ""
 "To decide whether you might qualify for legal aid, we need more information about\n"

--- a/helm_deploy/cla-public/values.yaml
+++ b/helm_deploy/cla-public/values.yaml
@@ -65,4 +65,7 @@ envVars:
     configmap:
       name: emergency-message
       key: message-on
-
+  FAMILY_ISSUE_FEATURE_FLAG:
+    configmap:
+      name: family-issue
+      key: family-issue-on


### PR DESCRIPTION
## What does this pull request do?

- Makes the first paragraph text on the `/results/eliglble` and `/results/provisional` page dynamic based off whether the category is `family` and whether the `family_issue_feature_flag` is True
- Adds a `family_issue_feature_flag` as a Kubernetes config map and django setting variable. When we eventually go live, this will get turnt on (set to True)
- Adds the new family text to the translation files (currently it is there as a placeholder till we get the Welsh translations for them)

## Any other changes that would benefit highlighting?

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
