### PR TITLE
LGA-3175 Track click and change events

### DIFF
--- a/cla_public/static-src/javascripts/modules/gtm-data.js
+++ b/cla_public/static-src/javascripts/modules/gtm-data.js
@@ -26,7 +26,7 @@ moj.Modules.GMTData = {
         case 'select': value = $(this).find('option:selected').text(); break;
       }
 
-      value = value.trim().replace(/\n/g,'').substr(0,30); // can be up to 100 if needed
+      value = value.trim().replace(/\n/g,'').substring(0,30); // can be up to 100 if needed
 
       GTM.push({ 
         'event': 'element-' + e.type, 

--- a/cla_public/static-src/javascripts/modules/gtm-data.js
+++ b/cla_public/static-src/javascripts/modules/gtm-data.js
@@ -1,0 +1,40 @@
+'use strict';
+
+moj.Modules.GMTData = {
+
+  init: function() {
+
+    var GTM = window.dataLayer;
+    if(!GTM)return;
+
+    // Track element clicks and form element changes
+    $('input, select, button, textarea').on('click change', function(e){
+      
+      var clickInputTypes = ['checkbox', 'radio', 'button', 'textarea'];
+      var thisIsAClickInput = clickInputTypes.includes($(this).attr('type'));
+      
+      // Don't track changes for clickable input types, only clicks
+      if(e.type === 'change' && thisIsAClickInput)return;
+
+      var elem = $(this).prop('tagName').toLowerCase();
+      var value = '';
+
+      switch(elem) {
+        case 'textarea':
+        case 'input': value = thisIsAClickInput ? $(this).val() : 'Redacted'; break;
+        case 'button': value = $(this).text(); break;
+        case 'select': value = $(this).find('option:selected').text(); break;
+      }
+
+      value = value.trim().replace(/\n/g,'').substr(0,30); // can be up to 100 if needed
+
+      GTM.push({ 
+        'event': 'element-' + e.type, 
+        'element_tag': elem, 
+        'element_id': $(this).attr('id'), 
+        'element_value': value,
+        'element_checked': $(this).is(':checked')     
+      });
+    });
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Part of a series of event tracking tickets. Sends information about about simple click events and updates to Google Tag Manager for forwarding to Google Analytics.

## Any other changes that would benefit highlighting?

Complex events e.g. Find address button is not interfered with to keep code clean, unless we really need it. But this covers most of the clicks and updates.

The new JS file is likely to have more events as time goes on.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
