### PR TITLE
LGA-1895 - Add external DNS annotations to ingress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,25 +104,25 @@ jobs:
     steps:
       # Add the necessary steps to deploy your website.
       - checkout
-      - run: 
+      - run:
           name: Delete existing javascript packages
-          command: | 
+          command: |
             rm -rf node_modules package.json package-lock.json
-      - run: 
+      - run:
           name: Extract staging URL
-          command: | 
+          command: |
             source .circleci/define_build_environment_variables
             echo "export RELEASE_HOST=$CLEANED_BRANCH_NAME.$STAGING_HOST" >> $BASH_ENV
-      - run: 
+      - run:
           name: Install cypress and axe-core
-          command: | 
+          command: |
             npm i cypress
             npm i cypress-downloadfile
-            npm i cypress-log-to-output   
+            npm i cypress-log-to-output
             npm i axe-core
-      - run: 
+      - run:
           name: Run accessibility test
-          command: | 
+          command: |
             mkdir ~/project/cypress/pages
             node node_modules/.bin/cypress run --env UAT_URL=https://$RELEASE_HOST/start --spec "cypress/integration/happy-path.spec.js"
       - store_artifacts:
@@ -198,6 +198,8 @@ jobs:
             - deploy:
                 name: Deploy laa-cla-public to fixed staging
                 command: |
+                  export INGRESS_CLUSTER_NAME=`kubectl get configmap ingress-cluster -o jsonpath='{.data.name}'`
+                  export INGRESS_CLUSTER_WEIGHT=`kubectl get configmap ingress-cluster -o jsonpath='{.data.weight}'`
                   source .circleci/define_build_environment_variables
                   ./bin/staging_deploy.sh
                   echo "export RELEASE_HOST=$STAGING_HOST" >> $BASH_ENV
@@ -207,6 +209,8 @@ jobs:
             - deploy:
                 name: Deploy laa-cla-public to multideploy staging
                 command: |
+                  export INGRESS_CLUSTER_NAME=`kubectl get configmap ingress-cluster -o jsonpath='{.data.name}'`
+                  export INGRESS_CLUSTER_WEIGHT=`kubectl get configmap ingress-cluster -o jsonpath='{.data.weight}'`
                   source .circleci/define_build_environment_variables
                   ./bin/staging_multideploy.sh
                   echo "export RELEASE_HOST=$CLEANED_BRANCH_NAME.$STAGING_HOST" >> $BASH_ENV
@@ -255,6 +259,8 @@ jobs:
       - deploy:
           name: Deploy laa-cla-public to production
           command: |
+            export INGRESS_CLUSTER_NAME=`kubectl get configmap ingress-cluster -o jsonpath='{.data.name}'`
+            export INGRESS_CLUSTER_WEIGHT=`kubectl get configmap ingress-cluster -o jsonpath='{.data.weight}'`
             source .circleci/define_build_environment_variables
             ./bin/production_deploy.sh
       - slack/notify:

--- a/bin/production_deploy.sh
+++ b/bin/production_deploy.sh
@@ -9,6 +9,8 @@ helm upgrade cla-public \
   --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} \
   --values ${HELM_DIR}/values-production.yaml \
   --set host=$PRODUCTION_HOST \
+  --set ingress.cluster.name=${INGRESS_CLUSTER_NAME} \
+  --set ingress.cluster.weight=${INGRESS_CLUSTER_WEIGHT} \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --force \

--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -9,6 +9,8 @@ helm upgrade cla-public \
   --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
   --values ${HELM_DIR}/values-staging.yaml \
   --set host=$STAGING_HOST \
+  --set ingress.cluster.name=${INGRESS_CLUSTER_NAME} \
+  --set ingress.cluster.weight=${INGRESS_CLUSTER_WEIGHT} \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \
   --force \

--- a/bin/staging_multideploy.sh
+++ b/bin/staging_multideploy.sh
@@ -11,6 +11,8 @@ helm upgrade $CLEANED_BRANCH_NAME \
   --set fullnameOverride=$CLEANED_BRANCH_NAME \
   --set environment=$CLEANED_BRANCH_NAME \
   --set host=$CLEANED_BRANCH_NAME.$STAGING_HOST \
+  --set ingress.cluster.name=${INGRESS_CLUSTER_NAME} \
+  --set ingress.cluster.weight=${INGRESS_CLUSTER_WEIGHT} \
   --set ingress.secretName=tls-wildcard-certificate \
   --set image.repository=$DOCKER_REPOSITORY \
   --set image.tag=$IMAGE_TAG \

--- a/helm_deploy/cla-public/templates/ingress.yaml
+++ b/helm_deploy/cla-public/templates/ingress.yaml
@@ -7,8 +7,12 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "cla-public.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    {{- if .Values.ingress.cluster.name }}
+    external-dns.alpha.kubernetes.io/set-identifier: "{{ $fullName }}-{{ .Release.Namespace }}-{{- .Values.ingress.cluster.name -}}"
+    external-dns.alpha.kubernetes.io/aws-weight: "{{- .Values.ingress.cluster.weight -}}"
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/helm_deploy/cla-public/values.yaml
+++ b/helm_deploy/cla-public/values.yaml
@@ -24,6 +24,9 @@ dashboard:
 ingress:
   enabled: false
   annotations: {}
+  cluster:
+    name: ~
+    weight: ~
   tls: []
 
 envVars:


### PR DESCRIPTION
## What does this pull request do?

- Add variable placeholders for cluster `name` and `weight` in `values.yaml`
- Add annotations to `ingress.yml` referencing the variables above
- Add parameters to all deployment scripts for setting (overriding) the cluster `name` and `weight` in `values.yaml`
- Create a `ingress-cluster` configmap with following values
    - `name` The cluster name i.e `blue` or `green`
    - `weight` The weighting of traffic that cluster should receive
- Update the circle config to read contents of `ingress-cluster` configmap and pass it to the deploy scripts as environment variables.

## Any other changes that would benefit highlighting?

Similar to https://github.com/ministryofjustice/cla_backend/pull/736

Command used to create configmap: `kubectl create configmap ingress-cluster --from-literal=name=blue --from-literal=weight=100`

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
