### PR TITLE
LGA-2457 Added third party confirmation email with welsh translation

### DIFF
--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -65,8 +65,16 @@ def generate_confirmation_email_data(data):
         # Path for confirmation email if no email is provided initially
         if "full_name" not in data:
             if session.stored["callback_requested"] is True:
-                personalisation = {"case_reference": data["case_ref"], "date_time": set_callback_time_string(data)}
-                template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED"][get_locale()[:2]]
+                if session.stored["contact_type"] == "thirdparty":
+                    personalisation = {"case_reference": data["case_ref"], "date_time": set_callback_time_string(data)}
+                    template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY"][
+                        get_locale()[:2]
+                    ]
+                else:
+                    personalisation = {"case_reference": data["case_ref"], "date_time": set_callback_time_string(data)}
+                    template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED"][
+                        get_locale()[:2]
+                    ]
             else:
                 personalisation = {"case_reference": data["case_ref"]}
                 template_id = GOVUK_NOTIFY_TEMPLATES["PUBLIC_CONFIRMATION_NO_CALLBACK"][get_locale()[:2]]

--- a/cla_public/config/common.py
+++ b/cla_public/config/common.py
@@ -162,6 +162,16 @@ GOVUK_NOTIFY_TEMPLATES = {
             "8b169ee3-4295-4a6b-beb3-ca67c8123e6b",
         ),
     },
+    "PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY": {
+        "en": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY",
+            "ca425753-c31b-426b-a532-b864701b2178",
+        ),
+        "cy": os.environ.get(
+            "GOVUK_NOTIFY_TEMPLATE_PUBLIC_CONFIRMATION_EMAIL_CALLBACK_REQUESTED_THIRDPARTY_WELSH",
+            "9fbf2cda-3097-4ce2-b6c2-371acf391698",
+        ),
+    },
 }
 
 GOOGLE_MAPS_API_KEY = os.environ.get("GOOGLE_MAPS_API_KEY", "")


### PR DESCRIPTION
## What does this pull request do?

Adds a third party confirmation email with welsh translations.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- https://dsdmoj.atlassian.net/jira/software/c/projects/LGA/boards/226?modal=detail&selectedIssue=LGA-2457
- Add template to Gov Notify
- Verify welsh template
