### PR TITLE
bug/Add GitHub team name to modsecurity-snippet

### DIFF
--- a/helm_deploy/cla-public/templates/ingress.yaml
+++ b/helm_deploy/cla-public/templates/ingress.yaml
@@ -22,6 +22,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-get-access"
 spec:
   ingressClassName: "modsec"
   tls:


### PR DESCRIPTION
## What does this pull request do?

Adds the GitHub team name to the modsecurity-snippet as per [the Cloud Platform documentation](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html#modsecurity-web-application-firewall).

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
