### PR TITLE
LGA-2125 updated ingress so that modsec ignores json

### DIFF
--- a/helm_deploy/cla-public/templates/ingress.yaml
+++ b/helm_deploy/cla-public/templates/ingress.yaml
@@ -20,6 +20,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleRemoveById 200001
 spec:
   ingressClassName: "modsec"
   tls:


### PR DESCRIPTION
## What does this pull request do?

updated ingress so that modsec ignores json to see if this is causing increase in sentry issues.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
