### PR TITLE
Feature/lga 2302 remove pre select callback datetime

### DIFF
--- a/accessibility_tests/cypress/README.md
+++ b/accessibility_tests/cypress/README.md
@@ -1,3 +1,15 @@
-Requires
+# Helpful links:
+- [Crypess](https://docs.cypress.io/guides/getting-started/installing-cypress)
+- [NVM](https://github.com/nvm-sh/nvm)
+- 
+# Requires
  - node version v16.13.1 (npm 8.1.2)
+
+# How to run:
+
+Npm install required version in accessibility_tests directory.
+Make sure to use NVM (Node Version Manager) when doing so to set to correct Node version.
+
+To run tests:
+`./node_modules/.bin/cypress run`
 

--- a/accessibility_tests/cypress/README.md
+++ b/accessibility_tests/cypress/README.md
@@ -1,5 +1,5 @@
 # Helpful links:
-- [Crypess](https://docs.cypress.io/guides/getting-started/installing-cypress)
+- [Cypress](https://docs.cypress.io/guides/getting-started/installing-cypress)
 - [NVM](https://github.com/nvm-sh/nvm)
 - 
 # Requires

--- a/cla_public/apps/checker/forms.py
+++ b/cla_public/apps/checker/forms.py
@@ -199,7 +199,7 @@ class YourBenefitsForm(BaseForm):
         label=_(u"If yes, enter the total amount you get for all your children"),
         choices=money_intervals("", "per_week", "per_4week"),
         validators=[
-            IgnoreIf("benefits", FieldValueNotIn("child_benefit"),),
+            IgnoreIf("benefits", FieldValueNotIn("child_benefit")),
             MoneyIntervalAmountRequired(
                 message=_(u"Enter the Child Benefit you receive"),
                 freq_message=_(u"Tell us how often you receive Child Benefit"),

--- a/cla_public/apps/checker/tests/test_payloads.py
+++ b/cla_public/apps/checker/tests/test_payloads.py
@@ -410,6 +410,8 @@ class TestApiPayloads(FlaskAppTestCase):
             "contact_number": "00000000000",
             "relationship": parent_guardian,
         }
+        form_data["thirdparty-time-specific_day"] = form_data["callback-time-specific_day"]
+        form_data["thirdparty-time-time_today"] = form_data["callback-time-time_today"]
         form_data.update(flatten_dict("thirdparty", thirdparty))
 
         with override_current_time(self.now):

--- a/cla_public/apps/checker/tests/test_payloads.py
+++ b/cla_public/apps/checker/tests/test_payloads.py
@@ -413,6 +413,10 @@ class TestApiPayloads(FlaskAppTestCase):
         form_data["thirdparty-time-specific_day"] = form_data["callback-time-specific_day"]
         form_data["thirdparty-time-time_today"] = form_data["callback-time-time_today"]
         form_data.update(flatten_dict("thirdparty", thirdparty))
+        # this form should not pass in callback
+        form_data.pop("callback-contact_number")
+        form_data.pop("callback-time-specific_day")
+        form_data.pop("callback-time-time_today")
 
         with override_current_time(self.now):
             payload = self.form_payload(ContactForm, form_data)

--- a/cla_public/apps/contact/constants.py
+++ b/cla_public/apps/contact/constants.py
@@ -7,7 +7,7 @@ from flask.ext.babel import lazy_gettext as _
 DAY_TODAY = "today"
 DAY_SPECIFIC = "specific_day"
 DAY_CHOICES = ((DAY_TODAY, _("Call today")), (DAY_SPECIFIC, _("Call on another day")))
-SELECT_OPTION_DEFAULT = [("", "-- Please select --")]
+SELECT_OPTION_DEFAULT = [("", _("-- Please select --"))]
 TIME_TODAY_VALIDATION_ERROR = u"Select what time you want to be called today"
 DAY_SPECIFIC_VALIDATION_ERROR = u"Select which day you want to be called"
 TIME_SPECIFIC_VALIDATION_ERROR = u"Select what time you want to be called"

--- a/cla_public/apps/contact/constants.py
+++ b/cla_public/apps/contact/constants.py
@@ -8,3 +8,6 @@ DAY_TODAY = "today"
 DAY_SPECIFIC = "specific_day"
 DAY_CHOICES = ((DAY_TODAY, _("Call today")), (DAY_SPECIFIC, _("Call on another day")))
 SELECT_OPTION_DEFAULT = [("", "-- Please select --")]
+TIME_TODAY_VALIDATION_ERROR = u"Select what time you want to be called today"
+DAY_SPECIFIC_VALIDATION_ERROR = u"Select which day you want to be called"
+TIME_SPECIFIC_VALIDATION_ERROR = u"Select what time you want to be called"

--- a/cla_public/apps/contact/constants.py
+++ b/cla_public/apps/contact/constants.py
@@ -7,3 +7,4 @@ from flask.ext.babel import lazy_gettext as _
 DAY_TODAY = "today"
 DAY_SPECIFIC = "specific_day"
 DAY_CHOICES = ((DAY_TODAY, _("Call today")), (DAY_SPECIFIC, _("Call on another day")))
+SELECT_OPTION_DEFAULT = [("", "-- Please select --")]

--- a/cla_public/apps/contact/fields.py
+++ b/cla_public/apps/contact/fields.py
@@ -96,12 +96,12 @@ class TimeChoiceField(FormattedChoiceField, SelectField):
         super(TimeChoiceField, self).__init__(validators=validators, **kwargs)
         self.choices = map(time_choice, choices_callback())
         append_default_option_to_list(self.choices, SELECT_OPTION_DEFAULT)
-        self.default = self.choices
+        self.default = SELECT_OPTION_DEFAULT[0][0]
 
     def set_day_choices(self, day):
         self.choices = time_slots_for_day(day)
         append_default_option_to_list(self.choices, SELECT_OPTION_DEFAULT)
-        self.default = self.choices
+        self.default = SELECT_OPTION_DEFAULT[0][0]
 
     def process_data(self, value):
         if isinstance(value, basestring):

--- a/cla_public/apps/contact/fields.py
+++ b/cla_public/apps/contact/fields.py
@@ -95,11 +95,13 @@ class TimeChoiceField(FormattedChoiceField, SelectField):
     def __init__(self, choices_callback=None, validators=None, **kwargs):
         super(TimeChoiceField, self).__init__(validators=validators, **kwargs)
         self.choices = map(time_choice, choices_callback())
-        append_default_option_to_list(self.choices, SELECT_OPTION_DEFAULT)
+        if self.choices:
+            append_default_option_to_list(self.choices, SELECT_OPTION_DEFAULT)
 
     def set_day_choices(self, day):
         self.choices = time_slots_for_day(day)
-        append_default_option_to_list(self.choices, SELECT_OPTION_DEFAULT)
+        if self.choices:
+            append_default_option_to_list(self.choices, SELECT_OPTION_DEFAULT)
 
     def process_data(self, value):
         if isinstance(value, basestring):

--- a/cla_public/apps/contact/fields.py
+++ b/cla_public/apps/contact/fields.py
@@ -96,12 +96,10 @@ class TimeChoiceField(FormattedChoiceField, SelectField):
         super(TimeChoiceField, self).__init__(validators=validators, **kwargs)
         self.choices = map(time_choice, choices_callback())
         append_default_option_to_list(self.choices, SELECT_OPTION_DEFAULT)
-        self.default = SELECT_OPTION_DEFAULT[0][0]
 
     def set_day_choices(self, day):
         self.choices = time_slots_for_day(day)
         append_default_option_to_list(self.choices, SELECT_OPTION_DEFAULT)
-        self.default = SELECT_OPTION_DEFAULT[0][0]
 
     def process_data(self, value):
         if isinstance(value, basestring):

--- a/cla_public/apps/contact/fields.py
+++ b/cla_public/apps/contact/fields.py
@@ -19,9 +19,6 @@ from cla_public.libs.call_centre_availability import day_choice, time_choice
 
 OPERATOR_HOURS = OpeningHours(**CALL_CENTRE_OPERATOR_HOURS)
 
-# array of errors raised
-ERRORS_RAISED = []
-
 
 class FormattedChoiceField(object):
     """
@@ -96,16 +93,15 @@ class TimeChoiceField(FormattedChoiceField, SelectField):
     """
 
     def __init__(self, choices_callback=None, validators=None, **kwargs):
-        """choices_callback is the datetime day argument"""
         super(TimeChoiceField, self).__init__(validators=validators, **kwargs)
         self.choices = map(time_choice, choices_callback())
         append_default_option_to_list(self.choices, SELECT_OPTION_DEFAULT)
-        self.default = self.choices[0][0]
+        self.default = self.choices
 
     def set_day_choices(self, day):
         self.choices = time_slots_for_day(day)
         append_default_option_to_list(self.choices, SELECT_OPTION_DEFAULT)
-        self.default = self.choices[0][0]
+        self.default = self.choices
 
     def process_data(self, value):
         if isinstance(value, basestring):
@@ -161,21 +157,21 @@ class AvailabilityCheckerForm(NoCsrfForm):
         OPERATOR_HOURS.today_slots,
         validators=[
             IgnoreIf("specific_day", FieldValueNot(DAY_TODAY)),
-            InputRequired(message=_(u"Select a callback time for today")),
+            InputRequired(message=_(u"Select what time to ring you back")),
             AvailableSlot(DAY_TODAY),
         ],
     )
     day = DayChoiceField(
         validators=[
             IgnoreIf("specific_day", FieldValueNot(DAY_SPECIFIC)),
-            InputRequired(message=_(u"Select a day to callback")),
+            InputRequired(message=_(u"Select what day to ring you back")),
         ]
     )
     time_in_day = TimeChoiceField(
         OPERATOR_HOURS.time_slots,
         validators=[
             IgnoreIf("specific_day", FieldValueNot(DAY_SPECIFIC)),
-            InputRequired(message=_(u"Select a time to callback")),
+            InputRequired(message=_(u"Select what time to ring you back")),
             AvailableSlot(DAY_SPECIFIC),
         ],
     )

--- a/cla_public/apps/contact/fields.py
+++ b/cla_public/apps/contact/fields.py
@@ -13,7 +13,15 @@ from cla_common import call_centre_availability
 from cla_common.call_centre_availability import OpeningHours
 from cla_common.constants import OPERATOR_HOURS as CALL_CENTRE_OPERATOR_HOURS
 from cla_public.apps.contact.helper import append_default_option_to_list
-from cla_public.apps.contact.constants import DAY_CHOICES, DAY_TODAY, DAY_SPECIFIC, SELECT_OPTION_DEFAULT
+from cla_public.apps.contact.constants import (
+    DAY_CHOICES,
+    DAY_TODAY,
+    DAY_SPECIFIC,
+    SELECT_OPTION_DEFAULT,
+    TIME_TODAY_VALIDATION_ERROR,
+    DAY_SPECIFIC_VALIDATION_ERROR,
+    TIME_SPECIFIC_VALIDATION_ERROR,
+)
 from cla_public.apps.checker.validators import IgnoreIf, FieldValueNot
 from cla_public.libs.call_centre_availability import day_choice, time_choice
 
@@ -157,21 +165,21 @@ class AvailabilityCheckerForm(NoCsrfForm):
         OPERATOR_HOURS.today_slots,
         validators=[
             IgnoreIf("specific_day", FieldValueNot(DAY_TODAY)),
-            InputRequired(message=_(u"Select what time to ring you back")),
+            InputRequired(message=_(TIME_TODAY_VALIDATION_ERROR)),
             AvailableSlot(DAY_TODAY),
         ],
     )
     day = DayChoiceField(
         validators=[
             IgnoreIf("specific_day", FieldValueNot(DAY_SPECIFIC)),
-            InputRequired(message=_(u"Select what day to ring you back")),
+            InputRequired(message=_(DAY_SPECIFIC_VALIDATION_ERROR)),
         ]
     )
     time_in_day = TimeChoiceField(
         OPERATOR_HOURS.time_slots,
         validators=[
             IgnoreIf("specific_day", FieldValueNot(DAY_SPECIFIC)),
-            InputRequired(message=_(u"Select what time to ring you back")),
+            InputRequired(message=_(TIME_SPECIFIC_VALIDATION_ERROR)),
             AvailableSlot(DAY_SPECIFIC),
         ],
     )
@@ -180,8 +188,6 @@ class AvailabilityCheckerForm(NoCsrfForm):
         super(AvailabilityCheckerForm, self).__init__(*args, **kwargs)
         if not self.time_today.choices:
             self.specific_day.data = DAY_SPECIFIC
-        # day = datetime.datetime.strptime(self.day.day_choices[0][0], "%Y%m%d").date()
-        # self.time_in_day.set_day_choices(day)
 
     def scheduled_time(self, today=None):
         """

--- a/cla_public/apps/contact/fields.py
+++ b/cla_public/apps/contact/fields.py
@@ -11,7 +11,7 @@ from wtforms.validators import InputRequired, ValidationError
 
 from cla_common import call_centre_availability
 from cla_common.call_centre_availability import OpeningHours
-from cla_common.constants import OPERATOR_HOURS as CALL_CENTRE_OPERATOR_HOURS
+from cla_common.constants import OPERATOR_HOURS as CALL_CENTRE_OPERATOR_HOURS, SELECT_OPTION_DEFAULT
 
 from cla_public.apps.contact.constants import DAY_CHOICES, DAY_TODAY, DAY_SPECIFIC
 from cla_public.apps.checker.validators import IgnoreIf, FieldValueNot
@@ -48,6 +48,12 @@ def time_slots_for_day(day):
     return map(time_choice, slots)
 
 
+def append_default_option_to_list(append_list):
+    """Append a default non selectable message to a HTML select option"""
+    # append to index 0
+    return append_list.insert(0, SELECT_OPTION_DEFAULT[0])
+
+
 class DayChoiceField(FormattedChoiceField, SelectField):
     """
     Select field with next `num_days` days as options
@@ -56,7 +62,7 @@ class DayChoiceField(FormattedChoiceField, SelectField):
     def __init__(self, num_days=6, *args, **kwargs):
         super(DayChoiceField, self).__init__(*args, **kwargs)
         self.choices = map(day_choice, OPERATOR_HOURS.available_days(num_days))
-        self.choices.insert(0, ("", "-- Please select --"))
+        append_default_option_to_list(self.choices)
         self.day_choices = map(day_choice, OPERATOR_HOURS.available_days(num_days))
 
     @property
@@ -97,12 +103,12 @@ class TimeChoiceField(FormattedChoiceField, SelectField):
         """choices_callback is the datetime day argument"""
         super(TimeChoiceField, self).__init__(validators=validators, **kwargs)
         self.choices = map(time_choice, choices_callback())
-        self.choices.insert(0, ("", "-- Please select --"))
+        append_default_option_to_list(self.choices)
         self.default = self.choices
 
     def set_day_choices(self, day):
         self.choices = time_slots_for_day(day)
-        self.choices.insert(0, ("", "-- Please select --"))
+        append_default_option_to_list(self.choices)
         self.default = self.choices
 
     def process_data(self, value):

--- a/cla_public/apps/contact/fields.py
+++ b/cla_public/apps/contact/fields.py
@@ -180,9 +180,8 @@ class AvailabilityCheckerForm(NoCsrfForm):
         super(AvailabilityCheckerForm, self).__init__(*args, **kwargs)
         if not self.time_today.choices:
             self.specific_day.data = DAY_SPECIFIC
-
-        day = datetime.datetime.strptime(self.day.day_choices[0][0], "%Y%m%d").date()
-        self.time_in_day.set_day_choices(day)
+        # day = datetime.datetime.strptime(self.day.day_choices[0][0], "%Y%m%d").date()
+        # self.time_in_day.set_day_choices(day)
 
     def scheduled_time(self, today=None):
         """

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -15,6 +15,7 @@ from cla_public.apps.checker.constants import SAFE_TO_CONTACT, CONTACT_PREFERENC
 from cla_public.apps.base.forms import BabelTranslationsFormMixin
 from cla_public.apps.checker.validators import IgnoreIf, FieldValue
 from cla_public.apps.contact.validators import EmailValidator
+from cla_public.apps.contact.constants import SELECT_OPTION_DEFAULT
 from cla_public.libs.honeypot import Honeypot
 from cla_public.libs.utils import get_locale
 
@@ -22,7 +23,7 @@ from cla_public.libs.utils import get_locale
 LANG_CHOICES = filter(lambda x: x[0] not in ("ENGLISH", "WELSH"), [("", "")] + ADAPTATION_LANGUAGES)
 
 THIRDPARTY_RELATIONSHIP = map(lambda relationship: (relationship[0], _(relationship[1])), THIRDPARTY_RELATIONSHIP)
-THIRDPARTY_RELATIONSHIP_CHOICES = [("", _("-- Please select --"))] + THIRDPARTY_RELATIONSHIP
+THIRDPARTY_RELATIONSHIP_CHOICES = SELECT_OPTION_DEFAULT + THIRDPARTY_RELATIONSHIP
 
 
 class AdaptationsForm(BabelTranslationsFormMixin, NoCsrfForm):

--- a/cla_public/apps/contact/helper.py
+++ b/cla_public/apps/contact/helper.py
@@ -1,0 +1,4 @@
+def append_default_option_to_list(append_list, list_options):
+    """Append a default non selectable message to a HTML select option"""
+    # append to index 0
+    return append_list.insert(0, list_options[0])

--- a/cla_public/apps/contact/tests/test_availability.py
+++ b/cla_public/apps/contact/tests/test_availability.py
@@ -9,7 +9,7 @@ from wtforms import Form
 from wtforms.validators import InputRequired, ValidationError
 
 from cla_common import call_centre_availability
-from cla_public.apps.contact.constants import DAY_TODAY, DAY_SPECIFIC, SELECT_OPTION_DEFAULT
+from cla_public.apps.contact.constants import DAY_TODAY, DAY_SPECIFIC
 from cla_public.apps.contact.fields import AvailableSlot, DayChoiceField, OPERATOR_HOURS, TimeChoiceField
 from cla_public.apps.contact.forms import ContactForm, CallBackForm
 from cla_public.apps.base.tests import FlaskAppTestCase
@@ -52,7 +52,7 @@ class TestAvailability(FlaskAppTestCase):
         mock_field.data = None
         with self.assertRaises(ValidationError) as context:
             self.validator(mock_form, mock_field)
-            self.assertTrue('Not a valid time' in str(context.exception))
+            self.assertTrue("Not a valid time" in str(context.exception))
 
     def assertAvailable(self, time, form=None):
         form = form or Mock()
@@ -259,4 +259,3 @@ class TestTimeChoiceField(unittest.TestCase):
                 # time_today should not have any values in choices so won't be displayed
                 time_today_field = getattr(field.form, "time_today")
                 self.assertEqual(len(time_today_field.choices), 0)
-

--- a/cla_public/apps/contact/tests/test_availability.py
+++ b/cla_public/apps/contact/tests/test_availability.py
@@ -171,8 +171,10 @@ class TestAvailability(FlaskAppTestCase):
 
             self.assertTrue(OPERATOR_HOURS.can_schedule_callback(monday_after_11))
 
-    def test_no_day_selected(self):
+    def test_no_time_selected(self):
         # check that this raises a validation error
+        self.validator = AvailableSlot(DAY_TODAY)
+        self.assertValidationError(time=None)
         self.validator = AvailableSlot(DAY_SPECIFIC)
         self.assertValidationError(time=None)
 

--- a/cla_public/apps/contact/tests/test_validation.py
+++ b/cla_public/apps/contact/tests/test_validation.py
@@ -22,7 +22,7 @@ def base_form_data():
 
 
 def validate_contact_form(data):
-    form = CallBackForm(MultiDict(data), csrf_enabled=False)
+    form = CallBackForm(MultiDict(data), csrf_enabled=True)
     valid_submit = form.validate()
     return valid_submit, form.errors.get("time", {})
 

--- a/cla_public/apps/contact/tests/test_validation.py
+++ b/cla_public/apps/contact/tests/test_validation.py
@@ -6,6 +6,11 @@ from werkzeug.datastructures import MultiDict
 from cla_public.app import create_app
 from cla_public.apps.contact.forms import CallBackForm
 from cla_public.apps.contact.tests.test_availability import override_current_time
+from cla_public.apps.contact.constants import (
+    TIME_TODAY_VALIDATION_ERROR,
+    DAY_SPECIFIC_VALIDATION_ERROR,
+    TIME_SPECIFIC_VALIDATION_ERROR,
+)
 
 logging.getLogger("MARKDOWN").setLevel(logging.WARNING)
 
@@ -67,7 +72,7 @@ class TestContactFormValidation(unittest.TestCase):
                 is_valid, errors = validate_contact_form(data)
                 if not is_valid:
                     # check the errors
-                    self.assertIn("Select what day to ring you back", errors["day"][0])
+                    self.assertIn(DAY_SPECIFIC_VALIDATION_ERROR, errors["day"][0])
                     self.assertIn("schedule a callback at the requested time", errors["time_in_day"][0][0])
                 else:
                     self.fail("Specific day was not set but form was validated")
@@ -80,7 +85,7 @@ class TestContactFormValidation(unittest.TestCase):
                 is_valid, errors = validate_contact_form(data)
                 if not is_valid:
                     # check the errors
-                    self.assertIn("Select what time to ring you back", errors["time_today"][0])
+                    self.assertIn(TIME_TODAY_VALIDATION_ERROR, errors["time_today"][0])
                 else:
                     self.fail("Time today was not set but form was validated")
 
@@ -97,6 +102,6 @@ class TestContactFormValidation(unittest.TestCase):
                 is_valid, errors = validate_contact_form(data)
                 if not is_valid:
                     # check the errors
-                    self.assertIn("Select what time to ring you back", errors["time_in_day"][0])
+                    self.assertIn(TIME_SPECIFIC_VALIDATION_ERROR, errors["time_in_day"][0])
                 else:
                     self.fail("Specific day was not set but form was validated")

--- a/cla_public/apps/contact/tests/test_validation.py
+++ b/cla_public/apps/contact/tests/test_validation.py
@@ -1,0 +1,102 @@
+import datetime
+import logging
+import unittest
+
+from werkzeug.datastructures import MultiDict
+from cla_public.app import create_app
+from cla_public.apps.contact.forms import CallBackForm
+from cla_public.apps.contact.tests.test_availability import override_current_time
+
+logging.getLogger("MARKDOWN").setLevel(logging.WARNING)
+
+
+def base_form_data():
+    data = {"contact_number": "000000000", "time-specific_day": "today", "time-time_today": "1400"}
+
+    return data
+
+
+def validate_contact_form(data):
+    form = CallBackForm(MultiDict(data), csrf_enabled=False)
+    valid_submit = form.validate()
+    return valid_submit, form.errors.get("time", {})
+
+
+class TestContactFormValidation(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app("config/testing.py")
+        self.ctx = self.app.test_request_context()
+        self.ctx.push()
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.ctx.pop()
+
+    def test_valid_callback_another_day(self):
+        with self.client:
+            # fix day, date and time as 9am Thursday Dec 8 22
+            with override_current_time(datetime.datetime(2022, 12, 8, 9, 00)):
+                data = {
+                    "time-specific_day": "specific_day",
+                    "time-day": "%04d%02d%02d" % (2022, 12, 9),
+                    "time-time_in_day": "0900",
+                    "contact_number": "000000000",
+                }
+                # should be valid
+                is_valid, errors = validate_contact_form(data)
+                self.assertTrue(is_valid)
+
+    def test_valid_callback_today(self):
+        with self.client:
+            # fix day, date and time as 9am Thursday Dec 8 22
+            with override_current_time(datetime.datetime(2022, 12, 8, 9, 00)):
+                data = {"time-specific_day": "today", "time-time_today": "1400", "contact_number": "000000000"}
+                is_valid, errors = validate_contact_form(data)
+                self.assertTrue(is_valid)
+
+    def test_callback_no_specific_day_set(self):
+        with self.client:
+            # fix day, date and time as 9am Thursday Dec 8 22
+            with override_current_time(datetime.datetime(2022, 12, 8, 9, 00)):
+                data = {
+                    "time-specific_day": "specific_day",
+                    "time-day": "",
+                    "time-time_in_day": "0900",
+                    "contact_number": "000000000",
+                }
+                is_valid, errors = validate_contact_form(data)
+                if not is_valid:
+                    # check the errors
+                    self.assertIn("Select what day to ring you back", errors["day"][0])
+                    self.assertIn("schedule a callback at the requested time", errors["time_in_day"][0][0])
+                else:
+                    self.fail("Specific day was not set but form was validated")
+
+    def test_callback_no_time_today_set(self):
+        with self.client:
+            # fix day, date and time as 9am Thursday Dec 8 22
+            with override_current_time(datetime.datetime(2022, 12, 8, 9, 00)):
+                data = {"time-specific_day": "today", "time-time_in_day": "", "contact_number": "000000000"}
+                is_valid, errors = validate_contact_form(data)
+                if not is_valid:
+                    # check the errors
+                    self.assertIn("Select what time to ring you back", errors["time_today"][0])
+                else:
+                    self.fail("Time today was not set but form was validated")
+
+    def test_callback_no_time_specific_day_set(self):
+        with self.client:
+            # fix day, date and time as 9am Thursday Dec 8 22
+            with override_current_time(datetime.datetime(2022, 12, 8, 9, 00)):
+                data = {
+                    "time-specific_day": "specific_day",
+                    "time-day": "%04d%02d%02d" % (2022, 12, 9),
+                    "time-time_in_day": "",
+                    "contact_number": "000000000",
+                }
+                is_valid, errors = validate_contact_form(data)
+                if not is_valid:
+                    # check the errors
+                    self.assertIn("Select what time to ring you back", errors["time_in_day"][0])
+                else:
+                    self.fail("Specific day was not set but form was validated")

--- a/cla_public/javascript-tests/test/format-nested-objects.test.js
+++ b/cla_public/javascript-tests/test/format-nested-objects.test.js
@@ -1,0 +1,90 @@
+var formatNestedObject = require('../../static-src/javascripts/modules/format-nested-objects').formatNestedCallbackErrors
+
+//Bad data structure created by Django for call today
+var mockBadlyNestedTimeToday = [
+  ["contact_number",
+    ["Test"]
+  ],
+  ["time", {
+      "time_today": ["Test"]
+    }
+  ]
+]
+
+//Bad data structure created by Django for call another day
+var mockBadlyNestedAnotherDay = [
+  ["contact_number",
+    ["Test"]
+  ],
+  ["time", {
+      "day": ["Test"],
+      "time_in_day": ["Test"]
+    }
+  ]
+]
+
+// Correct data structure for call another day object
+var mockFormattedAnotherDay = [
+  ["contact_number",
+    ["Test"]
+  ],
+  ["time-day",
+    ["Test"]
+  ],
+  ["time-time_in_day",
+    ["Test"]
+  ]
+]
+
+// Correct data structure for call today object
+var mockFormattedTimeToday = [
+    ["contact_number",
+      ["Test"]
+    ],
+    ["time-time_today",
+      ["Test"]
+    ]
+  ]
+
+test("formatNestedCallbackErrors formats nested time today object to correct data structure", () => {
+  expect(formatNestedObject(mockBadlyNestedTimeToday)).toEqual(mockFormattedTimeToday)
+})
+
+test("formatNestedCallbackErrors formats nested call another day object to correct data structure", () => {
+  expect(formatNestedObject(mockBadlyNestedAnotherDay)).toEqual(mockFormattedAnotherDay)
+})
+
+test("formatNestedCallbackErrors doesn't format data without key value time being present", () => {
+  //mockFormattedAnotherDay does not contain "time" as a key value in data structure
+  expect(formatNestedObject(mockFormattedAnotherDay)).toEqual(mockFormattedAnotherDay)
+})
+
+test("formatNestedCallbackErrors handles more values time value with correct appended pre-fix", () => {
+  var mockNewKeyValues = [
+      ["time", {
+        "day": ["Test"],
+        "time_in_day": ["Test"],
+        "foo_test": ["Test", "Test1", "Test2"],
+        "bar_test": ["Test"],
+      }
+    ]
+  ]
+
+  // Prefix time in front of keys
+  var mockFormattedNewKeyValues = [
+    ["time-day",
+      ["Test"]
+    ],
+    ["time-time_in_day",
+      ["Test"]
+    ],
+    ["time-foo_test",
+      ["Test", "Test1", "Test2"]
+    ],
+    ["time-bar_test",
+      ["Test"],
+    ]
+  ]
+
+  expect(formatNestedObject(mockNewKeyValues)).toEqual(mockFormattedNewKeyValues)
+})

--- a/cla_public/static-src/javascripts/modules/availability-times.js
+++ b/cla_public/static-src/javascripts/modules/availability-times.js
@@ -1,44 +1,67 @@
- 'use strict';
-  var _ = require('lodash');
-  moj.Modules.AvailabilityTimes = {
-    el: '[data-day-time-choices]',
+'use strict';
+var _ = require('lodash');
+moj.Modules.AvailabilityTimes = {
+  el: '[data-day-time-choices]',
 
-    init: function() {
-      if($(this.el).length === 0) {
-        return;
-      }
-      _.bindAll(this, 'handleDayChange');
-      this.cacheEls();
-      this.bindEvents();
-    },
-
-    bindEvents: function() {
-      this.$daySelectors.on('change', this.handleDayChange);
-      this.$timeSelectors.on('change', this.handleTimeRadioCheck);
-      this.$todayTimeSelectors.on('change', this.handleTimeRadioCheck);
-    },
-
-    cacheEls: function() {
-      this.$daySelectors = $(this.el);
-      this.$timeSelectors = $('[name$=time_in_day]');
-      this.$todayTimeSelectors = $('[name$=time_today]');
-    },
-
-    handleTimeRadioCheck: function(evt) {
-      var $target = $(evt.target);
-      var $radioButton = $target.closest('li').find('[type=radio]');
-
-      var targetName = $target.attr('name');
-      if(window.ga && targetName) {
-        window.ga('send', 'event', 'availability-times', 'select', targetName);
-      }
-      $radioButton
-        .prop('checked', true)
-        .trigger('label-select');
-    },
-
-    handleDayChange: function(evt) {
-      this.handleTimeRadioCheck(evt);
+  init: function() {
+    if($(this.el).length === 0) {
+      return;
     }
-  };
+    _.bindAll(this, 'handleDayChange');
+    this.cacheEls();
+    this.bindEvents();
+  },
+
+  bindEvents: function() {
+    this.$daySelectors.on('change', this.handleDayChange);
+    this.$timeSelectors.on('change', this.handleTimeRadioCheck);
+    this.$todayTimeSelectors.on('change', this.handleTimeRadioCheck);
+  },
+
+  cacheEls: function() {
+    this.$daySelectors = $(this.el);
+    this.$timeSelectors = $('[name$=time_in_day]');
+    this.$todayTimeSelectors = $('[name$=time_today]');
+  },
+
+  _populateDayTime: function($daySelector) {
+    var dayTimeHours = $daySelector.data('day-time-choices');
+    var dayValue = $daySelector.val();
+
+    if(!dayValue || !dayTimeHours) {
+      return;
+    }
+
+    var dayTimes = dayTimeHours[dayValue];
+    var timeOptions = _.keys(dayTimes).sort();
+    var $timeSelector = $daySelector.closest('.govuk-radios').find(this.$timeSelectors);
+    var $options = _.map(timeOptions, function(v) {
+      var d = dayTimes[v];
+      return $('<option>', { value: v, html: d });
+    });
+    $options.unshift($('<option>', { value: "", html: "-- Please select --" }))
+
+    $timeSelector
+      .html($options)
+      .val("");
+  },
+
+  handleTimeRadioCheck: function(evt) {
+    var $target = $(evt.target);
+    var $radioButton = $target.closest('li').find('[type=radio]');
+
+    var targetName = $target.attr('name');
+    if(window.ga && targetName) {
+      window.ga('send', 'event', 'availability-times', 'select', targetName);
+    }
+    $radioButton
+      .prop('checked', true)
+      .trigger('label-select');
+  },
+
+  handleDayChange: function(evt) {
+    this._populateDayTime($(evt.target));
+    this.handleTimeRadioCheck(evt);
+  }
+};
 

--- a/cla_public/static-src/javascripts/modules/availability-times.js
+++ b/cla_public/static-src/javascripts/modules/availability-times.js
@@ -24,27 +24,6 @@
       this.$todayTimeSelectors = $('[name$=time_today]');
     },
 
-    _populateDayTime: function($daySelector) {
-      var dayTimeHours = $daySelector.data('day-time-choices');
-      var dayValue = $daySelector.val();
-
-      if(!dayValue || !dayTimeHours) {
-        return;
-      }
-
-      var dayTimes = dayTimeHours[dayValue];
-      var timeOptions = _.keys(dayTimes).sort();
-      var $timeSelector = $daySelector.closest('.govuk-radios').find(this.$timeSelectors);
-      var $options = _.map(timeOptions, function(v) {
-        var d = dayTimes[v];
-        return $('<option>', { value: v, html: d });
-      });
-
-      $timeSelector
-        .html($options)
-        .val(timeOptions[Math.floor(Math.random() * timeOptions.length)]);
-    },
-
     handleTimeRadioCheck: function(evt) {
       var $target = $(evt.target);
       var $radioButton = $target.closest('li').find('[type=radio]');
@@ -59,7 +38,6 @@
     },
 
     handleDayChange: function(evt) {
-      this._populateDayTime($(evt.target));
       this.handleTimeRadioCheck(evt);
     }
   };

--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -81,37 +81,41 @@
     formatErrors: function(errors) {
       var errorFields = {};
 
+      function formatNestedCallbackErrors (errorsId) {
+        var callback_id_prefix = "time-"
+        // loop to check if call back time has generated any errors.
+        // array generated has been re-organised.
+        for (var key in errorsId) {
+          if (errorsId[key][0] === "time") {
+            var callback_values = errorsId[key][1]
+
+            //Splice time and object values to create empty array.
+            //empty array will be populated with new values
+            errorsId[key].splice(0)
+            errorsId[key].splice(1)
+
+            for (var key1 in callback_values) {
+              if (errorsId[key].length >= 2) {
+                // push new array object
+                errorsId.push([callback_id_prefix + key1, callback_values[key1]])
+              } else {
+                // push to old and empty array
+                errorsId[key].push(callback_id_prefix + key1, callback_values[key1])
+              }
+            }
+          }
+        }
+        return errorsId
+      }
+
       (function fieldName (errorsObj, prefix) {
         prefix = (typeof prefix === 'undefined') ? '' : prefix + '-';
 
         for (var key in errorsObj) {
           var field = prefix + key;
-          var callback_id = errorsObj[key]
-          var callback_id_prefix = "time-"
 
-          // loop to check if call back time has generated any errors.
-          // array generated has been re-organised.
-          for (var key1 in callback_id) {
-            if (callback_id[key1][0] === "time") {
-
-              var callback_values = callback_id[key1][1]
-
-              //Splice time and object values to create empty array.
-              //empty array will be populated with new values
-              callback_id[key1].splice(0)
-              callback_id[key1].splice(1)
-
-              for (var key2 in callback_values) {
-                if (callback_id[key1].length >= 2) {
-                  // push new array object
-                  callback_id.push([callback_id_prefix + key2, callback_values[key2]])
-                } else {
-                  // push to old and empty array
-                  callback_id[key1].push(callback_id_prefix + key2, callback_values[key2])
-                }
-              }
-            }
-          }
+          // Check for nested errors in errorsObj
+          errorsObj[key] = formatNestedCallbackErrors(errorsObj[key])
 
           if ($.isArray(errorsObj[key])) {
             errorFields[field] = errorsObj[key];

--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -1,5 +1,6 @@
  'use strict';
   var currencyValidation = require('./currencyInputValidation');
+  var formatNestedObject = require('./format-nested-objects');
   var _ = require('lodash');
   moj.Modules.FormErrors = {
     init: function() {
@@ -81,33 +82,6 @@
     formatErrors: function(errors) {
       var errorFields = {};
 
-      function formatNestedCallbackErrors (errorsId) {
-        var callback_id_prefix = "time-"
-        // loop to check if call back time has generated any errors.
-        // array generated has been re-organised.
-        for (var key in errorsId) {
-          if (errorsId[key][0] === "time") {
-            var callback_values = errorsId[key][1]
-
-            //Splice time and object values to create empty array.
-            //empty array will be populated with new values
-            errorsId[key].splice(0)
-            errorsId[key].splice(1)
-
-            for (var key1 in callback_values) {
-              if (errorsId[key].length >= 2) {
-                // push new array object
-                errorsId.push([callback_id_prefix + key1, callback_values[key1]])
-              } else {
-                // push to old and empty array
-                errorsId[key].push(callback_id_prefix + key1, callback_values[key1])
-              }
-            }
-          }
-        }
-        return errorsId
-      }
-
       (function fieldName (errorsObj, prefix) {
         prefix = (typeof prefix === 'undefined') ? '' : prefix + '-';
 
@@ -115,7 +89,7 @@
           var field = prefix + key;
 
           // Check for nested errors in errorsObj
-          errorsObj[key] = formatNestedCallbackErrors(errorsObj[key])
+          errorsObj[key] = formatNestedObject.formatNestedCallbackErrors(errorsObj[key])
 
           if ($.isArray(errorsObj[key])) {
             errorFields[field] = errorsObj[key];

--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -83,8 +83,36 @@
 
       (function fieldName (errorsObj, prefix) {
         prefix = (typeof prefix === 'undefined') ? '' : prefix + '-';
+
         for (var key in errorsObj) {
           var field = prefix + key;
+          var callback_id = errorsObj[key]
+          var callback_id_prefix = "time-"
+
+          // loop to check if call back time has generated any errors.
+          // array generated has been re-organised.
+          for (var key1 in callback_id) {
+            if (callback_id[key1][0] === "time") {
+
+              var callback_values = callback_id[key1][1]
+
+              //Splice time and object values to create empty array.
+              //empty array will be populated with new values
+              callback_id[key1].splice(0)
+              callback_id[key1].splice(1)
+
+              for (var key2 in callback_values) {
+                if (callback_id[key1].length >= 2) {
+                  // push new array object
+                  callback_id.push([callback_id_prefix + key2, callback_values[key2]])
+                } else {
+                  // push to old and empty array
+                  callback_id[key1].push(callback_id_prefix + key2, callback_values[key2])
+                }
+              }
+            }
+          }
+
           if ($.isArray(errorsObj[key])) {
             errorFields[field] = errorsObj[key];
           } else {

--- a/cla_public/static-src/javascripts/modules/format-nested-objects.js
+++ b/cla_public/static-src/javascripts/modules/format-nested-objects.js
@@ -1,0 +1,28 @@
+function formatNestedObjects (errorsId) {
+  var callback_id_prefix = "time-"
+  // loop to check if call back time has generated any errors.
+  // array generated has been re-organised.
+  for (var key in errorsId) {
+    if (errorsId[key][0] === "time") {
+      var callback_values = errorsId[key][1]
+
+      //Splice time and object values to create empty array.
+      //empty array will be populated with new values
+      errorsId[key].splice(0)
+      errorsId[key].splice(1)
+
+      for (var key1 in callback_values) {
+        if (errorsId[key].length >= 2) {
+          // push new array object
+          errorsId.push([callback_id_prefix + key1, callback_values[key1]])
+        } else {
+          // push to old and empty array
+          errorsId[key].push(callback_id_prefix + key1, callback_values[key1])
+        }
+      }
+    }
+  }
+  return errorsId
+}
+
+exports.formatNestedCallbackErrors = formatNestedObjects


### PR DESCRIPTION
## What does this pull request do?

- Callback time and day and time, ThirdParty time and day and time to all have default --please-select-- options first in all Select options.

- User are required now to select their own time instead of an auto select or random select being performed.

- Validation needs to be place to prevent users from submitting values of none (Default select option).

- Unit tests updated to cater to new logic change.

- New unit tests to test validation when trying to submit a form with invalid select options.

- Javascript updated to now format list of error objects in a way that other Javascript validation and error messages can read and work with.

## Any other changes that would benefit highlighting?

- End 2 end test WILL fail. End 2 end tests fixes and updates need to be merged first before this can be merged in.
- Validation differ from the Jira card, but correct validation messages have been approved and reworded by content designers. They are the following:

Call back today:
”Select which time you want to be called today”

Specific Day:
"Select which day you want to be called"
"Select what time you want to be called"


## Checklist

- [LGA-2302](https://dsdmoj.atlassian.net/browse/LGA-2302)
- Test and play in the following staging enviroment: [staging](https://lga-2302-remove-pre-select-c.staging.checklegalaid.service.gov.uk/contact)

- Scenario 1:

GIVEN I am requesting for CLA to ‘Call me back’
WHEN I select ‘Call today’ radio option
THEN the ‘Time’ dropdown should not be a pre-selected time
IF I do not not select a ‘Time’ from dropdown options
AND I try to submit details
THEN validation error message displayed ‘Select what time to ring you back’

- Scenario 2:

GIVEN I am requesting for CLA to ‘Call me back’
WHEN I select ‘Call on another day’ radio option
THEN the ‘Day’ dropdown should not be a pre-selected Day
AND the ‘Time’ dropdown should not be a pre-selected time
IF I do not not select a ‘Time’ and/or ‘Day’ from dropdown options
AND I try to submit details
THEN validation error message displayed ‘Select what day to ring you back’ and or ‘Select what time to ring you back’

- Scenario 3:

GIVEN I am requesting for CLA to ‘Call someone else instead of me’
WHEN I select ‘Call today’ radio option
THEN the ‘Time’ dropdown should not be a pre-selected time
IF I do not not select a ‘Time’ from dropdown options
AND I try to submit details
THEN validation error message displayed ‘Select what time to ring back’

- Scenario 4:

GIVEN I am requesting for CLA to ‘Call someone else instead of me’
WHEN I select ‘Call on another day’ radio option
THEN the ‘Day’ dropdown should not be a pre-selected Day
AND the ‘Time’ dropdown should not be a pre-selected time
IF I do not not select a ‘Time’ and/or ‘Day’ from dropdown options
AND I try to submit details
THEN validation error message displayed ‘Select what day to ring back’ and or ‘Select what time to ring back’


- Does turning Javascript off in the browser still display errors correctly and still submit the correct form.
- Was there any new accessibility issues introduced?
- Do the unit tests cover everything new introduced into the project?
- Does it meet everything required on the Jira card attached?
