### PR TITLE
Feature/LGA 3026 redesign find a legal advsior page

### DIFF
--- a/cla_public/apps/checker/forms.py
+++ b/cla_public/apps/checker/forms.py
@@ -700,3 +700,4 @@ class ReviewForm(BaseForm):
 
 class FindLegalAdviserForm(Honeypot, BabelTranslationsFormMixin, Form):
     postcode = StringField(_(u"Enter postcode"), validators=[InputRequired(_(u"Enter a postcode"))])
+    category = StringField()

--- a/cla_public/apps/checker/views.py
+++ b/cla_public/apps/checker/views.py
@@ -36,6 +36,7 @@ from cla_public.libs.utils import override_locale, category_id_to_name
 from cla_public.libs.views import AllowSessionOverride, FormWizard, FormWizardStep, RequiresSession, HasFormMixin
 from cla_public.libs import laalaa, honeypot
 from cla_public.apps.checker.cait_intervention import get_cait_params
+import math
 
 log = logging.getLogger(__name__)
 
@@ -247,8 +248,11 @@ class LaaLaaView(views.MethodView):
     @classmethod
     def handle_find_legal_adviser_form(cls, form, args):
         data = {}
-        page = 1
 
+        items_per_page = 10
+        max_pages = 9
+
+        page = 1
         if "postcode" in args:
             if form.validate():
                 if "page" in args and args["page"].isdigit():
@@ -262,6 +266,11 @@ class LaaLaaView(views.MethodView):
                     form.postcode.errors.append(
                         u"%s %s" % (_("Error looking up legal advisers."), _("Please try again later."))
                     )
+
+        data["num_pages"] = 1
+        if "count" in data:
+            data["num_pages"] = min(math.ceil(data["count"] / items_per_page), max_pages)
+
         data["current_page"] = page
         return data
 

--- a/cla_public/apps/scope/views.py
+++ b/cla_public/apps/scope/views.py
@@ -61,9 +61,13 @@ class ScopeDiagnosis(RequiresSession, views.MethodView):
                 except Exception:
                     is_hlpas = "no"
 
-                outcome_url = url_for(outcome_url[0], hlpas=is_hlpas, **outcome_url[1])
+                outcome_url[1]["hlpas"] = is_hlpas
+
                 if state == DIAGNOSIS_SCOPE.OUTOFSCOPE:
-                    outcome_url = "%s?category=%s" % (outcome_url, self.get_category_for_larp(session))
+                    category = self.get_category_for_larp(session)
+                    outcome_url[1]["category"] = category
+
+                outcome_url = url_for(outcome_url[0], **outcome_url[1])
 
             return redirect(outcome_url)
 

--- a/cla_public/templates/base.html
+++ b/cla_public/templates/base.html
@@ -40,6 +40,9 @@
         {% endif %}
       {% endfor %}
     {% endif %}
+  {% elif 'refer' in request.path and 'postcode' in request.args %}
+    {% set url = url_for(request.endpoint, category=request.args.category) %}
+    <a href={{ url }} class="govuk-back-link">{{ _('Back') }}</a>
   {% else %}
     {% if (session.checker.AboutYouForm and session.checker.AboutYouForm.is_completed) %}
       {% set url = '/about' %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -14,7 +14,9 @@
   {% endif %}
 
   <p class="govuk-body">You can call any legal advisor from this list, so you do not have to pick a local one. If they are busy, you may need to contact more than one.</p>
-  <p class="govuk-body govuk-!-margin-bottom-6">If you cannot find a legal adviser to help you, contact Civil Legal Advice. Tell them that you qualify for housing loss prevention advice.</p>
+  {% if category == 'hlpas' %}
+    <p class="govuk-body govuk-!-margin-bottom-6">If you cannot find a legal adviser to help you, contact Civil Legal Advice. Tell them that you qualify for housing loss prevention advice.</p>
+  {% endif %}
 
   {% for item in data.results %}
   <div>
@@ -26,14 +28,15 @@
       <p class="govuk-body govuk-!-margin-bottom-2">Address: {{ item.location.address}}, {{item.location.city }}, {{ item.location.postcode }}</p>
     {% endif %}
     {% if item.organisation.website %}
-      <p class="govuk-body govuk-!-margin-bottom-2">Website: <a href='http://{{ item.organisation.website }}'> {{ item.organisation.website }}</a></p>
+      <p class="govuk-body govuk-!-margin-bottom-2">Website: <a target="_blank" href='http://{{ item.organisation.website }}'> {{ item.organisation.website }} (opens in a new tab)</a></p>
     {% endif %}
-      <p class="govuk-body govuk-!-margin-bottom-2"><a href='https://www.google.com/maps/dir/?api=1&origin={{ data.origin.postcode }}&destination={{ item.location.address }}, {{ item.location.postcode }}'>Map and directions (opens in a new tab)</a></p>
-    <div class="govuk-!-margin-bottom-2">
+      <p class="govuk-body govuk-!-margin-bottom-2"><a target="_blank" href='https://www.google.com/maps/dir/?api=1&origin={{ data.origin.postcode }}&destination={{ item.location.address }}, {{ item.location.postcode }}'>Map and directions (opens in a new tab)</a></p>
+      <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-2">Categories of law</p>
+      <ul class="govuk-list govuk-list--bullet">
       {% for category in item.categories%}
-        <strong class="govuk-tag govuk-tag--grey">{{ category }}</strong>
+        <li><p class="govuk-body govuk-!-margin-bottom-1">{{ category }}</p></li>
       {% endfor %}
-    </div>
+      </ul>
   </div>
   
   {% endfor %}

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -1,38 +1,47 @@
 {% import "macros/form.html" as Form %}
 {% import "macros/element.html" as Element %}
 
-{% if data and data.count and data.count > 0 %}
-  <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
-    {{ _('Contact a legal advsior') }}
-  </h1>
+{% macro category_information(category) %}
+  {% if category == 'hlpas' %}
+    <p class="govuk-body">
+      {% trans %}If you cannot find a legal adviser to help you, contact Civil Legal advice. 
+      Tell them that you qualify for housing loss prevention advice.{% endtrans %}
+    </p>
+  {% elif category == 'clinneg' %}
+    <p class="govuk-body">
+    {% trans %}You will usually only get legal aid for advice about
+      clinical negligence if your child has suffered a brain injury during pregnancy,
+      birth or in the first 8 weeks of life.{% endtrans %}
+    </p>
+  {% elif category == 'pi' %}
+    <p class="govuk-body">
+    {% trans %}You may be able to get legal aid in exceptional cases. You
+      could seek advice from a legal adviser about whether an application
+      might succeed in your case and how to apply.{% endtrans %}
+    </p>
+  {% endif %}
+{% endmacro %}
+
+{% macro category_caption(category) %}
   {% if category %}
-    {% if category == 'housing' %}
-        <span class="govuk-caption-l govuk-!-margin-bottom-6">For the Housing Loss Prevention Advice Scheme</span>
-    {% elif category == 'aap' %}
-        <span class="govuk-caption-l govuk-!-margin-bottom-6">For trouble with the police and public authorities</span>
+    {% if category == 'aap' %}
+        <span class="govuk-caption-l govuk-!-margin-bottom-6">{% trans %}For trouble with the police and public authorities{% endtrans %}</span>
     {% else %}
       <span class="govuk-caption-l govuk-!-margin-bottom-6">For {{category_name.lower()}}</span>
     {% endif %}
   {% endif %}
+{% endmacro %}
+
+{% if data and data.count and data.count > 0 %}
+  <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+    {{ _('Contact a legal advsior') }}
+    {{ category_caption(category) }}
+  </h1>
+
 
   <p class="govuk-body">You can contact any legal adviser from this list.</p>
   <p class="govuk-body">Your adviser will check whether you qualify for legal aid <strong>at no cost to you</strong> by asking about your problem and your finances. In some cases you may need to pay a contribution towards your legal aid.</p>
-  {% if category == 'hlpas' %}
-    <p class="govuk-body govuk-!-margin-bottom-6">If you cannot find a legal adviser to help you, contact Civil Legal Advice. Tell them that you qualify for housing loss prevention advice.</p>
-  {% elif category == 'clinneg' %}
-  <p class="govuk-body">
-    {% trans %}You will usually only get legal aid for advice about
-      clinical negligence if your child has suffered a brain injury during pregnancy,
-      birth or in the first 8 weeks of life.{% endtrans %}
-  </p>
-
-{% elif category == 'pi' %}
-  <p class="govuk-body">
-    {% trans %}You may be able to get legal aid in exceptional cases. You
-      could seek advice from a legal adviser about whether an application
-      might succeed in your case and how to apply.{% endtrans %}
-  </p>
-{% endif %}
+  {{ category_information(category) }}
 
 <p id="aria-satisfaction-survey" class="govuk-body">
   {% trans -%}
@@ -192,13 +201,7 @@
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
       {{ _('Find a legal advisor') }}
     </h1>
-    {% if category %}
-      {% if category == 'aap' %}
-      <span class="govuk-caption-l govuk-!-margin-bottom-6">For trouble with the police and public authorities</span>
-      {% else %}
-      <span class="govuk-caption-l govuk-!-margin-bottom-6">For {{category_name.lower()}}</span>
-      {% endif %}
-    {% endif %}
+    {{ category_caption(category) }}
   {% endif %}
 
   {% set find_legal_advisor_subtitle = _('Find a legal adviser') %}
@@ -208,66 +211,51 @@
 
 {% if 'postcode' not in request.args %}
 
-{% if category == 'hlpas' %}
-<p class="govuk-body govuk-!-margin-bottom-6">If you cannot find a legal adviser to help you, contact Civil Legal Advice. Tell them that you qualify for housing loss prevention advice.</p>
-{% elif category == 'clinneg' %}
-<p class="govuk-body">
-{% trans %}You will usually only get legal aid for advice about
-  clinical negligence if your child has suffered a brain injury during pregnancy,
-  birth or in the first 8 weeks of life.{% endtrans %}
-</p>
+  {{ category_information(category) }}
 
-{% elif category == 'pi' %}
-<p class="govuk-body">
-{% trans %}You may be able to get legal aid in exceptional cases. You
-  could seek advice from a legal adviser about whether an application
-  might succeed in your case and how to apply.{% endtrans %}
-</p>
-{% endif %}
+  <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
 
-<h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
-
-<p class="govuk-body">
-  {% trans %}Your adviser will check whether you qualify for legal aid <strong>at no cost to you</strong> by asking about your problem and your finances.{% endtrans %}
-  {% trans %}In some cases you may need to pay a contribution towards your legal aid.{% endtrans %}
-</p>
-
-{% if category == 'mentalhealth' %}
   <p class="govuk-body">
-    {% trans %}If you’re applying for legal aid for a mental health issue,
-      the requirements for the financial assessment are less rigorous than
-      for other legal aid problems.{% endtrans %}
+    {% trans %}Your adviser will check whether you qualify for legal aid <strong>at no cost to you</strong> by asking about your problem and your finances.{% endtrans %}
+    {% trans %}In some cases you may need to pay a contribution towards your legal aid.{% endtrans %}
   </p>
-{% endif %}
 
-{% if find_legal_advisor_subtitle == _('Search again') %}
-  <p class="govuk-body">
-    <a class="govuk-link" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">
-      {% trans %}What did you think of this service?{% endtrans %}</a> {% trans %}(takes 30 seconds){% endtrans %}
-  </p>
-{% endif %}
-
-{% if not hide_subtitle %}
-  <h2 class="govuk-heading-m">{{ find_legal_advisor_subtitle }}</h2>
-{% endif %}
-
-<form method="GET">
-  {% if postcode_error == true %}
-    {{ Form.postcode_input(form.postcode, custom_error=_('Postcode not found')) }}
-  {% elif error_text %}
-    {{ Form.postcode_input(form.postcode, custom_error=error_text) }}
-  {% else %}
-    {{ Form.postcode_input(form.postcode) }}
+  {% if category == 'mentalhealth' %}
+    <p class="govuk-body">
+      {% trans %}If you’re applying for legal aid for a mental health issue,
+        the requirements for the financial assessment are less rigorous than
+        for other legal aid problems.{% endtrans %}
+    </p>
   {% endif %}
-  {% if category %}
-    <div class="govuk-form-group ">
-      <input class="govuk-input govuk-input--width-10 " id="category" type="hidden" name="category" value="{{ category }}" />
-    </div>
+
+  {% if find_legal_advisor_subtitle == _('Search again') %}
+    <p class="govuk-body">
+      <a class="govuk-link" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you" aria-labelledby="aria-satisfaction-survey">
+        {% trans %}What did you think of this service?{% endtrans %}</a> {% trans %}(takes 30 seconds){% endtrans %}
+    </p>
   {% endif %}
-  <button class="govuk-button" type="submit">
-    {{ _('Search') }}
-  </button>
-</form>
+
+  {% if not hide_subtitle %}
+    <h2 class="govuk-heading-m">{{ find_legal_advisor_subtitle }}</h2>
+  {% endif %}
+
+  <form method="GET">
+    {% if postcode_error == true %}
+      {{ Form.postcode_input(form.postcode, custom_error=_('Postcode not found')) }}
+    {% elif error_text %}
+      {{ Form.postcode_input(form.postcode, custom_error=error_text) }}
+    {% else %}
+      {{ Form.postcode_input(form.postcode) }}
+    {% endif %}
+    {% if category %}
+      <div class="govuk-form-group ">
+        <input class="govuk-input govuk-input--width-10 " id="category" type="hidden" name="category" value="{{ category }}" />
+      </div>
+    {% endif %}
+    <button class="govuk-button" type="submit">
+      {{ _('Search') }}
+    </button>
+  </form>
 {% endif %}
 
 <script nonce="{{ csp_nonce() }}">

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -8,12 +8,15 @@
   {% if category %}
     {% if category == 'housing' %}
         <span class="govuk-caption-l govuk-!-margin-bottom-6">For the Housing Loss Prevention Advice Scheme</span>
+    {% elif category == 'aap' %}
+        <span class="govuk-caption-l govuk-!-margin-bottom-6">For trouble with the police and public authorities</span>
     {% else %}
       <span class="govuk-caption-l govuk-!-margin-bottom-6">For {{category_name.lower()}}</span>
     {% endif %}
   {% endif %}
 
-  <p class="govuk-body">You can call any legal advisor from this list, so you do not have to pick a local one. If they are busy, you may need to contact more than one.</p>
+  <p class="govuk-body">You can contact any legal adviser from this list.</p>
+  <p class="govuk-body">Your adviser will check whether you qualify for legal aid <strong>at no cost to you</strong> by asking about your problem and your finances. In some cases you may need to pay a contribution towards your legal aid.</p>
   {% if category == 'hlpas' %}
     <p class="govuk-body govuk-!-margin-bottom-6">If you cannot find a legal adviser to help you, contact Civil Legal Advice. Tell them that you qualify for housing loss prevention advice.</p>
   {% elif category == 'clinneg' %}
@@ -31,19 +34,29 @@
   </p>
 {% endif %}
 
+<p id="aria-satisfaction-survey" class="govuk-body">
+  {% trans -%}
+    <a class="govuk-link" href="https://www.gov.uk/done/check-if-civil-legal-advice-can-help-you">What did you think of this service?</a> (takes 30 seconds)
+  {%- endtrans %}
+</p>
+
+  {% if data.origin.postcode %}
+    <p class="govuk-body">Results in order of closeness to <strong>{{data.origin.postcode}}</strong></p>
+  {% endif %}
+
   {% for item in data.results %}
   <div>
     <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4 govuk-!-margin-top-4">
     <span class="govuk-caption-m govuk-!-margin-bottom-2">{% trans miles=item.distance|round(2) %}{{ miles }} miles away{% endtrans %}</span>
     <p class="govuk-body-l govuk-!-font-weight-bold govuk-!-margin-bottom-2">{{ item.organisation.name }} </p>
-    <p class="govuk-body govuk-!-margin-bottom-2">{{ item.telephone }}</p>
+    <p class="govuk-body govuk-!-margin-bottom-2">Telephone: {{ item.telephone }}</p>
     {% if item.location.address %}
       <p class="govuk-body govuk-!-margin-bottom-2">Address: {{ item.location.address}}, {{item.location.city }}, {{ item.location.postcode }}</p>
     {% endif %}
     {% if item.organisation.website %}
-      <p class="govuk-body govuk-!-margin-bottom-2">Website: <a target="_blank" href='http://{{ item.organisation.website }}'> {{ item.organisation.website }} (opens in a new tab)</a></p>
+      <p class="govuk-body govuk-!-margin-bottom-2">Website: <a target="_blank" class="govuk-link" href='http://{{ item.organisation.website }}'> {{ item.organisation.website }} (opens in a new tab)</a></p>
     {% endif %}
-      <p class="govuk-body govuk-!-margin-bottom-2"><a target="_blank" href='https://www.google.com/maps/dir/?api=1&origin={{ data.origin.postcode }}&destination={{ item.location.address }}, {{ item.location.postcode }}'>Map and directions (opens in a new tab)</a></p>
+      <p class="govuk-body govuk-!-margin-bottom-2"><a target="_blank" class="govuk-link" href='https://www.google.com/maps/dir/?api=1&origin={{ data.origin.postcode }}&destination={{ item.location.address }}, {{ item.location.postcode }}'>Map and directions (opens in a new tab)</a></p>
   </div>
   
   {% endfor %}
@@ -180,7 +193,11 @@
       {{ _('Find a legal advisor') }}
     </h1>
     {% if category %}
+      {% if category == 'aap' %}
+      <span class="govuk-caption-l govuk-!-margin-bottom-6">For trouble with the police and public authorities</span>
+      {% else %}
       <span class="govuk-caption-l govuk-!-margin-bottom-6">For {{category_name.lower()}}</span>
+      {% endif %}
     {% endif %}
   {% endif %}
 

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -2,17 +2,85 @@
 {% import "macros/element.html" as Element %}
 
 {% if data and data.count and data.count > 0 %}
-  <h1 class="govuk-heading-xl">
-    {{ _('Legal adviser search results') }}
+  <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+    {{ _('Contact a legal advsior') }}
   </h1>
-  <p id="larp-results" class="govuk-body">
-    {% trans count=data.results|length %}Showing {{ count }} results around{% endtrans %}
-    <strong class="govuk-!-font-weight-bold">{{ data.origin.postcode }}</strong>
-    {% if category_name %}
-      {{ _('for') }}
-        <strong class="govuk-!-font-weight-bold">{{ category_name|lower }}</strong>.
+  {% if category %}
+    {% if category == 'housing' %}
+        <span class="govuk-caption-l govuk-!-margin-bottom-6">For the Housing Loss Prevention Advice Scheme</span>
+    {% else %}
+      <span class="govuk-caption-l govuk-!-margin-bottom-6">For {{category_name.lower()}}</span>
     {% endif %}
-  </p>
+  {% endif %}
+
+  <p class="govuk-body">You can call any legal advisor from this list, so you do not have to pick a local one. If they are busy, you may need to contact more than one.</p>
+  <p class="govuk-body govuk-!-margin-bottom-6">If you cannot find a legal adviser to help you, contact Civil Legal Advice. Tell them that you qualify for housing loss prevention advice.</p>
+
+  {% for item in data.results %}
+  <div>
+    <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4 govuk-!-margin-top-4">
+    <span class="govuk-caption-m govuk-!-margin-bottom-2">{% trans miles=item.distance|round(2) %}{{ miles }} miles away{% endtrans %}</span>
+    <p class="govuk-body-l govuk-!-font-weight-bold govuk-!-margin-bottom-2">{{ item.organisation.name }} </p>
+    <p class="govuk-body govuk-!-margin-bottom-2">{{ item.telephone }}</p>
+    {% if item.location.address %}
+      <p class="govuk-body govuk-!-margin-bottom-2">Address: {{ item.location.address}}, {{item.location.city }}, {{ item.location.postcode }}</p>
+    {% endif %}
+    {% if item.organisation.website %}
+      <p class="govuk-body govuk-!-margin-bottom-2">Website: <a href='http://{{ item.organisation.website }}'> {{ item.organisation.website }}</a></p>
+    {% endif %}
+      <p class="govuk-body govuk-!-margin-bottom-2"><a href='https://www.google.com/maps/dir/?api=1&origin={{ data.origin.postcode }}&destination={{ item.location.address }}, {{ item.location.postcode }}'>Map and directions (opens in a new tab)</a></p>
+    <div class="govuk-!-margin-bottom-2">
+      {% for category in item.categories%}
+        <strong class="govuk-tag govuk-tag--grey">{{ category }}</strong>
+      {% endfor %}
+    </div>
+  </div>
+  
+  {% endfor %}
+
+  <nav class="govuk-pagination" aria-label="Pagination">
+    {% if data.current_page | int != 1 %}
+    <div class="govuk-pagination__prev">
+      <a class="govuk-link govuk-pagination__link" href={{ url_for( request.endpoint, postcode=request.args.postcode, category=request.args.category, page=data.current_page | int - 1 )}} rel="prev">
+        <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+          <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+        </svg>
+        <span class="govuk-pagination__link-title">
+          Previous<span class="govuk-visually-hidden"> page</span>
+        </span>
+      </a>
+    </div>
+    {% endif %}
+    <ul class="govuk-pagination__list">
+      {% for page_number in range(1, data.num_pages + 1) %}
+        {% if page_number == data.current_page | int %}
+          <li class="govuk-pagination__item govuk-pagination__item--current">
+            <a class="govuk-link govuk-pagination__link" href={{ url_for( request.endpoint, postcode=request.args.postcode, category=request.args.category, page=page_number)}} aria-label="Page {{ page_number }}">
+              {{ page_number }}
+            </a>
+          </li>
+          {% else %}
+          <li class="govuk-pagination__item">
+            <a class="govuk-link govuk-pagination__link" href={{ url_for( request.endpoint, postcode=request.args.postcode, category=request.args.category, page=page_number )}} aria-label="Page {{ page_number }}">
+              {{ page_number }}
+            </a>
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+    {% if data.current_page | int != data.num_pages | int %}
+      <div class="govuk-pagination__next">
+        <a class="govuk-link govuk-pagination__link" href={{ url_for( request.endpoint, postcode=request.args.postcode, category=request.args.category, page=data.current_page | int + 1 )}} rel="next">
+          <span class="govuk-pagination__link-title">
+            Next<span class="govuk-visually-hidden"> page</span>
+          </span>
+          <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+            <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+          </svg>
+        </a>
+      </div>
+    {% endif %}
+  </nav>
 
   {% if postcode_info.is_scottish_postcode
     or postcode_info.is_ni_postcode
@@ -48,67 +116,6 @@
       </strong>
     </div>
   {% endif %}
-
-  <section class="find-legal-adviser govuk-!-margin-bottom-7">
-
-    <div class="search-results-container">
-      {% if data.origin %}
-        <div id="resultsMap" class="map" data-lat="{{ data.origin.point.coordinates[1] }}" data-lon="{{ data.origin.point.coordinates[0] }}"></div>
-      {% else %}
-        <div id="resultsMap" class="map"></div>
-      {% endif %}
-      <div class="search-results">
-        <div class="search-results-list" data-current-page="{{ data.current_page }}">
-          <ul class="org-list">
-            {% for item in data.results %}
-              <li class="org-list-item vcard" data-lat="{{ item.location.point.coordinates[1] }}" data-lon="{{ item.location.point.coordinates[0] }}" data-id="{{ loop.index }}">
-                <header class="org-summary" data-laa-google-tag-manager-index-and-name="{{ loop.index }}: {{ item.organisation.name }}">
-                  <h3 class="org-title">
-                    <span class="marker">{{ loop.index }}</span>
-                    <span class="fn org">{{ item.organisation.name }}</span>
-                  </h3>
-                  <div class="distance">
-                    <span class="govuk-visually-hidden">{{ _('Distance') }}</span>
-                    {% if data.origin %}
-                      {% trans miles=item.distance|round(2) %}{{ miles }} miles{% endtrans %}
-                    {% endif %}
-                  </div>
-                </header>
-                <div class="org-details">
-                  <p class="govuk-body-s">
-                    <span class="govuk-visually-hidden">{{ _('Address') }}:</span>
-                    <span class="adr">
-                      <span class="street-address">{{ item.location.address }}</span>
-                      <span class="city">{{ item.location.city }}</span>
-                      <span class="postal-code">{{ item.location.postcode }}</span>
-                    </span>
-                  </p>
-                  <p class="govuk-body-s">
-                    <span>{{ _('Helpline') }}:</span>
-                    <span class="tel">{{ item.telephone }}</span>
-                  </p>
-                  {% if item.organisation.website %}
-                    <p class="govuk-body-s">
-                      <span>{{ _('Website') }}:</span>
-                      {{ Element.link_same_window(item.organisation.website|human_to_url, item.organisation.website|url_to_human, is_external=True, **{'class': 'url'}) }}
-                    </p>
-                  {% endif %}
-                  {% if item.categories|length %}
-                    <h4 class="govuk-heading-s govuk-!-font-size-16 govuk-!-margin-bottom-2">{{ _('Categories of law') }}</h4>
-                    <ul class="govuk-list govuk-list--bullet govuk-!-font-size-14" role="list">
-                      {% for cat in item.categories if cat %}
-                        <li class="govuk-!-margin-0" role="listitem">{{ cat }}</li>
-                      {% endfor %}
-                    </ul>
-                  {% endif %}
-                </div>
-              </li>
-            {% endfor %}
-          </ul>
-        </div>
-      </div>
-    </div>
-  </section>
 
   {% set find_legal_advisor_subtitle = _('Search again') %}
 
@@ -159,14 +166,13 @@
     </h1>
   {% else %}
     <h1 class="govuk-heading-xl">
-      {{ _('A legal adviser may be able to help you') }}
+      {{ _('Find a legal advisor') }}
     </h1>
   {% endif %}
 
   {% set find_legal_advisor_subtitle = _('Find a legal adviser') %}
 
 {% endif %}
-
 
 {% if category == 'clinneg' %}
   <p class="govuk-body">

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -16,7 +16,20 @@
   <p class="govuk-body">You can call any legal advisor from this list, so you do not have to pick a local one. If they are busy, you may need to contact more than one.</p>
   {% if category == 'hlpas' %}
     <p class="govuk-body govuk-!-margin-bottom-6">If you cannot find a legal adviser to help you, contact Civil Legal Advice. Tell them that you qualify for housing loss prevention advice.</p>
-  {% endif %}
+  {% elif category == 'clinneg' %}
+  <p class="govuk-body">
+    {% trans %}You will usually only get legal aid for advice about
+      clinical negligence if your child has suffered a brain injury during pregnancy,
+      birth or in the first 8 weeks of life.{% endtrans %}
+  </p>
+
+{% elif category == 'pi' %}
+  <p class="govuk-body">
+    {% trans %}You may be able to get legal aid in exceptional cases. You
+      could seek advice from a legal adviser about whether an application
+      might succeed in your case and how to apply.{% endtrans %}
+  </p>
+{% endif %}
 
   {% for item in data.results %}
   <div>
@@ -31,15 +44,11 @@
       <p class="govuk-body govuk-!-margin-bottom-2">Website: <a target="_blank" href='http://{{ item.organisation.website }}'> {{ item.organisation.website }} (opens in a new tab)</a></p>
     {% endif %}
       <p class="govuk-body govuk-!-margin-bottom-2"><a target="_blank" href='https://www.google.com/maps/dir/?api=1&origin={{ data.origin.postcode }}&destination={{ item.location.address }}, {{ item.location.postcode }}'>Map and directions (opens in a new tab)</a></p>
-      <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-2">Categories of law</p>
-      <ul class="govuk-list govuk-list--bullet">
-      {% for category in item.categories%}
-        <li><p class="govuk-body govuk-!-margin-bottom-1">{{ category }}</p></li>
-      {% endfor %}
-      </ul>
   </div>
   
   {% endfor %}
+
+  <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4 govuk-!-margin-top-4">
 
   <nav class="govuk-pagination" aria-label="Pagination">
     {% if data.current_page | int != 1 %}
@@ -162,42 +171,44 @@
     {% endcall %}
   {% endif %}
 
-  {% if title %}
-  {% elif category == 'pi' %}
+  {% if category == 'pi' %}
     <h1 class="govuk-heading-xl">
       {{ _('Legal aid is not usually available for advice about personal injury') }}
     </h1>
   {% else %}
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
       {{ _('Find a legal advisor') }}
     </h1>
+    {% if category %}
+      <span class="govuk-caption-l govuk-!-margin-bottom-6">For {{category_name.lower()}}</span>
+    {% endif %}
   {% endif %}
 
   {% set find_legal_advisor_subtitle = _('Find a legal adviser') %}
 
 {% endif %}
 
-{% if category == 'clinneg' %}
-  <p class="govuk-body">
-    {% trans %}You will usually only get legal aid for advice about
-      clinical negligence if your child has suffered a brain injury during pregnancy,
-      birth or in the first 8 weeks of life.{% endtrans %}
-  </p>
-  <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
-  <p class="govuk-body">
-    {% trans %}You should contact a legal aid adviser in your area, who may be able to help.{% endtrans %}
-  </p>
+
+{% if 'postcode' not in request.args %}
+
+{% if category == 'hlpas' %}
+<p class="govuk-body govuk-!-margin-bottom-6">If you cannot find a legal adviser to help you, contact Civil Legal Advice. Tell them that you qualify for housing loss prevention advice.</p>
+{% elif category == 'clinneg' %}
+<p class="govuk-body">
+{% trans %}You will usually only get legal aid for advice about
+  clinical negligence if your child has suffered a brain injury during pregnancy,
+  birth or in the first 8 weeks of life.{% endtrans %}
+</p>
 
 {% elif category == 'pi' %}
-  <p class="govuk-body">
-    {% trans %}You may be able to get legal aid in exceptional cases. You
-      could seek advice from a legal adviser about whether an application
-      might succeed in your case and how to apply.{% endtrans %}
-  </p>
-  <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
-{% else %}
-  <h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
+<p class="govuk-body">
+{% trans %}You may be able to get legal aid in exceptional cases. You
+  could seek advice from a legal adviser about whether an application
+  might succeed in your case and how to apply.{% endtrans %}
+</p>
 {% endif %}
+
+<h2 class="govuk-heading-m">{{ _('What happens next') }}</h2>
 
 <p class="govuk-body">
   {% trans %}Your adviser will check whether you qualify for legal aid <strong>at no cost to you</strong> by asking about your problem and your finances.{% endtrans %}
@@ -240,7 +251,7 @@
     {{ _('Search') }}
   </button>
 </form>
-
+{% endif %}
 
 <script nonce="{{ csp_nonce() }}">
   window.LABELS = {


### PR DESCRIPTION
## What does this pull request do?

Redesigns the Find a Legal Advisor page to match the updated design found [here](https://www.figma.com/file/RPecObJVq83Is9uNQsmzaz/Building-HLPAS-into-CLA?node-id=1916%3A1139&mode=dev).

### Desktop view:
![Screenshot 2024-04-09 at 10 58 01](https://github.com/ministryofjustice/cla_public/assets/143531642/f9280ef4-0a0a-45de-a028-00f332e490be)

### Mobile view:
![Screenshot 2024-04-09 at 11 59 56](https://github.com/ministryofjustice/cla_public/assets/143531642/71768251-8d8d-4c22-a3db-1351150d0f58)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
