### PR TITLE
Update to latest version of cla_common which contains xmas operating hours

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ PyYAML==3.11
 Werkzeug==0.9.6
 argparse==1.2.1
 blinker==1.3
-git+git://github.com/ministryofjustice/cla_common.git@0.3.14#egg=cla_common
+git+git://github.com/ministryofjustice/cla_common.git@0.3.17#egg=cla_common
 speaklater==1.3 # Required by cla_common
 itsdangerous==0.24
 logstash_formatter==0.5.9


### PR DESCRIPTION
## What does this pull request do?

Update to latest version of cla_common which contains xmas operating hours

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
