### PR TITLE
LGA-2798: Fixed error message appearing in Welsh

### DIFF
--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -1944,7 +1944,7 @@ msgstr ""
 #: cla_public/templates/base.html:220
 #: cla_public/templates/macros/element.html:18
 msgid "There is a problem"
-msgstr "Mae yna broblem"
+msgstr ""
 
 #: cla_public/templates/base.html:252 cla_public/templates/contact.html:178
 #: cla_public/templates/contact.html:195 cla_public/templates/contact.html:202


### PR DESCRIPTION
## What does this pull request do?

Fixes one error message "There was a problem" appearing in Welsh

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
