### PR TITLE
LGA-3339 - Fix broken add property button

### DIFF
--- a/cla_public/static-src/javascripts/modules/properties.js
+++ b/cla_public/static-src/javascripts/modules/properties.js
@@ -37,7 +37,7 @@
       $.post('', this._injectFormData({
         name: button.name,
         value: button.value
-      })).success(function(res) {
+      })).done(function(res) {
         self._updateForm(res);
 
         var totalProperties = self.$form.find('#PropertiesForm > .govuk-form-group').length;


### PR DESCRIPTION
## What does this pull request do?

Fix broken add property button

## Any other changes that would benefit highlighting?

The promise returned from $.post no longer has a `success `method. Instead the `done` method should be used

From the jquery docs:
> Deprecation Notice
The jqXHR.success(), jqXHR.error(), and jqXHR.complete() callback methods are removed as of jQuery 3.0. You can use jqXHR.done(), jqXHR.fail(), and jqXHR.always() instead.

The bug was probably introduced around the same time that the jquery version was upgraded in #1220 

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
