### PR TITLE
Install python2 with pyenv because brew no longer has it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ node_modules/
 
 .sass-cache/
 
+# pyenv
+.python-version
+
 cla_public/config/local.py
 cla_public/static-src/vendor/**
 cla_public/static/

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 ## Dependencies
 
 - [Virtualenv](http://www.virtualenv.org/en/latest/)
-- [Python 2.7](http://www.python.org/) (Can be installed using `brew`)
+- [Python 2.7.18](http://www.python.org/) (Can be installed using `pyenv`)
 - [nodejs.org](http://nodejs.org/) (v8.12 - can be installed using [nvm](https://github.com/creationix/nvm))
 - [docker](https://www.docker.com/) - Only required for running application from Docker
 


### PR DESCRIPTION
## What does this pull request do?

Fixes the python2 suggested install.

I couldn't get brew to install it - I guess it's taken out as it's out of date.

Devs on CLA team say they use pyenv: https://mojdt.slack.com/archives/CFUESB43G/p1661956186094889?thread_ts=1661956005.152889&cid=CFUESB43G

## Any other changes that would benefit highlighting?

`pyenv local 2.7.18` causes `.python-version` to be written. I think the intention behind it being a dot-file is that it should be gitignored rather than checked in, to give developers a bit of control.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
