### PR TITLE
Better error message when backend broken

### DIFF
--- a/cla_public/apps/scope/api.py
+++ b/cla_public/apps/scope/api.py
@@ -38,7 +38,9 @@ class DiagnosisApiClient(object):
     def post_to_scope(self, path="", payload={}):
         request_args = self.request_args()
         request_args["json"] = payload
-        return requests.post(self.request_path(path), **request_args)
+        response = requests.post(self.request_path(path), **request_args)
+        response.raise_for_status()
+        return response
 
     def create_diagnosis(self):
         if not session.checker.get(REF_KEY):


### PR DESCRIPTION
When cla_backend returns 500 error, then lets raise an exception for that, rather than ignore it and raise it soon after when we JSON decode the blank response.

This has been a frequent annoyance when getting started developing cla_backend and cla_public together.

Before this PR:
![Screenshot 2024-02-06 at 17 13 13](https://github.com/ministryofjustice/cla_public/assets/307612/7d12edb3-7b01-4d62-a6d6-c19311714066)
Is backend returning invalid JSON? what's going on?

After this PR: 
![Screenshot 2024-02-06 at 17 13 02](https://github.com/ministryofjustice/cla_public/assets/307612/9f087ec5-f25b-412e-bf46-59a3f5f7dc59)
Ah, backend is broken. And I know the hostname and port it was using too now.

## Analysis showing this is a safe change

post_to_scope() gets called in two places:

1. create_diagnosis() immediately does response.json(), and the current behaviour is for the ValueError() to bubble up through the View (ScopeDiagnosis.get()) and the user gets a 500 error page. So this PR changes that to a HTTPError. The user sees the same thing, but a developer user benefits from the nicer error, saying what the problem URL was etc

2. move() returns the response to ScopeDiagnosis.get(), which does response.json(), but catches the ValueError, in debug mode returns the text, but otherwise reraises it. So this PR means an HTTP error will be raised marginally earlier, but basically unchanged.


## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
