### PR TITLE
LGA-2412 - Update build job docker image to use latest cloud-platform image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
         type: boolean
         default: false
     docker:
-      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+      - image: ministryofjustice/cloud-platform-tools:2.1
     steps:
       - checkout
       - run:
@@ -218,7 +218,7 @@ jobs:
 
   cleanup_merged:
     docker:
-      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+      - image: ministryofjustice/cloud-platform-tools:2.1
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## What does this pull request do?

Update build job docker image to use latest cloud-platform image

## Any other changes that would benefit highlighting?

The previous cloud-platform/tools:circleci image is out of date and is using out of date ubuntu version that is missing latest lets encrypt root certificate which was causing our slack notifications not to go out.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
