### PR TITLE
LGA-1812 Change thickness of links in line with latest GDS guidelines

### DIFF
--- a/cla_public/static-src/stylesheets/main.scss
+++ b/cla_public/static-src/stylesheets/main.scss
@@ -9,6 +9,7 @@ $govuk-images-path: "/static/images/";
 $govuk-fonts-path: "/static/images/fonts/";
 $govuk-use-legacy-font: false;
 $govuk-typography-use-rem: false;
+$govuk-new-link-styles: true;
 @import "govuk/all";
 
 /**


### PR DESCRIPTION
## What does this pull request do?

- Use new link changes by setting sass variable `$govuk-new-link-styles` to `true`

## Any other changes that would benefit highlighting?

Has to be imported above `govuk/all` so it does not get overwritten 

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
