### PR TITLE
LGA 3027 Display postcode errors

### DIFF
--- a/cla_public/templates/checker/result/find-legal-adviser-search/form.html
+++ b/cla_public/templates/checker/result/find-legal-adviser-search/form.html
@@ -14,6 +14,44 @@
   {% call FALA.category_caption(category, category_name) %}{% endcall %}
 {% endif %}
 
+{% if 'count' in data and data.count == 0 %}
+  {% call Element.alert('error', title=_('No results')) %}
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li>
+          <a href="#postcode">
+            {% trans %}We couldn’t find any results for your search. We are constantly updating our records so please try again later.{% endtrans %}
+          </a>
+        </li>
+      </ul>
+    </div>
+  {% endcall %}
+
+  {% set postcode_error = true %}
+
+{% endif %}
+
+{% if form.postcode and form.postcode.errors %}
+  {% if postcode_info.is_mann_postcode %}
+    {% set error_text = _('No results returned for the Isle of Man, try a postcode in England or Wales') %}
+  {% elif postcode_info.is_jersey_postcode %}
+    {% set error_text = _('No results returned for Jersey, try a postcode in England or Wales') %}
+  {% elif postcode_info.is_guernsey_postcode %}
+    {% set error_text = _('No results returned for Guernsey, try a postcode in England or Wales') %}
+  {% else %}
+    {% set error_text = form.postcode.errors[0] %}
+  {% endif %}
+  {% call Element.alert('error') %}
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li>
+          <a href="#postcode">{{ error_text }}</a>
+        </li>
+      </ul>
+    </div>
+  {% endcall %}
+{% endif %}
+
 
 {% if category == "hlpas" %}
   <p class="govuk-body">{% trans %}We’ll show you a list of legal advisers. You can contact any adviser from this list.{% endtrans %}</p>

--- a/cla_public/templates/checker/result/find-legal-adviser-search/index.html
+++ b/cla_public/templates/checker/result/find-legal-adviser-search/index.html
@@ -1,4 +1,4 @@
-{% if "postcode" in request.args %}
+{% if "postcode" in request.args and not form.postcode.errors and data.count > 0 %}
   {% include 'checker/result/find-legal-adviser-search/result.html' %}
 {% else %}
   {% include 'checker/result/find-legal-adviser-search/form.html' %}

--- a/cla_public/templates/checker/result/find-legal-adviser-search/result.html
+++ b/cla_public/templates/checker/result/find-legal-adviser-search/result.html
@@ -132,7 +132,8 @@
   {% endif %}
 
 
-
   {% set find_legal_advisor_subtitle = _('Find a legal adviser') %}
+
+  {% include 'checker/result/find-legal-adviser-search/form.html' %}
 
 {% endif %}

--- a/cla_public/templates/checker/result/find-legal-adviser-search/result.html
+++ b/cla_public/templates/checker/result/find-legal-adviser-search/result.html
@@ -9,7 +9,6 @@
 
 {{ FALA.out_of_bounds_warning(postcode_info) }}
 
-{% if data and data.count and data.count > 0 %}
   {% if category != "hlpas" %}
   <p class="govuk-body">You can contact any legal adviser from this list.</p>
   <p class="govuk-body">Your adviser will check whether you qualify for legal aid <strong>at no cost to you</strong> by asking about your problem and your finances. In some cases you may need to pay a contribution towards your legal aid.</p>
@@ -22,11 +21,11 @@
   {%- endtrans %}
 </p>
 
-  {% if data.origin.postcode %}
-    <p class="govuk-body">Results in order of closeness to <strong>{{data.origin.postcode}}</strong></p>
-  {% endif %}
+{% if data.origin.postcode %}
+  <p class="govuk-body">Results in order of closeness to <strong>{{data.origin.postcode}}</strong></p>
+{% endif %}
 
-  {% for item in data.results %}
+{% for item in data.results %}
   <div>
     <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4 govuk-!-margin-top-4">
     <span class="govuk-caption-m govuk-!-margin-bottom-2">{% trans miles=item.distance|round(2) %}{{ miles }} miles away{% endtrans %}</span>
@@ -40,100 +39,51 @@
     {% endif %}
       <p class="govuk-body govuk-!-margin-bottom-2"><a target="_blank" class="govuk-link" href='https://www.google.com/maps/dir/?api=1&origin={{ data.origin.postcode }}&destination={{ item.location.address }}, {{ item.location.postcode }}'>Map and directions (opens in a new tab)</a></p>
   </div>
+{% endfor %}
 
-  {% endfor %}
+<hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4 govuk-!-margin-top-4">
 
-  <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4 govuk-!-margin-top-4">
-
-  <nav class="govuk-pagination" aria-label="Pagination">
-    {% if data.current_page | int != 1 %}
-    <div class="govuk-pagination__prev">
-      <a class="govuk-link govuk-pagination__link" href={{ url_for( request.endpoint, postcode=request.args.postcode, category=request.args.category, page=data.current_page | int - 1 )}} rel="prev">
-        <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-          <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-        </svg>
+<nav class="govuk-pagination" aria-label="Pagination">
+  {% if data.current_page | int != 1 %}
+  <div class="govuk-pagination__prev">
+    <a class="govuk-link govuk-pagination__link" href={{ url_for( request.endpoint, postcode=request.args.postcode, category=request.args.category, page=data.current_page | int - 1 )}} rel="prev">
+      <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+        <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+      </svg>
+      <span class="govuk-pagination__link-title">
+        Previous<span class="govuk-visually-hidden"> page</span>
+      </span>
+    </a>
+  </div>
+  {% endif %}
+  <ul class="govuk-pagination__list">
+    {% for page_number in range(1, data.num_pages + 1) %}
+      {% if page_number == data.current_page | int %}
+        <li class="govuk-pagination__item govuk-pagination__item--current">
+          <a class="govuk-link govuk-pagination__link" href={{ url_for( request.endpoint, postcode=request.args.postcode, category=request.args.category, page=page_number)}} aria-label="Page {{ page_number }}">
+            {{ page_number }}
+          </a>
+        </li>
+        {% else %}
+        <li class="govuk-pagination__item">
+          <a class="govuk-link govuk-pagination__link" href={{ url_for( request.endpoint, postcode=request.args.postcode, category=request.args.category, page=page_number )}} aria-label="Page {{ page_number }}">
+            {{ page_number }}
+          </a>
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+  {% if data.current_page | int != data.num_pages | int %}
+    <div class="govuk-pagination__next">
+      <a class="govuk-link govuk-pagination__link" href={{ url_for( request.endpoint, postcode=request.args.postcode, category=request.args.category, page=data.current_page | int + 1 )}} rel="next">
         <span class="govuk-pagination__link-title">
-          Previous<span class="govuk-visually-hidden"> page</span>
+          Next<span class="govuk-visually-hidden"> page</span>
         </span>
+        <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+          <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+        </svg>
       </a>
     </div>
-    {% endif %}
-    <ul class="govuk-pagination__list">
-      {% for page_number in range(1, data.num_pages + 1) %}
-        {% if page_number == data.current_page | int %}
-          <li class="govuk-pagination__item govuk-pagination__item--current">
-            <a class="govuk-link govuk-pagination__link" href={{ url_for( request.endpoint, postcode=request.args.postcode, category=request.args.category, page=page_number)}} aria-label="Page {{ page_number }}">
-              {{ page_number }}
-            </a>
-          </li>
-          {% else %}
-          <li class="govuk-pagination__item">
-            <a class="govuk-link govuk-pagination__link" href={{ url_for( request.endpoint, postcode=request.args.postcode, category=request.args.category, page=page_number )}} aria-label="Page {{ page_number }}">
-              {{ page_number }}
-            </a>
-          </li>
-        {% endif %}
-      {% endfor %}
-    </ul>
-    {% if data.current_page | int != data.num_pages | int %}
-      <div class="govuk-pagination__next">
-        <a class="govuk-link govuk-pagination__link" href={{ url_for( request.endpoint, postcode=request.args.postcode, category=request.args.category, page=data.current_page | int + 1 )}} rel="next">
-          <span class="govuk-pagination__link-title">
-            Next<span class="govuk-visually-hidden"> page</span>
-          </span>
-          <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-            <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-          </svg>
-        </a>
-      </div>
-    {% endif %}
-  </nav>
-
-  {% set find_legal_advisor_subtitle = _('Search again') %}
-
-{% else %}
-
-  {% if 'count' in data and data.count == 0 %}
-    {% call Element.alert('error', title=_('No results')) %}
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          <li>
-            <a href="#postcode">
-              {% trans %}We couldn’t find any results for your search. We are constantly updating our records so please try again later.{% endtrans %}
-            </a>
-          </li>
-        </ul>
-      </div>
-    {% endcall %}
-
-    {% set postcode_error = true %}
-
   {% endif %}
+</nav>
 
-  {% if form.postcode and form.postcode.errors %}
-    {% if postcode_info.is_mann_postcode %}
-      {% set error_text = _('No results returned for the Isle of Man, try a postcode in England or Wales') %}
-    {% elif postcode_info.is_jersey_postcode %}
-      {% set error_text = _('No results returned for Jersey, try a postcode in England or Wales') %}
-    {% elif postcode_info.is_guernsey_postcode %}
-      {% set error_text = _('No results returned for Guernsey, try a postcode in England or Wales') %}
-    {% else %}
-      {% set error_text = form.postcode.errors[0] %}
-    {% endif %}
-    {% call Element.alert('error') %}
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          <li>
-            <a href="#postcode">{{ error_text }}</a>
-          </li>
-        </ul>
-      </div>
-    {% endcall %}
-  {% endif %}
-
-
-  {% set find_legal_advisor_subtitle = _('Find a legal adviser') %}
-
-  {% include 'checker/result/find-legal-adviser-search/form.html' %}
-
-{% endif %}

--- a/cla_public/templates/checker/result/find-legal-adviser-search/result.html
+++ b/cla_public/templates/checker/result/find-legal-adviser-search/result.html
@@ -7,6 +7,8 @@
   {% call FALA.category_caption(category, category_name) %}{% endcall %}
 </h1>
 
+{{ FALA.out_of_bounds_warning(postcode_info) }}
+
 {% if data and data.count and data.count > 0 %}
   {% if category != "hlpas" %}
   <p class="govuk-body">You can contact any legal adviser from this list.</p>
@@ -86,41 +88,6 @@
       </div>
     {% endif %}
   </nav>
-
-  {% if postcode_info.is_scottish_postcode
-    or postcode_info.is_ni_postcode
-    or postcode_info.is_mann_postcode
-    or postcode_info.is_jersey_postcode
-    or postcode_info.is_guernsey_postcode
-    %}
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning </span>
-        {% if postcode_info.is_scottish_postcode %}
-          {% trans
-            link=Element.link_same_window('https://www.mygov.scot/legal-aid/', _('mygov.scot'), True)
-          %}Legal Aid is different in Scotland. Visit {{ link }} for more information.{% endtrans %}
-        {% elif postcode_info.is_ni_postcode %}
-          {% trans
-            link=Element.link_same_window('https://www.nidirect.gov.uk/articles/legal-aid-schemes', _('nidirect.gov.uk'), True)
-          %}Legal Aid is different in Northern Ireland. Visit {{ link }} for more information.{% endtrans %}
-        {% elif postcode_info.is_mann_postcode %}
-          {% trans
-            link=Element.link_same_window('https://www.gov.im/categories/benefits-and-financial-support/legal-aid/', _('gov.im'), True)
-          %}Legal Aid is different on the Isle of Man. Visit {{ link }} for more information.{% endtrans %}
-        {% elif postcode_info.is_jersey_postcode  %}
-          {% trans
-            link=Element.link_same_window('https://www.legalaid.je/', _('legalaid.je'), True)
-          %}Legal Aid is different in Jersey. Visit {{ link }} for more information.{% endtrans %}
-        {% elif postcode_info.is_guernsey_postcode %}
-          {% trans
-            link=Element.link_same_window('https://www.gov.gg/legalaid', _('gov.gg'), True)
-          %}Legal Aid is different in Guernsey. Visit {{ link }} for more information.{% endtrans %}
-        {% endif %}
-      </strong>
-    </div>
-  {% endif %}
 
   {% set find_legal_advisor_subtitle = _('Search again') %}
 

--- a/cla_public/templates/checker/result/find-legal-adviser-search/result.html
+++ b/cla_public/templates/checker/result/find-legal-adviser-search/result.html
@@ -39,6 +39,7 @@
     {% endif %}
       <p class="govuk-body govuk-!-margin-bottom-2"><a target="_blank" class="govuk-link" href='https://www.google.com/maps/dir/?api=1&origin={{ data.origin.postcode }}&destination={{ item.location.address }}, {{ item.location.postcode }}'>Map and directions (opens in a new tab)</a></p>
   </div>
+
 {% endfor %}
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4 govuk-!-margin-top-4">

--- a/cla_public/templates/checker/result/find-legal-adviser-search/result.html
+++ b/cla_public/templates/checker/result/find-legal-adviser-search/result.html
@@ -39,7 +39,6 @@
     {% endif %}
       <p class="govuk-body govuk-!-margin-bottom-2"><a target="_blank" class="govuk-link" href='https://www.google.com/maps/dir/?api=1&origin={{ data.origin.postcode }}&destination={{ item.location.address }}, {{ item.location.postcode }}'>Map and directions (opens in a new tab)</a></p>
   </div>
-
 {% endfor %}
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4 govuk-!-margin-top-4">

--- a/cla_public/templates/macros/find-legal-adviser.html
+++ b/cla_public/templates/macros/find-legal-adviser.html
@@ -1,3 +1,5 @@
+{% import "macros/element.html" as Element %}
+
 {% macro category_information(category, caller=None) %}
   {% if category == 'hlpas' %}
     <p class="govuk-body">{% trans %}You can contact any legal adviser from this list.{% endtrans %}</p>
@@ -28,4 +30,42 @@
       <span class="govuk-caption-l govuk-!-margin-bottom-6">For {{category_name.lower()}}</span>
     {% endif %}
   {% endif %}
+{% endmacro %}
+
+
+{% macro out_of_bounds_warning(postcode_info, caller=None) %}
+{% if postcode_info.is_scottish_postcode
+  or postcode_info.is_ni_postcode
+  or postcode_info.is_mann_postcode
+  or postcode_info.is_jersey_postcode
+  or postcode_info.is_guernsey_postcode
+  %}
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning </span>
+      {% if postcode_info.is_scottish_postcode %}
+        {% trans
+          link=Element.link_same_window('https://www.mygov.scot/legal-aid/', _('mygov.scot'), True)
+        %}Legal Aid is different in Scotland. Visit {{ link }} for more information.{% endtrans %}
+      {% elif postcode_info.is_ni_postcode %}
+        {% trans
+          link=Element.link_same_window('https://www.nidirect.gov.uk/articles/legal-aid-schemes', _('nidirect.gov.uk'), True)
+        %}Legal Aid is different in Northern Ireland. Visit {{ link }} for more information.{% endtrans %}
+      {% elif postcode_info.is_mann_postcode %}
+        {% trans
+          link=Element.link_same_window('https://www.gov.im/categories/benefits-and-financial-support/legal-aid/', _('gov.im'), True)
+        %}Legal Aid is different on the Isle of Man. Visit {{ link }} for more information.{% endtrans %}
+      {% elif postcode_info.is_jersey_postcode  %}
+        {% trans
+          link=Element.link_same_window('https://www.legalaid.je/', _('legalaid.je'), True)
+        %}Legal Aid is different in Jersey. Visit {{ link }} for more information.{% endtrans %}
+      {% elif postcode_info.is_guernsey_postcode %}
+        {% trans
+          link=Element.link_same_window('https://www.gov.gg/legalaid', _('gov.gg'), True)
+        %}Legal Aid is different in Guernsey. Visit {{ link }} for more information.{% endtrans %}
+      {% endif %}
+    </strong>
+  </div>
+{% endif %}
 {% endmacro %}

--- a/cla_public/templates/macros/find-legal-adviser.html
+++ b/cla_public/templates/macros/find-legal-adviser.html
@@ -21,7 +21,7 @@
 
 
 {% macro category_caption(category, category_name, caller=None) %}
-  {% if category %}
+  {% if category and category_name %}
     {% if category == 'aap' %}
         <span class="govuk-caption-l govuk-!-margin-bottom-6">{% trans %}For trouble with the police and public authorities{% endtrans %}</span>
     {% elif category == 'hlpas' %}

--- a/cla_public/templates/macros/find-legal-adviser.html
+++ b/cla_public/templates/macros/find-legal-adviser.html
@@ -33,39 +33,39 @@
 {% endmacro %}
 
 
-{% macro out_of_bounds_warning(postcode_info, caller=None) %}
-{% if postcode_info.is_scottish_postcode
-  or postcode_info.is_ni_postcode
-  or postcode_info.is_mann_postcode
-  or postcode_info.is_jersey_postcode
-  or postcode_info.is_guernsey_postcode
-  %}
-  <div class="govuk-warning-text">
-    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-    <strong class="govuk-warning-text__text">
-      <span class="govuk-warning-text__assistive">Warning </span>
-      {% if postcode_info.is_scottish_postcode %}
-        {% trans
-          link=Element.link_same_window('https://www.mygov.scot/legal-aid/', _('mygov.scot'), True)
-        %}Legal Aid is different in Scotland. Visit {{ link }} for more information.{% endtrans %}
-      {% elif postcode_info.is_ni_postcode %}
-        {% trans
-          link=Element.link_same_window('https://www.nidirect.gov.uk/articles/legal-aid-schemes', _('nidirect.gov.uk'), True)
-        %}Legal Aid is different in Northern Ireland. Visit {{ link }} for more information.{% endtrans %}
-      {% elif postcode_info.is_mann_postcode %}
-        {% trans
-          link=Element.link_same_window('https://www.gov.im/categories/benefits-and-financial-support/legal-aid/', _('gov.im'), True)
-        %}Legal Aid is different on the Isle of Man. Visit {{ link }} for more information.{% endtrans %}
-      {% elif postcode_info.is_jersey_postcode  %}
-        {% trans
-          link=Element.link_same_window('https://www.legalaid.je/', _('legalaid.je'), True)
-        %}Legal Aid is different in Jersey. Visit {{ link }} for more information.{% endtrans %}
-      {% elif postcode_info.is_guernsey_postcode %}
-        {% trans
-          link=Element.link_same_window('https://www.gov.gg/legalaid', _('gov.gg'), True)
-        %}Legal Aid is different in Guernsey. Visit {{ link }} for more information.{% endtrans %}
-      {% endif %}
-    </strong>
-  </div>
-{% endif %}
+{% macro out_of_bounds_warning(postcode_info) %}
+  {% if postcode_info.is_scottish_postcode
+    or postcode_info.is_ni_postcode
+    or postcode_info.is_mann_postcode
+    or postcode_info.is_jersey_postcode
+    or postcode_info.is_guernsey_postcode
+    %}
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning </span>
+        {% if postcode_info.is_scottish_postcode %}
+          {% trans
+            link=Element.link_same_window('https://www.mygov.scot/legal-aid/', _('mygov.scot'), True)
+          %}Legal Aid is different in Scotland. Visit {{ link }} for more information.{% endtrans %}
+        {% elif postcode_info.is_ni_postcode %}
+          {% trans
+            link=Element.link_same_window('https://www.nidirect.gov.uk/articles/legal-aid-schemes', _('nidirect.gov.uk'), True)
+          %}Legal Aid is different in Northern Ireland. Visit {{ link }} for more information.{% endtrans %}
+        {% elif postcode_info.is_mann_postcode %}
+          {% trans
+            link=Element.link_same_window('https://www.gov.im/categories/benefits-and-financial-support/legal-aid/', _('gov.im'), True)
+          %}Legal Aid is different on the Isle of Man. Visit {{ link }} for more information.{% endtrans %}
+        {% elif postcode_info.is_jersey_postcode  %}
+          {% trans
+            link=Element.link_same_window('https://www.legalaid.je/', _('legalaid.je'), True)
+          %}Legal Aid is different in Jersey. Visit {{ link }} for more information.{% endtrans %}
+        {% elif postcode_info.is_guernsey_postcode %}
+          {% trans
+            link=Element.link_same_window('https://www.gov.gg/legalaid', _('gov.gg'), True)
+          %}Legal Aid is different in Guernsey. Visit {{ link }} for more information.{% endtrans %}
+        {% endif %}
+      </strong>
+    </div>
+  {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## What does this pull request do?

### Displays the postcode form when the previous request resulted in an error
![Screenshot 2024-04-25 at 11 36 11](https://github.com/ministryofjustice/cla_public/assets/143531642/e3bebcb2-4316-4eb0-95e4-208a9fbccdf7)

### Renders out of bounds warning at the top of the results list
![Screenshot 2024-04-25 at 11 36 37](https://github.com/ministryofjustice/cla_public/assets/143531642/40eb8ba7-8ccc-4dae-b58a-46c32211f843)

## Any other changes that would benefit highlighting?

Now only attempts to render the category caption when `category_name` is present.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
