### PR TITLE
Disable callbacks for today due to phone system not working

### DIFF
--- a/cla_public/apps/contact/tests/test_mail.py
+++ b/cla_public/apps/contact/tests/test_mail.py
@@ -23,21 +23,18 @@ def submit(**kwargs):
         "thirdparty-contact_number": kwargs.get("thirdparty_contact_number", ""),
     }
 
-    if datetime.datetime.now().time() > datetime.time(hour=14, minute=30):
-        # use tomorrow because no more callbacks available today
-        another_day = datetime.date.today() + datetime.timedelta(days=1)
-        if another_day.weekday() in (5, 6):
-            # use monday or tuesday next week to avoid weekend
-            another_day += datetime.timedelta(days=2)
-        data.update(
-            {
-                "callback-time-specific_day": "specific_day",
-                "callback-time-day": "%04d%02d%02d" % (another_day.year, another_day.month, another_day.day),
-                "callback-time-time_in_day": "0900",
-            }
-        )
-    else:
-        data.update({"callback-time-specific_day": "today", "callback-time-time_today": "0900"})
+    # use tomorrow because no more callbacks available today
+    another_day = datetime.date.today() + datetime.timedelta(days=1)
+    if another_day.weekday() in (5, 6):
+        # use monday or tuesday next week to avoid weekend
+        another_day += datetime.timedelta(days=2)
+    data.update(
+        {
+            "callback-time-specific_day": "specific_day",
+            "callback-time-day": "%04d%02d%02d" % (another_day.year, another_day.month, another_day.day),
+            "callback-time-time_in_day": "0900",
+        }
+    )
 
     data.update(kwargs)
     return ContactForm(MultiDict(data), csrf_enabled=False)

--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -31,7 +31,7 @@ cfgv==2.0.1
     # via pre-commit
 chardet==3.0.4
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.14.tar.gz
+https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.21.tar.gz
     # via -r requirements/source/requirements-base.in
 click==7.1.2
     # via pip-tools
@@ -170,10 +170,11 @@ python-dateutil==2.2
     # via
     #   -r requirements/source/requirements-base.in
     #   cla-common
-pytz==2018.5
+pytz==2021.1
     # via
     #   -r requirements/source/requirements-base.in
     #   babel
+    #   cla-common
 pyyaml==3.11
     # via
     #   -r requirements/source/requirements-base.in

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -25,7 +25,7 @@ cffi==1.15.1
     # via cryptography
 chardet==3.0.4
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.14.tar.gz
+https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.21.tar.gz
     # via -r requirements/source/requirements-base.in
 cryptography==3.3.2
     # via pyopenssl
@@ -105,10 +105,11 @@ python-dateutil==2.2
     # via
     #   -r requirements/source/requirements-base.in
     #   cla-common
-pytz==2018.5
+pytz==2021.1
     # via
     #   -r requirements/source/requirements-base.in
     #   babel
+    #   cla-common
 pyyaml==3.11
     # via -r requirements/source/requirements-base.in
 requests==2.19.1

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -26,7 +26,7 @@ cffi==1.15.1
     # via cryptography
 chardet==3.0.4
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.14.tar.gz
+https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.21.tar.gz
     # via -r requirements/source/requirements-base.in
 coverage==5.0.3
     # via
@@ -123,10 +123,11 @@ python-dateutil==2.2
     # via
     #   -r requirements/source/requirements-base.in
     #   cla-common
-pytz==2018.5
+pytz==2021.1
     # via
     #   -r requirements/source/requirements-base.in
     #   babel
+    #   cla-common
 pyyaml==3.11
     # via -r requirements/source/requirements-base.in
 requests==2.19.1

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -10,13 +10,13 @@ PyYAML==3.11
 Werkzeug==0.9.6
 argparse==1.2.1
 blinker==1.3
-https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.14.tar.gz
+https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.21.tar.gz
 speaklater==1.3 # Required by cla_common
 itsdangerous==0.24
 logstash_formatter==0.5.9
 markdown2==2.3.5
 python-dateutil==2.2
-pytz==2018.5
+pytz==2021.1
 requests==2.19.1
 wsgiref==0.1.2
 Babel==1.3
@@ -37,3 +37,4 @@ supervisor==4.2.4
 https://github.com/s-block/slumber/archive/da38360d6d158ee7ed445b43228fefc6f7e430e6.zip
 Flask-Script==2.0.5
 notifications-python-client==6.0.0
+# this is an update


### PR DESCRIPTION
## What does this pull request do?

Disable callbacks for today due to phone system not working

## Any other changes that would benefit highlighting?

Had to upgrade from pytz==2018.5 to pytz==2021.1 because cla_common uses pytz==2021.1 otherwise we couldn't include cla_common due to that conflict

Updated tests that were doing callbacks for today if the tests ran before 14:30 to instead use tomorrows date for callbacks. There is no logic for only making today callbacks available before 14:30

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
