### PR TITLE
LGA-2267 changing url for BACKEND_BASE_URI to point at backend servic…

### DIFF
--- a/helm_deploy/cla-public/values-dev.yaml
+++ b/helm_deploy/cla-public/values-dev.yaml
@@ -18,7 +18,7 @@ envVars:
   GDS_GA_ID:
     value: UA-145652997-1
   BACKEND_BASE_URI:
-    value: "https://staging.fox.civillegaladvice.service.gov.uk"
+    value: "http://cla-backend-app.laa-cla-backend-staging.svc.cluster.local"
   LAALAA_API_HOST:
     value: "https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk"
   GOOGLE_MAPS_API_KEY:

--- a/helm_deploy/cla-public/values-production.yaml
+++ b/helm_deploy/cla-public/values-production.yaml
@@ -23,7 +23,7 @@ envVars:
   MOJ_GTM_PREVIEW:
     value: "env-1"
   BACKEND_BASE_URI:
-    value: "https://fox.civillegaladvice.service.gov.uk"
+    value: "http://cla-backend-app.laa-cla-backend-production.svc.cluster.local"
   LAALAA_API_HOST:
     value: "https://laa-legal-adviser-api-production.cloud-platform.service.justice.gov.uk"
   GOOGLE_MAPS_API_KEY:

--- a/helm_deploy/cla-public/values-staging.yaml
+++ b/helm_deploy/cla-public/values-staging.yaml
@@ -23,7 +23,7 @@ envVars:
   MOJ_GTM_PREVIEW:
     value: "env-3"
   BACKEND_BASE_URI:
-    value: "https://laa-cla-backend-uat.apps.live-1.cloud-platform.service.justice.gov.uk"
+    value: "http://cla-backend-app.laa-cla-backend-staging.svc.cluster.local"
   LAALAA_API_HOST:
     value: "https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk"
   GOOGLE_MAPS_API_KEY:


### PR DESCRIPTION
LGA 2267

## What does this pull request do?

Cloud platforms have recommended that we use the backend service namespace to communicate with backend from frontend. So instead of https://fox.civillegaladvice.service.gov.uk/ we should use http://cla-backend-app.laa-cla-backend-production.svc.cluster.local/

Using the service name would mean not using HTTPS but cloud platforms have assured us this is fine as the request will not leave the cluster

Cloudplatform PRs Required before merge:

Production: 

[production namespace label](https://github.com/ministryofjustice/cloud-platform-environments/pull/9607)
[Production network policy](https://github.com/ministryofjustice/cloud-platform-environments/pull/9609/files)

Staging:

[Staging namespace label](https://github.com/ministryofjustice/cloud-platform-environments/pull/9589/files)
[Staging network policy](https://github.com/ministryofjustice/cloud-platform-environments/commit/b73873c3a1865779f4490870b55a80c88d13642e)

## Any other changes that would benefit highlighting?

All HTTPS calls to fox are not pointing at cla_backend namespace.

## Checklist

[LGA-2267](https://dsdmoj.atlassian.net/browse/LGA-2267)
