### PR TITLE
LGA-1938-remove-deprecated-extensions-ingress-api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,8 +184,8 @@ jobs:
       - run:
           name: Install helm v3
           command: |
-            wget https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz
-            tar -zxvf helm-v3.1.2-linux-amd64.tar.gz
+            wget https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz
+            tar -zxvf helm-v3.2.4-linux-amd64.tar.gz
             mv linux-amd64/helm /usr/local/bin/helm
       - run:
           name: Authenticate with cluster
@@ -225,8 +225,8 @@ jobs:
       - run:
           name: Install helm v3
           command: |
-            wget https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz
-            tar -zxvf helm-v3.1.2-linux-amd64.tar.gz
+            wget https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz
+            tar -zxvf helm-v3.2.4-linux-amd64.tar.gz
             mv linux-amd64/helm /usr/local/bin/helm
       - run:
           name: Authenticate with cluster
@@ -244,8 +244,8 @@ jobs:
       - run:
           name: Install helm v3
           command: |
-            wget https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz
-            tar -zxvf helm-v3.1.2-linux-amd64.tar.gz
+            wget https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz
+            tar -zxvf helm-v3.2.4-linux-amd64.tar.gz
             mv linux-amd64/helm /usr/local/bin/helm
       - run:
           name: Authenticate with cluster

--- a/helm_deploy/cla-public/templates/ingress.yaml
+++ b/helm_deploy/cla-public/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
           - path: "/"
             pathType: ImplementationSpecific
             backend:
-              service
+              service:
                 name: {{ $fullName }}-app
                 port:
                   number: {{ $svcPort }}

--- a/helm_deploy/cla-public/templates/ingress.yaml
+++ b/helm_deploy/cla-public/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cla-public.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -25,7 +25,10 @@ spec:
       http:
         paths:
           - path: "/"
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}-app
-              servicePort: {{ $svcPort }}
+              service
+                name: {{ $fullName }}-app
+                port:
+                  number: {{ $svcPort }}
 {{- end }}


### PR DESCRIPTION
## What does this pull request do?

updated ingress api version and also upgraded helm version to avoid helm bug when trying to reuse a existing resource

## Any other changes that would benefit highlighting?

Need to manually annotate existing ingress resources in all namespaces before running workflows:
NAME=***
RELEASE=***
NAMESPACE=***
kubectl annotate $KIND $NAME meta.helm.sh/release-name=$RELEASE
kubectl annotate $KIND $NAME meta.helm.sh/release-namespace=$NAMESPACE

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
