### PR TITLE
LGA-2931: Correct contact content

### DIFF
--- a/cla_public/apps/contact/forms.py
+++ b/cla_public/apps/contact/forms.py
@@ -85,7 +85,7 @@ class CallBackForm(BabelTranslationsFormMixin, NoCsrfForm):
     """
 
     contact_number = StringField(
-        _(u"Phone number for the callback"),
+        _(u"Phone number"),
         description=_(u"Enter the full number, including the area code. For example, 01632 960 1111."),
         validators=[
             InputRequired(message=_(u"Tell us what number to ring")),
@@ -119,7 +119,7 @@ class ThirdPartyForm(BabelTranslationsFormMixin, NoCsrfForm):
         validators=[Required(message=_(u"Tell us how you know this person"))],
     )
     contact_number = StringField(
-        _(u"Phone number for the callback"),
+        _(u"Phone number"),
         description=_(u"Enter the full number, including the area code. For example, 01632 960 1111."),
         validators=[
             InputRequired(message=_(u"Tell us what number to ring")),

--- a/cla_public/translations/cy/LC_MESSAGES/messages.po
+++ b/cla_public/translations/cy/LC_MESSAGES/messages.po
@@ -1320,8 +1320,8 @@ msgid "Your other communication needs must be 4000 characters or fewer"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:63 cla_public/apps/contact/forms.py:97
-msgid "Phone number for the callback"
-msgstr "Rhif ffôn ar gyfer eich ffonio’n ôl"
+msgid "Phone number"
+msgstr "Rhif ffôn"
 
 #: cla_public/apps/contact/forms.py:64 cla_public/apps/contact/forms.py:98
 msgid "Enter the full number, including the area code. For example, 01632 960 1111."

--- a/cla_public/translations/en/LC_MESSAGES/messages.po
+++ b/cla_public/translations/en/LC_MESSAGES/messages.po
@@ -1316,7 +1316,7 @@ msgid "Your other communication needs must be 4000 characters or fewer"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:63 cla_public/apps/contact/forms.py:97
-msgid "Phone number for the callback"
+msgid "Phone number"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:64 cla_public/apps/contact/forms.py:98

--- a/cla_public/translations/messages.pot
+++ b/cla_public/translations/messages.pot
@@ -1316,7 +1316,7 @@ msgid "Your other communication needs must be 4000 characters or fewer"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:63 cla_public/apps/contact/forms.py:97
-msgid "Phone number for the callback"
+msgid "Phone number"
 msgstr ""
 
 #: cla_public/apps/contact/forms.py:64 cla_public/apps/contact/forms.py:98


### PR DESCRIPTION
## What does this pull request do?

- Updates both instances of the text "Phone number for the callback" to "Phone number" to reflect the latest content record.
- Updates the Welsh translation for these to reflect the latest content record.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
