### PR TITLE
LGA-1925 deploy staging to live

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,6 +288,34 @@ workflows:
           context:
             - laa-cla-public-live-1
             - laa-cla-public-live1-staging
+          name: staging_deploy_master_live1
+          multideploy: false
+          filters:
+            branches:
+              only:
+                - master
+      - staging_deploy:
+          name: staging_deploy_live1
+          requires:
+            - build
+            - staging_deploy_approval
+          context:
+            - laa-cla-public-live-1
+            - laa-cla-public-live1-staging
+          multideploy: true
+          filters:
+            branches:
+              ignore:
+                - master
+
+      # Deploy staging to live (both master and feature branches)
+      - staging_deploy:
+          requires:
+            - build
+            - staging_deploy_approval
+          context:
+            - laa-cla-public-live-1
+            - laa-cla-public-live-staging
           name: staging_deploy_master
           multideploy: false
           filters:
@@ -300,12 +328,13 @@ workflows:
             - staging_deploy_approval
           context:
             - laa-cla-public-live-1
-            - laa-cla-public-live1-staging
+            - laa-cla-public-live-staging
           multideploy: true
           filters:
             branches:
               ignore:
                 - master
+
       - accessibility-test:
           requires:
             - staging_deploy


### PR DESCRIPTION
## What does this pull request do?

Deploy staging to live
Rename live-1 staging deployments with a suffix of `live1`

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
