### PR TITLE
LGA-3158 - Add BSL E-mail field

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,9 @@ ARG ALPINE_BASE_IMAGE="alpine:3.15"
 ARG BASE_REQUIREMENTS_FILE="requirements.txt"
 
 FROM ${NODE_BASE_IMAGE} as node_build
-COPY ./cla_public/static-src ./cla_public/static-src
 COPY ./package.json ./package-lock.json ./
 RUN npm install
-
+COPY ./cla_public/static-src ./cla_public/static-src
 COPY ./gulpfile.js .
 COPY ./tasks ./tasks
 RUN ./node_modules/.bin/gulp build

--- a/cla_public/apps/checker/tests/test_payloads.py
+++ b/cla_public/apps/checker/tests/test_payloads.py
@@ -336,7 +336,6 @@ class TestApiPayloads(FlaskAppTestCase):
     def application_form_data(self):
         adaptations_data = {
             "bsl_webcam": YES,
-            "minicom": YES,
             "text_relay": YES,
             "welsh": YES,
             "is_other_language": YES,
@@ -374,7 +373,6 @@ class TestApiPayloads(FlaskAppTestCase):
             self.assertEqual(payload["personal_details"]["street"], "21 Jump Street")
 
             self.assertEqual(payload["adaptation_details"]["bsl_webcam"], True)
-            self.assertEqual(payload["adaptation_details"]["minicom"], True)
             self.assertEqual(payload["adaptation_details"]["text_relay"], True)
             self.assertEqual(payload["adaptation_details"]["language"], "WELSH")
             self.assertEqual(payload["adaptation_details"]["notes"], "other")

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -70,6 +70,11 @@ class AdaptationsForm(BabelTranslationsFormMixin, NoCsrfForm):
     def __init__(self, formdata=None, obj=None, prefix="", data=None, meta=None, **kwargs):
         if data is None:
             data = {"welsh": get_locale()[:2] == "cy"}
+        if formdata is not None:
+            is_bsl = formdata.get("adaptations-bsl_webcam")
+            email = formdata.get("adaptations-bsl_email") or formdata.get("email")
+            if is_bsl and email:
+                formdata["adaptations-bsl_email"] = email
         super(AdaptationsForm, self).__init__(formdata, obj, prefix, data, meta, **kwargs)
 
 

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -43,8 +43,7 @@ class AdaptationsForm(BabelTranslationsFormMixin, NoCsrfForm):
 
     bsl_webcam = BooleanField(_(u"British Sign Language – webcam"))
     bsl_email = StringField(
-        _(u"Email"),
-        description=_(u"Enter your email address so we can arrange a BSL call."),
+        _(u"Enter your email address so we can arrange a BSL call."),
         validators=[
             IgnoreIf("bsl_webcam", FieldValue(False)),
             Length(max=255, message=_(u"Your address must be 255 characters or less")),

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -48,7 +48,7 @@ class AdaptationsForm(BabelTranslationsFormMixin, NoCsrfForm):
         validators=[
             IgnoreIf("bsl_webcam", FieldValue(False)),
             Length(max=255, message=_(u"Your address must be 255 characters or less")),
-            EmailValidator(message=_(u"Enter an email address.")),
+            EmailValidator(message=_(u"Enter your email address so we can arrange a BSL call")),
         ],
     )
     text_relay = BooleanField(_(u"Text relay"))

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -43,7 +43,7 @@ class AdaptationsForm(BabelTranslationsFormMixin, NoCsrfForm):
 
     bsl_webcam = BooleanField(_(u"British Sign Language – webcam"))
     bsl_email = StringField(
-        _(u"Enter your email address so we can arrange a BSL call."),
+        _(u"Enter your email address so we can arrange a BSL call"),
         validators=[
             IgnoreIf("bsl_webcam", FieldValue(False)),
             Length(max=255, message=_(u"Your address must be 255 characters or less")),

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -48,7 +48,7 @@ class AdaptationsForm(BabelTranslationsFormMixin, NoCsrfForm):
         validators=[
             IgnoreIf("bsl_webcam", FieldValue(False)),
             Length(max=255, message=_(u"Your address must be 255 characters or less")),
-            EmailValidator(message=_(u"Enter your email address so we can arrange a BSL call")),
+            EmailValidator(message=_(u"Enter your email address")),
         ],
     )
     text_relay = BooleanField(_(u"Text relay"))

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 "Contact forms"
 
+from werkzeug.datastructures import ImmutableMultiDict
 from flask import current_app
 from flask.ext.babel import lazy_gettext as _
 from flask_wtf import Form
@@ -72,7 +73,9 @@ class AdaptationsForm(BabelTranslationsFormMixin, NoCsrfForm):
             is_bsl = formdata.get("adaptations-bsl_webcam")
             email = formdata.get("adaptations-bsl_email") or formdata.get("email")
             if is_bsl and email:
+                formdata = formdata.to_dict()
                 formdata["adaptations-bsl_email"] = email
+                formdata = ImmutableMultiDict(formdata)
         super(AdaptationsForm, self).__init__(formdata, obj, prefix, data, meta, **kwargs)
 
 

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -42,6 +42,15 @@ class AdaptationsForm(BabelTranslationsFormMixin, NoCsrfForm):
     """
 
     bsl_webcam = BooleanField(_(u"British Sign Language – webcam"))
+    bsl_email = StringField(
+        _(u"Email"),
+        description=_(u"Enter your email address so we can arrange a BSL call."),
+        validators=[
+            IgnoreIf("bsl_webcam", FieldValue(False)),
+            Length(max=255, message=_(u"Your address must be 255 characters or less")),
+            EmailValidator(message=_(u"Enter an email address   ")),
+        ],
+    )
     minicom = BooleanField(_(u"Minicom – for textphone users"))
     text_relay = BooleanField(_(u"Text Relay – for people with hearing or speech impairments"))
     welsh = BooleanField(_(u"Welsh"))
@@ -182,6 +191,9 @@ class ContactForm(Honeypot, BabelTranslationsFormMixin, Form):
     )
     adaptations = ValidatedFormField(AdaptationsForm, _(u"Do you have any special communication needs? (optional)"))
 
+    def get_email(self):
+        return self.email.data or self.adaptations.bsl_email.data
+
     def api_payload(self):
         "Form data as data structure ready to send to API"
 
@@ -198,7 +210,7 @@ class ContactForm(Honeypot, BabelTranslationsFormMixin, Form):
         data = {
             "personal_details": {
                 "full_name": self.full_name.data,
-                "email": self.email.data,
+                "email": self.get_email(),
                 "postcode": self.address.form.post_code.data,
                 "mobile_phone": self.callback.form.contact_number.data,
                 "street": self.address.form.street_address.data,

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -48,7 +48,7 @@ class AdaptationsForm(BabelTranslationsFormMixin, NoCsrfForm):
         validators=[
             IgnoreIf("bsl_webcam", FieldValue(False)),
             Length(max=255, message=_(u"Your address must be 255 characters or less")),
-            EmailValidator(message=_(u"Enter an email address   ")),
+            EmailValidator(message=_(u"Enter an email address.")),
         ],
     )
     minicom = BooleanField(_(u"Minicom – for textphone users"))

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -50,10 +50,9 @@ class AdaptationsForm(BabelTranslationsFormMixin, NoCsrfForm):
             EmailValidator(message=_(u"Enter an email address.")),
         ],
     )
-    minicom = BooleanField(_(u"Minicom – for textphone users"))
     text_relay = BooleanField(_(u"Text relay"))
     welsh = BooleanField(_(u"Welsh"))
-    is_other_language = BooleanField(_(u"Other language"))
+    is_other_language = BooleanField(_(u"Other language - need an interpreter"))
     other_language = SelectField(_(u"Choose a language"), choices=(LANG_CHOICES))
     is_other_adaptation = BooleanField(_(u"Any other communication need"))
     other_adaptation = TextAreaField(
@@ -223,7 +222,6 @@ class ContactForm(Honeypot, BabelTranslationsFormMixin, Form):
             },
             "adaptation_details": {
                 "bsl_webcam": self.adaptations.bsl_webcam.data,
-                "minicom": self.adaptations.minicom.data,
                 "text_relay": self.adaptations.text_relay.data,
                 "language": self.adaptations.welsh.data and "WELSH" or self.adaptations.other_language.data,
                 "notes": self.adaptations.other_adaptation.data if self.adaptations.is_other_adaptation.data else "",

--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -41,7 +41,7 @@ class AdaptationsForm(BabelTranslationsFormMixin, NoCsrfForm):
     Subform for adaptations
     """
 
-    bsl_webcam = BooleanField(_(u"British Sign Language – webcam"))
+    bsl_webcam = BooleanField(_(u"British Sign Language (BSL)"))
     bsl_email = StringField(
         _(u"Enter your email address so we can arrange a BSL call"),
         validators=[
@@ -51,13 +51,13 @@ class AdaptationsForm(BabelTranslationsFormMixin, NoCsrfForm):
         ],
     )
     minicom = BooleanField(_(u"Minicom – for textphone users"))
-    text_relay = BooleanField(_(u"Text Relay – for people with hearing or speech impairments"))
+    text_relay = BooleanField(_(u"Text relay"))
     welsh = BooleanField(_(u"Welsh"))
     is_other_language = BooleanField(_(u"Other language"))
     other_language = SelectField(_(u"Choose a language"), choices=(LANG_CHOICES))
-    is_other_adaptation = BooleanField(_(u"Any other communication needs"))
+    is_other_adaptation = BooleanField(_(u"Any other communication need"))
     other_adaptation = TextAreaField(
-        _(u"Other communication needs"),
+        _(u"Other language - need an interpreter"),
         description=_(u"Please tell us what you need in the box below"),
         validators=[
             IgnoreIf("is_other_adaptation", FieldValue(False)),

--- a/cla_public/apps/contact/tests/test_validation.py
+++ b/cla_public/apps/contact/tests/test_validation.py
@@ -168,4 +168,6 @@ class TestContactFormValidation(unittest.TestCase):
             }
             form = ContactForm(MultiDict(data), csrf_enabled=False)
             self.assertFalse(form.validate())
-            self.assertIn(("bsl_email", ["Enter an email address."]), form.errors["adaptations"])
+            self.assertIn(
+                ("bsl_email", ["Enter your email address so we can arrange a BSL call"]), form.errors["adaptations"]
+            )

--- a/cla_public/apps/contact/tests/test_validation.py
+++ b/cla_public/apps/contact/tests/test_validation.py
@@ -168,6 +168,4 @@ class TestContactFormValidation(unittest.TestCase):
             }
             form = ContactForm(MultiDict(data), csrf_enabled=False)
             self.assertFalse(form.validate())
-            self.assertIn(
-                ("bsl_email", ["Enter your email address so we can arrange a BSL call"]), form.errors["adaptations"]
-            )
+            self.assertIn(("bsl_email", ["Enter your email address"]), form.errors["adaptations"])

--- a/cla_public/apps/contact/tests/test_validation.py
+++ b/cla_public/apps/contact/tests/test_validation.py
@@ -132,6 +132,19 @@ class TestContactFormValidation(unittest.TestCase):
                 else:
                     self.fail("Specific day was not set but form was validated")
 
+    def test_bsl(self):
+        with self.client:
+            data = {
+                "adaptations-other_language": "",
+                "adaptations-bsl_webcam": "y",
+                "email": "john.doe@digital.justice.gov.uk",
+                "contact_type": "call",
+                "full_name": "John Doe",
+            }
+            form = ContactForm(MultiDict(data), csrf_enabled=False)
+            self.assertTrue(form.validate())
+            self.assertEqual(form.api_payload()["personal_details"]["email"], "john.doe@digital.justice.gov.uk")
+
     def test_bsl_email_success(self):
         with self.client:
             data = {

--- a/cla_public/apps/contact/tests/test_validation.py
+++ b/cla_public/apps/contact/tests/test_validation.py
@@ -5,7 +5,7 @@ import unittest
 
 from werkzeug.datastructures import MultiDict
 from cla_public.app import create_app
-from cla_public.apps.contact.forms import CallBackForm
+from cla_public.apps.contact.forms import CallBackForm, ContactForm
 from cla_public.apps.contact.tests.test_availability import override_current_time
 from cla_public.apps.contact.constants import (
     TIME_TODAY_VALIDATION_ERROR,
@@ -131,3 +131,28 @@ class TestContactFormValidation(unittest.TestCase):
                     self.assertIn(TIME_SPECIFIC_VALIDATION_ERROR, errors["time_in_day"][0])
                 else:
                     self.fail("Specific day was not set but form was validated")
+
+    def test_bsl_email_success(self):
+        with self.client:
+            data = {
+                "adaptations-other_language": "",
+                "adaptations-bsl_webcam": "y",
+                "adaptations-bsl_email": "john.doe@digital.justice.gov.uk",
+                "contact_type": "call",
+                "full_name": "John Doe",
+            }
+            form = ContactForm(MultiDict(data), csrf_enabled=False)
+            self.assertTrue(form.validate())
+            self.assertEqual(form.api_payload()["personal_details"]["email"], "john.doe@digital.justice.gov.uk")
+
+    def test_bsl_email_missing_email(self):
+        with self.client:
+            data = {
+                "adaptations-other_language": "",
+                "adaptations-bsl_webcam": "y",
+                "contact_type": "call",
+                "full_name": "John Doe",
+            }
+            form = ContactForm(MultiDict(data), csrf_enabled=False)
+            self.assertFalse(form.validate())
+            self.assertIn(("bsl_email", ["Enter an email address."]), form.errors["adaptations"])

--- a/cla_public/apps/contact/views.py
+++ b/cla_public/apps/contact/views.py
@@ -158,9 +158,12 @@ class Contact(AllowSessionOverride, UpdatesMeansTest, SessionBackedFormView):
                 )
                 del session[ReasonsForContacting.MODEL_REF_SESSION_KEY]
             session.store_checker_details()
-            if self.form.email.data:
+            email = self.form.get_email()
+            if email:
                 govuk_notify = NotifyEmailOrchestrator()
-                create_and_send_confirmation_email(govuk_notify, self.form.data)
+                data = self.form.data
+                data["email"] = email
+                create_and_send_confirmation_email(govuk_notify, data)
             return self.redirect(url_for("contact.confirmation"))
         except AlreadySavedApiError:
             return self.already_saved()

--- a/cla_public/static-src/javascripts/modules/bsl_email.js
+++ b/cla_public/static-src/javascripts/modules/bsl_email.js
@@ -1,0 +1,34 @@
+ 'use strict';
+
+  moj.Modules.BSLEmail = {
+    moreInfos: [],
+
+    init: function() {
+      this.bindEvents();
+    },
+
+    bindEvents: function() {
+      $('#adaptations-bsl_webcam').on('click', function (){
+        moj.Modules.BSLEmail.handleToggle(this);
+      });
+
+      $('#field-adaptations-bsl_email').on('error', function (errors){
+        moj.Modules.BSLEmail.handleToggle($('#adaptations-bsl_webcam')[0]);
+      });
+
+    },
+
+    handleToggle: function(target) {
+      var bsl_email_wrapper = $('#field-adaptations-bsl_email-wrapper');
+      var email_wrapper = $("#field-email")
+      var email = $('#email').val();
+      if (target.checked && email === '') {
+        bsl_email_wrapper.removeClass('s-hidden');
+        email_wrapper.addClass('s-hidden');
+      } else {
+        bsl_email_wrapper.addClass('s-hidden');
+        email_wrapper.removeClass('s-hidden');
+      }
+    }
+  };
+

--- a/cla_public/static-src/javascripts/modules/bsl_email.js
+++ b/cla_public/static-src/javascripts/modules/bsl_email.js
@@ -13,21 +13,22 @@
       });
 
       $('#field-adaptations-bsl_email').on('error', function (errors){
+        $('#field-bsl-email-wrapper').removeClass("govuk-inset-text");
         moj.Modules.BSLEmail.handleToggle($('#adaptations-bsl_webcam')[0]);
       });
 
     },
 
     handleToggle: function(target) {
-      var bsl_email_wrapper = $('#field-adaptations-bsl_email-wrapper');
-      var email_wrapper = $("#field-email")
+      var field_bsl_email_wrapper = $('#field-bsl-email-wrapper');
+      var field_email = $("#field-email")
       var email = $('#email').val();
       if (target.checked && email === '') {
-        bsl_email_wrapper.removeClass('s-hidden');
-        email_wrapper.addClass('s-hidden');
+        field_bsl_email_wrapper.removeClass('s-hidden');
+        field_email.addClass('s-hidden');
       } else {
-        bsl_email_wrapper.addClass('s-hidden');
-        email_wrapper.removeClass('s-hidden');
+        field_bsl_email_wrapper.addClass('s-hidden');
+        field_email.removeClass('s-hidden');
       }
     }
   };

--- a/cla_public/static-src/javascripts/modules/bsl_email.js
+++ b/cla_public/static-src/javascripts/modules/bsl_email.js
@@ -13,7 +13,7 @@
       });
 
       $('#field-adaptations-bsl_email').on('error', function (errors){
-        $('#field-bsl-email-wrapper').removeClass("govuk-inset-text");
+        $('#field-bsl-email-wrapper').removeClass("govuk-checkboxes__conditional");
         moj.Modules.BSLEmail.handleToggle($('#adaptations-bsl_webcam')[0]);
       });
 

--- a/cla_public/static-src/javascripts/modules/form-errors.js
+++ b/cla_public/static-src/javascripts/modules/form-errors.js
@@ -234,6 +234,7 @@
         } else {
           insertError(label.closest('.govuk-label'), errors, fieldName);
         }
+        $('#field-' + fieldName).trigger("error", errors);
       }
 
       function addSubformErrors(errors, fieldName) {

--- a/cla_public/static-src/stylesheets/_forms.scss
+++ b/cla_public/static-src/stylesheets/_forms.scss
@@ -7,3 +7,12 @@
 .hp-field {
   display: none;
 }
+
+#field-adaptations-bsl_email.govuk-form-group:last-of-type {
+    margin-bottom: 30px;
+}
+
+#field-bsl-email-wrapper {
+  margin-left: 10px;
+  margin-top: 15px;
+}

--- a/cla_public/templates/macros/form.html
+++ b/cla_public/templates/macros/form.html
@@ -154,7 +154,7 @@
     {% if field %}id="field-{{ field.id }}"{% endif %}
   >
 
-    {{ render_field_label(field, kwargs.hide_label, kwargs.custom_label) }}
+    {{ render_field_label(field, kwargs.hide_label, kwargs.custom_label, kwargs.field_label_class) }}
 
     {{ render_field_description(field) }}
 
@@ -308,7 +308,7 @@
     - hide_label <boolean> (default: False)
         Whether to hide the label visually (still available for screen readers)
 #}
-{% macro render_field_label(field, hide_label=False, custom_label='') %}
+{% macro render_field_label(field, hide_label=False, custom_label='', field_label_class=None) %}
   {% if field %}
     {% if custom_label %}
       {% set label_text = _(custom_label) %}
@@ -320,11 +320,17 @@
       {% set label_text = label_text + ' (' + _('optional') + ')' %}
     {% endif %}
 
+    {% if field_label_class  is defined %}
+        {% set field_label_class = field_label_class %}
+    {% else %}
+        {% set field_label_class = "govuk-label%s" % (' govuk-visually-hidden' if hide_label) %}
+    {% endif %}
+
     {% set field_label = field.label(
          for=field.per_interval_value.id if field.per_interval_value else field.id,
          text=label_text,
          id="field-label-%s" % field.id,
-         class="govuk-label%s" % (' govuk-visually-hidden' if hide_label)
+         class=field_label_class
        ) %}
 
     {{ field_label }}

--- a/cla_public/templates/macros/subform.html
+++ b/cla_public/templates/macros/subform.html
@@ -143,7 +143,7 @@
       </label>
     </div>
     <div class="govuk-inset-text{{ ' s-hidden' if not subform.bsl_email.errors }}" id="field-adaptations-bsl_email-wrapper">
-      {{ Form.group(subform.bsl_email, 'cla-question-text--large', hide_label=True) }}
+      {{ Form.group(subform.bsl_email, 'cla-question-text--large') }}
     </div>
     <div class="govuk-checkboxes__item">
       {{ subform.minicom(**{"class": "govuk-checkboxes__input"}) }}

--- a/cla_public/templates/macros/subform.html
+++ b/cla_public/templates/macros/subform.html
@@ -143,7 +143,7 @@
       </label>
     </div>
     <div class="govuk-inset-text{{ ' s-hidden' if not subform.bsl_email.errors }}" id="field-adaptations-bsl_email-wrapper">
-      {{ Form.group(subform.bsl_email, 'cla-question-text--large') }}
+      {{ Form.group(subform.bsl_email, field_label_class='govuk-label govuk-checkboxes__label') }}
     </div>
     <div class="govuk-checkboxes__item">
       {{ subform.minicom(**{"class": "govuk-checkboxes__input"}) }}

--- a/cla_public/templates/macros/subform.html
+++ b/cla_public/templates/macros/subform.html
@@ -146,12 +146,6 @@
       {{ Form.group(subform.bsl_email, field_label_class='govuk-label govuk-checkboxes__label') }}
     </div>
     <div class="govuk-checkboxes__item">
-      {{ subform.minicom(**{"class": "govuk-checkboxes__input"}) }}
-      <label class="govuk-label govuk-checkboxes__label" for="{{subform.minicom.id}}">
-        {{ subform.minicom.label.text }}
-      </label>
-    </div>
-    <div class="govuk-checkboxes__item">
       {{ subform.text_relay(**{"class": "govuk-checkboxes__input"}) }}
       <label class="govuk-label govuk-checkboxes__label" for="{{subform.text_relay.id}}">
         {{ subform.text_relay.label.text }}

--- a/cla_public/templates/macros/subform.html
+++ b/cla_public/templates/macros/subform.html
@@ -142,8 +142,8 @@
         {{ subform.bsl_webcam.label.text }}
       </label>
     </div>
-    <div class="govuk-inset-text{{ ' s-hidden' if not subform.bsl_email.errors }}" id="field-adaptations-bsl_email-wrapper">
-      {{ Form.group(subform.bsl_email, field_label_class='govuk-label govuk-checkboxes__label') }}
+    <div class="govuk-inset-text s-hidden" id="field-bsl-email-wrapper">
+      {{ Form.group(subform.bsl_email, field_label_class="govuk-label govuk-!-font-weight-regular") }}
     </div>
     <div class="govuk-checkboxes__item">
       {{ subform.text_relay(**{"class": "govuk-checkboxes__input"}) }}

--- a/cla_public/templates/macros/subform.html
+++ b/cla_public/templates/macros/subform.html
@@ -142,7 +142,7 @@
         {{ subform.bsl_webcam.label.text }}
       </label>
     </div>
-    <div class="govuk-inset-text s-hidden" id="field-bsl-email-wrapper">
+    <div class="govuk-checkboxes__conditional s-hidden" id="field-bsl-email-wrapper">
       {{ Form.group(subform.bsl_email, field_label_class="govuk-label govuk-!-font-weight-regular") }}
     </div>
     <div class="govuk-checkboxes__item">

--- a/cla_public/templates/macros/subform.html
+++ b/cla_public/templates/macros/subform.html
@@ -142,6 +142,9 @@
         {{ subform.bsl_webcam.label.text }}
       </label>
     </div>
+    <div class="govuk-inset-text{{ ' s-hidden' if not subform.bsl_email.errors }}" id="field-adaptations-bsl_email-wrapper">
+      {{ Form.group(subform.bsl_email, 'cla-question-text--large', hide_label=True) }}
+    </div>
     <div class="govuk-checkboxes__item">
       {{ subform.minicom(**{"class": "govuk-checkboxes__input"}) }}
       <label class="govuk-label govuk-checkboxes__label" for="{{subform.minicom.id}}">

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4037,8 +4037,8 @@ msgstr "Dwedwch wrthynt fod eich tŷ mewn perygl a bod eisiau cyngor trwy’r Cy
 msgid "Enter an email address."
 msgstr "Rhowch gyfeiriad e-bost."
 
-msgid "Enter your email address so we can arrange a BSL call."
-msgstr "Rhowch eich cyfeiriad e-bost er mwyn i ni allu trefnu galwad Iaith Arwyddion Prydain (BSL)."
+msgid "Enter your email address so we can arrange a BSL call"
+msgstr "Rhowch eich cyfeiriad e-bost er mwyn i ni allu trefnu galwad Iaith Arwyddion Prydain (BSL)"
 
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -1280,16 +1280,16 @@ msgid "Arrange a callback time"
 msgstr "Trefnu amser i ffonio’n ôl"
 
 #: cla_public/apps/contact/forms.py:34
-msgid "British Sign Language – webcam"
-msgstr "Iaith Arwyddo Brydeinig  – webcam"
+msgid "British Sign Language (BSL)"
+msgstr "Iaith Arwyddion Prydain (BSL)"
 
 #: cla_public/apps/contact/forms.py:35
 msgid "Minicom – for textphone users"
 msgstr "Minicom - ar gyfer defnyddwyr ffôn testun"
 
 #: cla_public/apps/contact/forms.py:36
-msgid "Text Relay – for people with hearing or speech impairments"
-msgstr "Trosglwyddo Neges Destun - ar gyfer pobl sydd â nam ar y clyw neu ar y lleferydd"
+msgid "Text relay"
+msgstr "Cyfnewid testun"
 
 #: cla_public/apps/contact/forms.py:37
 msgid "Welsh"
@@ -1308,8 +1308,8 @@ msgid "Any other communication needs"
 msgstr "Unrhyw anghenion cyfathrebu eraill"
 
 #: cla_public/apps/contact/forms.py:42
-msgid "Other communication needs"
-msgstr "Anghenion cyfathrebu eraill"
+msgid "Other language - need an interpreter"
+msgstr "Iaith arall – angen cyfieithydd"
 
 #: cla_public/apps/contact/forms.py:43
 msgid "Please tell us what you need in the box below"
@@ -4501,9 +4501,6 @@ msgstr "Rhowch eich cyfeiriad e-bost er mwyn i ni allu trefnu galwad Iaith Arwyd
 
 #~ msgid "Type in a number"
 #~ msgstr "Rhowch swm"
-
-#~ msgid "British Sign Language – Webcam"
-#~ msgstr "Iaith Arwyddion Prydain – Gwe-gamera"
 
 #~ msgid "Language required"
 #~ msgstr "Iaith sydd ei hangen"

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4034,6 +4034,12 @@ msgstr "Gallwch gysylltu ag unrhyw un o’r ymgynghorydd cyfreithiol o restr yma
 msgid "Tell them that your home is at risk and that you want advice through the Housing Loss Prevention Advice Scheme."
 msgstr "Dwedwch wrthynt fod eich tŷ mewn perygl a bod eisiau cyngor trwy’r Cynllun Cyngor Atal Colli Tai."
 
+msgid "Enter an email address."
+msgstr "Rhowch gyfeiriad e-bost."
+
+msgid "Enter your email address so we can arrange a BSL call."
+msgstr "Rhowch eich cyfeiriad e-bost er mwyn i ni allu trefnu galwad Iaith Arwyddion Prydain (BSL)."
+
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"
 

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -4040,6 +4040,9 @@ msgstr "Rhowch gyfeiriad e-bost."
 msgid "Enter your email address so we can arrange a BSL call"
 msgstr "Rhowch eich cyfeiriad e-bost er mwyn i ni allu trefnu galwad Iaith Arwyddion Prydain (BSL)"
 
+msgid "Enter your email address"
+msgstr "Rhowch eich cyfeiriad e-bost"
+
 #~ msgid "Overall, how did you feel about the service you received today?"
 #~ msgstr "Ar y cyfan, sut oeddech yn teimlo ynghylch y gwasanaeth a gawsoch heddiw?"
 

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -1304,7 +1304,7 @@ msgid "Choose a language"
 msgstr "Dewiswch iaith"
 
 #: cla_public/apps/contact/forms.py:40
-msgid "Any other communication needs"
+msgid "Any other communication need"
 msgstr "Unrhyw anghenion cyfathrebu eraill"
 
 #: cla_public/apps/contact/forms.py:42

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -1276,7 +1276,7 @@ msgid "Arrange a callback time"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:34
-msgid "British Sign Language – webcam"
+msgid "British Sign Language (BSL)"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:35
@@ -1284,7 +1284,7 @@ msgid "Minicom – for textphone users"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:36
-msgid "Text Relay – for people with hearing or speech impairments"
+msgid "Text relay"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:37
@@ -1304,7 +1304,7 @@ msgid "Any other communication needs"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:42
-msgid "Other communication needs"
+msgid "Other language - need an interpreter"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:43
@@ -4493,9 +4493,6 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "-- Choose a language --"
-#~ msgstr ""
-
-#~ msgid "British Sign Language – Webcam"
 #~ msgstr ""
 
 #~ msgid "Language required"

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -1300,7 +1300,7 @@ msgid "Choose a language"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:40
-msgid "Any other communication needs"
+msgid "Any other communication need"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:42

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -1300,7 +1300,7 @@ msgid "Choose a language"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:40
-msgid "Any other communication needs"
+msgid "Any other communication need"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:42

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -1276,7 +1276,7 @@ msgid "Arrange a callback time"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:34
-msgid "British Sign Language – webcam"
+msgid "British Sign Language (BSL)"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:35
@@ -1284,7 +1284,7 @@ msgid "Minicom – for textphone users"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:36
-msgid "Text Relay – for people with hearing or speech impairments"
+msgid "Text relay"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:37
@@ -1304,7 +1304,7 @@ msgid "Any other communication needs"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:42
-msgid "Other communication needs"
+msgid "Other language - need an interpreter"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:43

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       platforms:
         - "linux/amd64"
     ports:
-      - "8000:5000"
+      - "8011:5000"
     stdin_open: true
     tty: true
     volumes:


### PR DESCRIPTION
## What does this pull request do?

- Add BSL E-mail field
- Remove `Minicom – for textphone users` adaptation option
- Reword adaptation options

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
