### PR TITLE
LGA-3047: Fixed bug where postcode input disappeared when invalid postcode entered

### DIFF
--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -209,7 +209,7 @@
 {% endif %}
 
 
-{% if 'postcode' not in request.args or form.postcode.errors %}
+{% if 'postcode' not in request.args or form.postcode.errors or data.count == 0 %}
 
   {{ category_information(category) }}
 

--- a/cla_public/templates/checker/result/_find-legal-adviser.html
+++ b/cla_public/templates/checker/result/_find-legal-adviser.html
@@ -38,6 +38,41 @@
     {{ category_caption(category) }}
   </h1>
 
+  {% if postcode_info.is_scottish_postcode
+    or postcode_info.is_ni_postcode
+    or postcode_info.is_mann_postcode
+    or postcode_info.is_jersey_postcode
+    or postcode_info.is_guernsey_postcode
+    %}
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning </span>
+        {% if postcode_info.is_scottish_postcode %}
+          {% trans
+            link=Element.link_same_window('https://www.mygov.scot/legal-aid/', _('mygov.scot'), True)
+          %}Legal Aid is different in Scotland. Visit {{ link }} for more information.{% endtrans %}
+        {% elif postcode_info.is_ni_postcode %}
+          {% trans
+            link=Element.link_same_window('https://www.nidirect.gov.uk/articles/legal-aid-schemes', _('nidirect.gov.uk'), True)
+          %}Legal Aid is different in Northern Ireland. Visit {{ link }} for more information.{% endtrans %}
+        {% elif postcode_info.is_mann_postcode %}
+          {% trans
+            link=Element.link_same_window('https://www.gov.im/categories/benefits-and-financial-support/legal-aid/', _('gov.im'), True)
+          %}Legal Aid is different on the Isle of Man. Visit {{ link }} for more information.{% endtrans %}
+        {% elif postcode_info.is_jersey_postcode  %}
+          {% trans
+            link=Element.link_same_window('https://www.legalaid.je/', _('legalaid.je'), True)
+          %}Legal Aid is different in Jersey. Visit {{ link }} for more information.{% endtrans %}
+        {% elif postcode_info.is_guernsey_postcode %}
+          {% trans
+            link=Element.link_same_window('https://www.gov.gg/legalaid', _('gov.gg'), True)
+          %}Legal Aid is different in Guernsey. Visit {{ link }} for more information.{% endtrans %}
+        {% endif %}
+      </strong>
+    </div>
+  {% endif %}
+
 
   <p class="govuk-body">You can contact any legal adviser from this list.</p>
   <p class="govuk-body">Your adviser will check whether you qualify for legal aid <strong>at no cost to you</strong> by asking about your problem and your finances. In some cases you may need to pay a contribution towards your legal aid.</p>
@@ -116,41 +151,6 @@
     {% endif %}
   </nav>
 
-  {% if postcode_info.is_scottish_postcode
-    or postcode_info.is_ni_postcode
-    or postcode_info.is_mann_postcode
-    or postcode_info.is_jersey_postcode
-    or postcode_info.is_guernsey_postcode
-    %}
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning </span>
-        {% if postcode_info.is_scottish_postcode %}
-          {% trans
-            link=Element.link_same_window('https://www.mygov.scot/legal-aid/', _('mygov.scot'), True)
-          %}Legal Aid is different in Scotland. Visit {{ link }} for more information.{% endtrans %}
-        {% elif postcode_info.is_ni_postcode %}
-          {% trans
-            link=Element.link_same_window('https://www.nidirect.gov.uk/articles/legal-aid-schemes', _('nidirect.gov.uk'), True)
-          %}Legal Aid is different in Northern Ireland. Visit {{ link }} for more information.{% endtrans %}
-        {% elif postcode_info.is_mann_postcode %}
-          {% trans
-            link=Element.link_same_window('https://www.gov.im/categories/benefits-and-financial-support/legal-aid/', _('gov.im'), True)
-          %}Legal Aid is different on the Isle of Man. Visit {{ link }} for more information.{% endtrans %}
-        {% elif postcode_info.is_jersey_postcode  %}
-          {% trans
-            link=Element.link_same_window('https://www.legalaid.je/', _('legalaid.je'), True)
-          %}Legal Aid is different in Jersey. Visit {{ link }} for more information.{% endtrans %}
-        {% elif postcode_info.is_guernsey_postcode %}
-          {% trans
-            link=Element.link_same_window('https://www.gov.gg/legalaid', _('gov.gg'), True)
-          %}Legal Aid is different in Guernsey. Visit {{ link }} for more information.{% endtrans %}
-        {% endif %}
-      </strong>
-    </div>
-  {% endif %}
-
   {% set find_legal_advisor_subtitle = _('Search again') %}
 
 {% else %}
@@ -209,7 +209,7 @@
 {% endif %}
 
 
-{% if 'postcode' not in request.args %}
+{% if 'postcode' not in request.args or form.postcode.errors %}
 
   {{ category_information(category) }}
 


### PR DESCRIPTION
## What does this pull request do?

- Fixes an issue where the input field was wrongly removed when an invalid postcode was entered.
- Moves the warning banners to the top of the list.


<img width="1536" alt="Screenshot 2024-04-15 at 15 48 26" src="https://github.com/ministryofjustice/cla_public/assets/143531642/02409d8e-600b-420a-8b03-6b21d19d712c">
<img width="1536" alt="Screenshot 2024-04-15 at 15 49 06" src="https://github.com/ministryofjustice/cla_public/assets/143531642/1e7f0ed1-bb47-4d49-b541-2e0717d85e9b">
<img width="1183" alt="Screenshot 2024-04-15 at 15 49 53" src="https://github.com/ministryofjustice/cla_public/assets/143531642/128c9b9e-923c-41e0-8ec6-b414e4039f8f">

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
