### PR TITLE
LGA-2423 ITHC update images ADDITION

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
 
   cleanup_merged:
     docker:
-      - image: ministryofjustice/cloud-platform-tools:2.1
+      - image: ministryofjustice/cloud-platform-tools
     steps:
       - checkout
       - run:
@@ -238,7 +238,7 @@ jobs:
 
   production_deploy:
     docker:
-      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+      - image: ministryofjustice/cloud-platform-tools
     steps:
       - checkout
       - run:


### PR DESCRIPTION
 Now both match more up to date image used for staging - this means that the slack notification works because the certificate is up to date.

## What does this pull request do?

Required.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
