### PR TITLE
Disable operator hours for 28th July 23

### DIFF
--- a/requirements/generated/requirements-dev.txt
+++ b/requirements/generated/requirements-dev.txt
@@ -31,7 +31,7 @@ cfgv==2.0.1
     # via pre-commit
 chardet==3.0.4
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.21.tar.gz
+https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.22.tar.gz
     # via -r requirements/source/requirements-base.in
 click==7.1.2
     # via pip-tools

--- a/requirements/generated/requirements-production.txt
+++ b/requirements/generated/requirements-production.txt
@@ -25,7 +25,7 @@ cffi==1.15.1
     # via cryptography
 chardet==3.0.4
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.21.tar.gz
+https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.22.tar.gz
     # via -r requirements/source/requirements-base.in
 cryptography==3.3.2
     # via pyopenssl

--- a/requirements/generated/requirements-testing.txt
+++ b/requirements/generated/requirements-testing.txt
@@ -26,7 +26,7 @@ cffi==1.15.1
     # via cryptography
 chardet==3.0.4
     # via requests
-https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.21.tar.gz
+https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.22.tar.gz
     # via -r requirements/source/requirements-base.in
 coverage==5.0.3
     # via

--- a/requirements/source/requirements-base.in
+++ b/requirements/source/requirements-base.in
@@ -10,7 +10,7 @@ PyYAML==3.11
 Werkzeug==0.9.6
 argparse==1.2.1
 blinker==1.3
-https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.21.tar.gz
+https://github.com/ministryofjustice/cla_common/archive/refs/tags/0.3.22.tar.gz
 speaklater==1.3 # Required by cla_common
 itsdangerous==0.24
 logstash_formatter==0.5.9


### PR DESCRIPTION
## What does this pull request do?

Update tag for cla_common so can disable callbacks for Friday 28th July 2023

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
