### PR TITLE
LGA-2612 bumping gov frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "yargs": "^10.0.3"
   },
   "dependencies": {
-    "govuk-frontend": "^3.13.0",
+    "govuk-frontend": "^4.7.0",
     "govuk_publishing_components": "https://github.com/alphagov/govuk_publishing_components.git#v20.5.2",
     "lodash": "^3.10.1",
     "numeral": "^1.5.6"


### PR DESCRIPTION
## What does this pull request do?

Bumps GOV Frontend Components to allow exit page CSS to be used within our live site. 

## Any other changes that would benefit highlighting?

- [https://design-system.service.gov.uk/components/exit-this-page/](GDS Exit page component.)
- [https://lga-2612-bump-govuk-frontend.staging.checklegalaid.service.gov.uk/start](Staging environment for manual testing.)

## Checklist

- [https://dsdmoj.atlassian.net/browse/LGA-2622](LGA-2622)
