### PR TITLE
LGA-1914 - Remove setup kube auth

### DIFF
--- a/.circleci/authenticate_with_kubernetes_cluster
+++ b/.circleci/authenticate_with_kubernetes_cluster
@@ -1,0 +1,8 @@
+#!/bin/sh -eu
+
+echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt
+kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=./ca.crt --server=${K8S_SERVER_ADDRESS}
+kubectl config set-credentials circleci --token=${K8S_TOKEN}
+kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=circleci --namespace=${K8S_NAMESPACE}
+kubectl config use-context ${K8S_CLUSTER_NAME}
+kubectl --namespace=${K8S_NAMESPACE} get pods

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,10 +188,8 @@ jobs:
             tar -zxvf helm-v3.1.2-linux-amd64.tar.gz
             mv linux-amd64/helm /usr/local/bin/helm
       - run:
-          name: Initialise Kubernetes staging context
-          command: |
-            setup-kube-auth
-            kubectl config use-context staging
+          name: Authenticate with cluster
+          command: .circleci/authenticate_with_kubernetes_cluster
       - unless:
           condition: << parameters.multideploy >>
           steps:
@@ -231,10 +229,8 @@ jobs:
             tar -zxvf helm-v3.1.2-linux-amd64.tar.gz
             mv linux-amd64/helm /usr/local/bin/helm
       - run:
-          name: Initialise Kubernetes staging context
-          command: |
-            setup-kube-auth
-            kubectl config use-context staging
+          name: Authenticate with cluster
+          command: .circleci/authenticate_with_kubernetes_cluster
       - run:
           name: Delete staging release
           command: |
@@ -252,10 +248,8 @@ jobs:
             tar -zxvf helm-v3.1.2-linux-amd64.tar.gz
             mv linux-amd64/helm /usr/local/bin/helm
       - run:
-          name: Initialise Kubernetes production context
-          command: |
-            setup-kube-auth
-            kubectl config use-context production
+          name: Authenticate with cluster
+          command: .circleci/authenticate_with_kubernetes_cluster
       - deploy:
           name: Deploy laa-cla-public to production
           command: |
@@ -276,7 +270,9 @@ workflows:
       - lint-with-py3-tools
       - test
       - cleanup_merged:
-          context: laa-cla-public-live-1
+          context:
+            - laa-cla-public-live-1
+            - laa-cla-public-live1-staging
       - build:
           requires:
             - lint-with-py2-tools
@@ -289,7 +285,9 @@ workflows:
           requires:
             - build
             - staging_deploy_approval
-          context: laa-cla-public-live-1
+          context:
+            - laa-cla-public-live-1
+            - laa-cla-public-live1-staging
           name: staging_deploy_master
           multideploy: false
           filters:
@@ -300,7 +298,9 @@ workflows:
           requires:
             - build
             - staging_deploy_approval
-          context: laa-cla-public-live-1
+          context:
+            - laa-cla-public-live-1
+            - laa-cla-public-live1-staging
           multideploy: true
           filters:
             branches:
@@ -320,4 +320,6 @@ workflows:
       - production_deploy:
           requires:
             - production_deploy_approval
-          context: laa-cla-public-live-1
+          context:
+            - laa-cla-public-live-1
+            - laa-cla-public-live1-production


### PR DESCRIPTION
## What does this pull request do?

Removes the use of the `setup-kube-auth` script
Specifies additional contexts so that each step can have only the kubernetes env vars it needs
Creates and uses a script to authenticate with the kubernetes cluster given the presence of these env vars

## Any other changes that would benefit highlighting?

The staging_deploy and production_deploy steps could be consolidated but it's not strictly in the scope of this and I'm pressed for time so I left it for now

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
