### PR TITLE
Feature/lga 2457 third party confirmation email

### DIFF
--- a/cla_public/apps/contact/tests/test_mail.py
+++ b/cla_public/apps/contact/tests/test_mail.py
@@ -10,6 +10,7 @@ from cla_public.app import create_app
 from cla_public.apps.contact.views import create_and_send_confirmation_email, set_callback_time_string
 from cla_public.apps.contact.forms import ContactForm
 from cla_public.config.common import GOVUK_NOTIFY_TEMPLATES
+from cla_public.libs.utils import get_locale
 
 
 def submit(**kwargs):
@@ -81,7 +82,7 @@ class TestConfirmationEmail(unittest.TestCase):
         self.assert_email_arguments(
             govuk_notify,
             personalisation=personalisation_data,
-            template_id=GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_WITH_NUMBER"],
+            template_id=GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_WITH_NUMBER"][get_locale()[:2]],
         )
 
     def test_confirmation_email_no_callback(self):
@@ -99,7 +100,7 @@ class TestConfirmationEmail(unittest.TestCase):
         self.assert_email_arguments(
             govuk_notify,
             personalisation=personalisation_data,
-            template_id=GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_NOT_REQUESTED"],
+            template_id=GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_NOT_REQUESTED"][get_locale()[:2]],
         )
 
     def test_confirmation_email_thirdparty(self):
@@ -118,7 +119,7 @@ class TestConfirmationEmail(unittest.TestCase):
         self.assert_email_arguments(
             govuk_notify,
             personalisation=personalisation_data,
-            template_id=GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_THIRD_PARTY"],
+            template_id=GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_THIRD_PARTY"][get_locale()[:2]],
         )
 
     def test_confirmation_no_callback(self):
@@ -132,7 +133,7 @@ class TestConfirmationEmail(unittest.TestCase):
         self.assert_email_arguments(
             govuk_notify,
             personalisation=personalisation_data,
-            template_id=GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_NO_CALLBACK"],
+            template_id=GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_NO_CALLBACK"][get_locale()[:2]],
         )
 
     def test_confirmation_callback(self):
@@ -147,7 +148,7 @@ class TestConfirmationEmail(unittest.TestCase):
         self.assert_email_arguments(
             govuk_notify,
             personalisation=personalisation_data,
-            template_id=GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED"],
+            template_id=GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED"][get_locale()[:2]],
         )
 
 

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -67,10 +67,10 @@ def generate_confirmation_email_data(data):
             if session.stored["callback_requested"] is True:
                 if session.stored["contact_type"] == "thirdparty":
                     personalisation = {"case_reference": data["case_ref"], "date_time": set_callback_time_string(data)}
-                    template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY"]
+                    template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY"][get_locale()[:2]]
                 else:
                     personalisation = {"case_reference": data["case_ref"], "date_time": set_callback_time_string(data)}
-                    template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED"]
+                    template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED"][get_locale()[:2]]
             else:
                 personalisation = {"case_reference": data["case_ref"]}
                 template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_NO_CALLBACK"][get_locale()[:2]]

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -21,7 +21,7 @@ from cla_public.apps.checker.views import UpdatesMeansTest
 from cla_public.libs.views import AjaxOrNormalMixin, AllowSessionOverride, SessionBackedFormView, HasFormMixin
 from cla_public.apps.base.govuk_notify.api import GovUkNotify
 from cla_public.config.common import GOVUK_NOTIFY_TEMPLATES
-
+from cla_public.libs.utils import get_locale
 
 log = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ def generate_confirmation_email_data(data):
                     template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED"]
             else:
                 personalisation = {"case_reference": data["case_ref"]}
-                template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_NO_CALLBACK"]
+                template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_NO_CALLBACK"][get_locale()[:2]]
 
             return email_address, template_id, personalisation
 
@@ -86,16 +86,16 @@ def generate_confirmation_email_data(data):
         }
 
         if session.stored["callback_requested"] is False:
-            template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_NOT_REQUESTED"]
+            template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_NOT_REQUESTED"][get_locale()[:2]]
 
             return email_address, template_id, personalisation
 
         # Decides between a personal callback or a third party callback
         if data["callback"]["contact_number"]:
-            template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_WITH_NUMBER"]
+            template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_WITH_NUMBER"][get_locale()[:2]]
             personalisation.update(contact_number=data["callback"]["contact_number"])
         elif data["thirdparty"]["contact_number"]:
-            template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_THIRD_PARTY"]
+            template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CALLBACK_THIRD_PARTY"][get_locale()[:2]]
             personalisation.update(contact_number=data["thirdparty"]["contact_number"])
 
         return email_address, template_id, personalisation

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -65,8 +65,12 @@ def generate_confirmation_email_data(data):
         # Path for confirmation email if no email is provided initially
         if "full_name" not in data:
             if session.stored["callback_requested"] is True:
-                personalisation = {"case_reference": data["case_ref"], "date_time": set_callback_time_string(data)}
-                template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED"]
+                if session.stored["contact_type"] == "thirdparty":
+                    personalisation = {"case_reference": data["case_ref"], "date_time": set_callback_time_string(data)}
+                    template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY"]
+                else:
+                    personalisation = {"case_reference": data["case_ref"], "date_time": set_callback_time_string(data)}
+                    template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED"]
             else:
                 personalisation = {"case_reference": data["case_ref"]}
                 template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_NO_CALLBACK"]

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -67,10 +67,14 @@ def generate_confirmation_email_data(data):
             if session.stored["callback_requested"] is True:
                 if session.stored["contact_type"] == "thirdparty":
                     personalisation = {"case_reference": data["case_ref"], "date_time": set_callback_time_string(data)}
-                    template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY"][get_locale()[:2]]
+                    template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY"][
+                        get_locale()[:2]
+                    ]
                 else:
                     personalisation = {"case_reference": data["case_ref"], "date_time": set_callback_time_string(data)}
-                    template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED"][get_locale()[:2]]
+                    template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED"][
+                        get_locale()[:2]
+                    ]
             else:
                 personalisation = {"case_reference": data["case_ref"]}
                 template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_NO_CALLBACK"][get_locale()[:2]]

--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -22,7 +22,7 @@ CLEAR_SESSION = True
 
 GOV_UK_START_PAGE = "https://www.gov.uk/check-legal-aid"
 
-BACKEND_BASE_URI = os.environ.get("BACKEND_BASE_URI", "http://127.0.0.1:8000")  # For healthcheck.json requests
+BACKEND_BASE_URI = os.environ.get("BACKEND_BASE_URI", "http://127.0.0.1:8010")  # For healthcheck.json requests
 
 # Disable eligibility check and allow users to request a callback only
 CONTACT_ONLY = os.environ.get("CALLMEBACK_ONLY", False) == "True"
@@ -129,6 +129,10 @@ GOVUK_NOTIFY_TEMPLATES = {
     ),
     "PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED": os.environ.get(
         "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED", "020ba10c-ac98-4b7c-a49f-1f129462506b"
+    ),
+    "PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY": os.environ.get(
+        "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY",
+        "ca425753-c31b-426b-a532-b864701b2178",
     ),
 }
 

--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -22,7 +22,7 @@ CLEAR_SESSION = True
 
 GOV_UK_START_PAGE = "https://www.gov.uk/check-legal-aid"
 
-BACKEND_BASE_URI = os.environ.get("BACKEND_BASE_URI", "http://127.0.0.1:8010")  # For healthcheck.json requests
+BACKEND_BASE_URI = os.environ.get("BACKEND_BASE_URI", "http://127.0.0.1:8000")  # For healthcheck.json requests
 
 # Disable eligibility check and allow users to request a callback only
 CONTACT_ONLY = os.environ.get("CALLMEBACK_ONLY", False) == "True"

--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -112,28 +112,66 @@ MAIL_DEFAULT_SENDER = ("Civil Legal Advice", "no-reply@civillegaladvice.service.
 GOVUK_NOTIFY_API_KEY = os.environ.get("GOVUK_NOTIFY_API_KEY")
 
 GOVUK_NOTIFY_TEMPLATES = {
-    "PUBLIC_CALLBACK_NOT_REQUESTED": os.environ.get(
-        "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CALLBACK_NOT_REQUESTED", "382cc41c-b81d-4197-8819-2ad76522d03d"
-    ),
-    "PUBLIC_CALLBACK_WITH_NUMBER": os.environ.get(
-        "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CALLBACK_WITH_NUMBER", "b4cfa1b6-f1e9-44c1-9b02-f07ba896b669"
-    ),
-    "PUBLIC_CALLBACK_WITH_NO_NUMBER": os.environ.get(
-        "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CALLBACK_WITH_NO_NUMBER", "3e2926c5-1bdf-4eb3-b212-7f206f1d764d"
-    ),
-    "PUBLIC_CALLBACK_THIRD_PARTY": os.environ.get(
-        "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CALLBACK_THIRD_PARTY", "7ffc6de3-07bd-4232-b416-cf18d0abfec6"
-    ),
-    "PUBLIC_CONFIRMATION_NO_CALLBACK": os.environ.get(
-        "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CONFIRMATION_NO_CALLBACK", "1a56ee47-a200-43f9-bab2-e0852da0714b"
-    ),
-    "PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED": os.environ.get(
-        "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED", "020ba10c-ac98-4b7c-a49f-1f129462506b"
-    ),
-    "PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY": os.environ.get(
-        "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY",
-        "ca425753-c31b-426b-a532-b864701b2178",
-    ),
+    "PUBLIC_CALLBACK_NOT_REQUESTED": {
+        "en": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CALLBACK_NOT_REQUESTED", "382cc41c-b81d-4197-8819-2ad76522d03d"
+        ),
+        "cy": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CALLBACK_NOT_REQUESTED_WELSH", "5ae3e895-95f5-44bb-b7d0-0224273c908d"
+        ),
+    },
+    "PUBLIC_CALLBACK_WITH_NUMBER": {
+        "en": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CALLBACK_WITH_NUMBER", "b4cfa1b6-f1e9-44c1-9b02-f07ba896b669"
+        ),
+        "cy": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CALLBACK_WITH_NUMBER_WELSH", "7428dd15-8583-4e2d-9d0a-c8a4e0b740b4"
+        ),
+    },
+    "PUBLIC_CALLBACK_WITH_NO_NUMBER": {
+        "en": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CALLBACK_WITH_NO_NUMBER", "3e2926c5-1bdf-4eb3-b212-7f206f1d764d"
+        ),
+        "cy": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CALLBACK_WITH_NO_NUMBER_WELSH", "71f9343e-09c0-49d8-aee6-86ceec7fcda8"
+        ),
+    },
+    "PUBLIC_CALLBACK_THIRD_PARTY": {
+        "en": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CALLBACK_THIRD_PARTY", "7ffc6de3-07bd-4232-b416-cf18d0abfec6"
+        ),
+        "cy": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CALLBACK_THIRD_PARTY_WELSH", "23105d37-d59a-47a5-afdb-17a442cab3d8"
+        ),
+    },
+    "PUBLIC_CONFIRMATION_NO_CALLBACK": {
+        "en": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CONFIRMATION_NO_CALLBACK", "1a56ee47-a200-43f9-bab2-e0852da0714b"
+        ),
+        "cy": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CONFIRMATION_NO_CALLBACK_WELSH", "25237d11-a531-4aca-a482-d232c2cb47d4"
+        ),
+    },
+    "PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED": {
+        "en": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED",
+            "020ba10c-ac98-4b7c-a49f-1f129462506b",
+        ),
+        "cy": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_WELSH",
+            "8b169ee3-4295-4a6b-beb3-ca67c8123e6b",
+        ),
+    },
+    "PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY": {
+        "en": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY",
+            "ca425753-c31b-426b-a532-b864701b2178",
+        ),
+        "cy": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY_WELSH",
+            "9fbf2cda-3097-4ce2-b6c2-371acf391698",
+        ),
+    },
 }
 
 GOOGLE_MAPS_API_KEY = os.environ.get("GOOGLE_MAPS_API_KEY", "")


### PR DESCRIPTION
## What does this pull request do?

Adds in a third party confirmation email and it's welsh version to be called when required

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- https://dsdmoj.atlassian.net/jira/software/c/projects/LGA/boards/226?modal=detail&selectedIssue=LGA-2457
- Add template to Gov Notify
- Verify welsh template
