### PR TITLE
Remove rule SecRuleRemoveById 942230

### DIFF
--- a/helm_deploy/cla-public/templates/ingress.yaml
+++ b/helm_deploy/cla-public/templates/ingress.yaml
@@ -23,6 +23,7 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-get-access"
+      SecRuleRemoveById 942230
 spec:
   ingressClassName: "modsec"
   tls:

--- a/helm_deploy/cla-public/templates/ingress.yaml
+++ b/helm_deploy/cla-public/templates/ingress.yaml
@@ -24,6 +24,8 @@ metadata:
       SecRuleEngine On
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-get-access"
       SecRuleRemoveById 942230
+      SecRuleRemoveById 930120
+      SecRuleRemoveById 933210
 spec:
   ingressClassName: "modsec"
   tls:


### PR DESCRIPTION
## What does this pull request do?

This request removes security rule 942230 from modsec which has been causing a false positive.
https://github.com/SpiderLabs/owasp-modsecurity-crs/blob/v3.3/dev/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf#L221

This rule was preventing any input field from putting 'having £' as it was viewing this as an SQL injection. Although this is an edge case this has occurred and blocked this on our system.

Disable Rule 930120; this rule is showing an OS File Access Attempt but is being caused by .nsr included in cookies which is added at random.

Disable Rule 933210; this rule shows as PHP Injection Attack when someone enters )( into a field; this is blocking legitimate requests so needs to be disabled ASAP, also we don't use PHP anyway

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
