### PR TITLE
Return 503 status code when in maintenance mode

### DIFF
--- a/cla_public/apps/base/tests/test_extensions.py
+++ b/cla_public/apps/base/tests/test_extensions.py
@@ -65,7 +65,7 @@ class TestMaintenanceModeEnabled(FlaskAppTestCase):
         self.app.config["MAINTENANCE_MODE"] = True
         client = self.app.test_client()
         response = client.get("/maintenance")
-        self.assertEqual(200, response.status_code)
+        self.assertEqual(503, response.status_code)
         self.assertIn("This service is currently down for maintenance", response.data)
 
     def test_maintenance_mode_disabled_maintenance_page(self):

--- a/cla_public/apps/base/views.py
+++ b/cla_public/apps/base/views.py
@@ -268,4 +268,4 @@ def healthcheck():
 
 @base.route("/maintenance")
 def maintenance_page():
-    return render_template("maintenance.html")
+    return render_template("maintenance.html"), 503


### PR DESCRIPTION
## What does this pull request do?

Return 503 status code when in maintenance mode

## Any other changes that would benefit highlighting?

Like the rest of our apps, update public to return a 503 status code when in maintenance mode. It is currently returning a 200 status code even though it is maintenance mode.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
