### PR TITLE
LGA-2420 adding quotes around title value

### DIFF
--- a/helm_deploy/cla-public/templates/dashboard.yml
+++ b/helm_deploy/cla-public/templates/dashboard.yml
@@ -446,7 +446,7 @@ data:
         ]
       },
       "timezone": "browser",
-      "title": {{ include "cla-public.fullname" . }},
+      "title": "{{ include "cla-public.fullname" . }}",
       "version": 1
     }
 {{- end }}


### PR DESCRIPTION
## What does this pull request do?

Adds quotes around `cla-public.fullname` in dashboard.yml for title value.

Cloud platform has reported erroring which is preventing us from adding new dashboards, we have a hack but it involves us restarting pods every time somebody wants to add a new dashboard. Here's the error:

logger=provisioning.dashboard type=file name=sidecarProvider t=2023-04-05T11:53:29.832085199Z level=error msg="failed to load dashboard from " file=/tmp/dashboards/laa-cla-public-staging-dashboard.json error="invalid character 'l' looking for beginning of value"

[cla_public/dashboard.yml at 432bdfb7244ccc22035846a5350890ac068c21a1 · ministryofjustice/cla_public](https://github.com/ministryofjustice/cla_public/blob/432bdfb7244ccc22035846a5350890ac068c21a1/helm_deploy/cla-public/templates/dashboard.yml)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ [LGA-2420](https://dsdmoj.atlassian.net/browse/LGA-2420)] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"


[LGA-2420]: https://dsdmoj.atlassian.net/browse/LGA-2420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ