### PR TITLE
LGA-3077 Fix misdirect issue for benefits category

### DIFF
--- a/cla_public/apps/checker/views.py
+++ b/cla_public/apps/checker/views.py
@@ -373,7 +373,7 @@ class Eligible(HasFormMixin, RequiresSession, views.MethodView, object):
         steps = CheckerWizard("").relevant_steps[:-1]
         if session.checker.category in NO_CALLBACK_CATEGORIES:
             session.store({"outcome": "referred/f2f/means"})
-            return redirect(url_for(".find-legal-adviser", category=session.checker.category))
+            return redirect(url_for(".face-to-face", category=session.checker.category))
 
         current_step = {"count": len(steps) + 1, "is_current": True, "is_completed": False}
 

--- a/cla_public/templates/checker/result/eligible-f2f.html
+++ b/cla_public/templates/checker/result/eligible-f2f.html
@@ -1,6 +1,6 @@
 {% if request.is_xhr %}
     {% with postcode_info=postcode_info  %}
-      {% include "checker/result/_find-legal-adviser.html" %}
+      {% include "checker/result/find-legal-adviser-search/index.html" %}
     {% endwith %}
 {% else %}
 
@@ -42,7 +42,7 @@
     </p>
 
     {% with postcode_info=postcode_info  %}
-      {% include "checker/result/_find-legal-adviser.html" %}
+      {% include "checker/result/find-legal-adviser-search/index.html" %}
     {% endwith %}
     {% include "checker/time-out-warning.html" %}
   {% endblock %}

--- a/cla_public/templates/checker/result/face-to-face.html
+++ b/cla_public/templates/checker/result/face-to-face.html
@@ -1,6 +1,6 @@
 {% if request.is_xhr %}
   {% with postcode_info=postcode_info  %}
-    {% include "checker/result/_find-legal-adviser.html" %}
+    {% include "checker/result/find-legal-adviser-search/index.html" %}
   {% endwith %}
 {% else %}
 

--- a/cla_public/templates/checker/result/find-legal-adviser-search/form.html
+++ b/cla_public/templates/checker/result/find-legal-adviser-search/form.html
@@ -9,7 +9,7 @@
   </h1>
 {% elif category == 'benefits' %}
   <h1 class="govuk-heading-xl">
-    {{ _('You might quality for legal aid') }}
+    {{ _('You might qualify for legal aid') }}
   </h1>
 {% else %}
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">

--- a/cla_public/templates/checker/result/find-legal-adviser-search/form.html
+++ b/cla_public/templates/checker/result/find-legal-adviser-search/form.html
@@ -7,6 +7,10 @@
   <h1 class="govuk-heading-xl">
     {{ _('Legal aid is not usually available for advice about personal injury') }}
   </h1>
+{% elif category == 'benefits' %}
+  <h1 class="govuk-heading-xl">
+    {{ _('You might quality for legal aid') }}
+  </h1>
 {% else %}
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
     {{ _('Find a legal adviser') }}

--- a/cla_public/templates/laalaa.html
+++ b/cla_public/templates/laalaa.html
@@ -1,6 +1,6 @@
 {% if request.is_xhr %}
   {% with postcode_info=postcode_info  %}
-    {% include "checker/result/_find-legal-adviser.html" %}
+    {% include "checker/result/find-legal-adviser-search/index.html" %}
   {% endwith %}
 {% else %}
 
@@ -30,7 +30,7 @@
 
     {% set hide_subtitle = True %}
     {% with postcode_info=postcode_info  %}
-      {% include "checker/result/_find-legal-adviser.html" %}
+      {% include "checker/result/find-legal-adviser-search/index.html" %}
     {% endwith %}
   {% endblock %}
 

--- a/cla_public/templates/macros/find-legal-adviser.html
+++ b/cla_public/templates/macros/find-legal-adviser.html
@@ -16,6 +16,25 @@
       could seek advice from a legal adviser about whether an application
       might succeed in your case and how to apply.{% endtrans %}
     </p>
+  {% elif category == 'benefits' %}
+      <p class="govuk-body">
+      {% trans %}Civil Legal Advice does not provide advice about issues
+        related to welfare benefits but you may be able to get free advice from
+        a legal adviser in your area.{% endtrans %}
+    </p>
+
+    <p class="govuk-body">
+      {% trans %}To get advice about appealing a decision made by the social
+        security tribunal about your benefits to the Upper Tribunal, Court of
+        Appeal or Supreme Court, you should contact a legal adviser.
+      {% endtrans %}
+    </p>
+
+    <p class="govuk-body">
+      {% trans %}If you don’t qualify for legal aid, you will have to pay for
+        legal advice. You should ask your adviser about the cost of their
+        advice.{% endtrans %}
+    </p>
   {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
## What does this pull request do?

Fixes an issue where references to the now removed `_find_a_legal_advisor.html` template were still present.

When the user is eligible for legal aid with the benefits category they are presented with mini fala as expected.

This page matches the page before the HLPAS changes were introduced.
<img width="1215" alt="Screenshot 2024-04-29 at 12 35 01" src="https://github.com/ministryofjustice/cla_public/assets/143531642/83ffccfb-48c4-4b72-bdc6-582dfdcb8a16">

## Any other changes that would benefit highlighting?

Removes all references to the now removed `_find_a_legal_advisor.html`

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
